### PR TITLE
Fix config copy placement

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -109,8 +109,7 @@ def main():
     out_dir = os.path.join(args.output_dir, now_str)
     os.makedirs(out_dir, exist_ok=True)
 
-    #  Write a copy of the config used (for provenance)
-    copy_config(out_dir, args.config)
+
 
     # ────────────────────────────────────────────────────────────
     # 2. Load event data
@@ -429,7 +428,8 @@ def main():
         "baseline": baseline_info
     }
 
-    write_summary(out_dir, summary)
+    out_dir = write_summary(args.output_dir, summary)
+    copy_config(args.output_dir, args.config)
 
     print(f"Analysis complete. Results written to → {out_dir}")
 


### PR DESCRIPTION
## Summary
- ensure analyze writes summary before copying the config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683f917a1ef0832bbcd5db8c56b82e4d