### PR TITLE
Implement calibration wrappers and spectrum utilities

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,9 @@
 # utils.py
 
 import numpy as np
+from scipy.signal import find_peaks
+
+__all__ = ["to_native", "find_adc_peaks"]
 
 
 def to_native(obj):
@@ -19,3 +22,59 @@ def to_native(obj):
         return [to_native(x) for x in obj.tolist()]
     else:
         return obj
+
+
+def find_adc_peaks(adc_values, expected, window=50):
+    """Locate peak centroids in an ADC array.
+
+    Parameters
+    ----------
+    adc_values : array-like
+        Raw ADC values (integers).
+    expected : dict
+        Mapping of peak name -> expected ADC centroid.
+    window : int, optional
+        Search window around each expected centroid (± window).
+
+    Returns
+    -------
+    dict
+        {peak_name: adc_centroid}
+    """
+    adc_arr = np.asarray(adc_values, dtype=float)
+    if adc_arr.size == 0:
+        return {k: float(v) for k, v in expected.items()}
+
+    # Build 1-channel histogram to locate maxima
+    min_adc = int(adc_arr.min())
+    max_adc = int(adc_arr.max())
+    edges = np.arange(min_adc, max_adc + 2)
+    hist, _ = np.histogram(adc_arr, bins=edges)
+    centers = 0.5 * (edges[:-1] + edges[1:])
+
+    # Global peak search
+    peak_indices, _ = find_peaks(hist)
+
+    results = {}
+    for name, guess in expected.items():
+        lo = guess - window
+        hi = guess + window
+        mask = (centers >= lo) & (centers <= hi)
+        if np.any(mask):
+            idx_candidates = np.where(mask)[0]
+            if len(idx_candidates) == 0:
+                results[name] = float(guess)
+                continue
+            # Among candidates that are peaks, choose the highest histogram count
+            best_idx = idx_candidates[0]
+            best_count = -1
+            for idx in idx_candidates:
+                if idx in peak_indices and hist[idx] > best_count:
+                    best_count = hist[idx]
+                    best_idx = idx
+            results[name] = float(centers[best_idx])
+        else:
+            # No histogram bin in range -> just return the guess
+            results[name] = float(guess)
+
+    return results


### PR DESCRIPTION
## Summary
- add `find_adc_peaks` utility
- implement calibration wrappers `derive_calibration_constants` and `_auto`
- provide basic spectrum fitter and plotting
- expose new functions in `__all__` lists

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fa03e6260832b8bb6a84a63e0c8c1