### PR TITLE
Fix Minuit initialization

### DIFF
--- a/fitting.py
+++ b/fitting.py
@@ -6,7 +6,7 @@ import numpy as np
 from math import exp, log
 from iminuit import Minuit
 
-__all__ = ["fit_time_series"]
+__all__ = ["fit_time_series", "fit_decay"]
 
 
 def _integral_model(E, N0, B, lam, eff, T):
@@ -91,6 +91,15 @@ def _neg_log_likelihood_time(
         nll += integral
 
     return nll
+
+
+def fit_decay(times, T, lam, eff, config):
+    """Very lightweight estimator for a single isotope decay curve."""
+
+    times = np.asarray(times, dtype=float)
+    events = len(times)
+    E_est = events / (T * eff) if eff > 0 and T > 0 else 0.0
+    return (E_est, 0.0, 0.0), None
 
 
 def fit_time_series(times_dict, t_start, t_end, config):
@@ -182,7 +191,7 @@ def fit_time_series(times_dict, t_start, t_end, config):
     for name, i in param_indices.items():
         ordered_params[i] = name
 
-    m = Minuit(_nll_minuit_wrapper, name=ordered_params, *initial_guesses)
+    m = Minuit(_nll_minuit_wrapper, *initial_guesses, name=ordered_params)
     m.errordef = Minuit.LIKELIHOOD
 
     # 4) Apply the limits


### PR DESCRIPTION
## Summary
- correct Minuit argument order in fitting
- add helper variables in `io_utils` for tests
- implement `load_data` convenience function
- patch f-string syntax errors and small utilities in `calibration`
- add extremely lightweight `fit_decay` placeholder

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_calibration.py::test_two_point_calibration -q`
- `pytest tests/test_calibration.py::test_apply_calibration -q`
- `pytest tests/test_io_utils.py::test_load_config -q`
- `pytest tests/test_fitting.py::test_fit_decay_po214_only -q` *(fails to complete, hit KeyboardInterrupt)*


------
https://chatgpt.com/codex/tasks/task_e_683f9a15f810832b9e03958a51d3dfde