### PR TITLE
Fix decay_out reuse

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -351,6 +351,7 @@ def main():
         flags_time = cfg["time_fit"].get("flags", {})
 
         # Run decay fit
+        decay_out = None  # fresh variable each iteration
         try:
             decay_out = fit_decay(
                 times=times_rel,
@@ -368,7 +369,7 @@ def main():
         try:
             _ = plot_time_series(
                 events_times=iso_events["timestamp"].values,
-                fit_dict=decay_out if "decay_out" in locals() else None,
+                fit_dict=decay_out,
                 t0=t0_global,
                 out_png=os.path.join(out_dir, f"time_series_{iso}.png"),
                 bin_width = cfg["time_fit"].get("bin_width", 3600),

--- a/calibration.py
+++ b/calibration.py
@@ -89,8 +89,9 @@ def calibrate_run(adc_values, config):
     chosen_idx = {}
     for iso in candidates:
         if not candidates[iso]:
-            raise RuntimeError(f"No candidate peak found for {
-                               iso} around ADC={nominal_adc[iso]}.")
+            raise RuntimeError(
+                f"No candidate peak found for {iso} around ADC={nominal_adc[iso]}."
+            )
         # pick the one with max(hist) among candidates
         best = max(candidates[iso], key=lambda i: hist[i])
         chosen_idx[iso] = best
@@ -108,8 +109,9 @@ def calibrate_run(adc_values, config):
         x_slice = centers[mask]
         y_slice = hist[mask].astype(float)
         if len(x_slice) < 5:
-            raise RuntimeError(f"Not enough points to fit peak for {
-                               iso} (only {len(x_slice)} bins).")
+            raise RuntimeError(
+                f"Not enough points to fit peak for {iso} (only {len(x_slice)} bins)."
+            )
 
         # Initial guesses:
         amp0 = float(np.max(y_slice))


### PR DESCRIPTION
## Summary
- reset `decay_out` before each time-series fit
- pass this variable directly to `plot_time_series`
- clean up malformed f-strings in `calibration.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for calibration, fitting and io_utils)*

------
https://chatgpt.com/codex/tasks/task_e_683f917b9518832bb0d868e4ef9e564e