### PR TITLE
Fix Minuit argument order

### DIFF
--- a/fitting.py
+++ b/fitting.py
@@ -191,7 +191,7 @@ def fit_time_series(times_dict, t_start, t_end, config):
     for name, i in param_indices.items():
         ordered_params[i] = name
 
-    m = Minuit(_nll_minuit_wrapper, name=ordered_params, *initial_guesses)
+    m = Minuit(_nll_minuit_wrapper, *initial_guesses, name=ordered_params)
     m.errordef = Minuit.LIKELIHOOD
 
     # 4) Apply the limits


### PR DESCRIPTION
## Summary
- fix Minuit call to pass positional args before `name`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fa03e66c4832b84c8e424dee71a22