### PR TITLE
Add calibration section and time windows

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,6 +5,19 @@
         "output_subfolder": true,
         "enable_peak_tracking": true
     },
+    "calibration": {
+        "method": "auto",
+        "noise_cutoff": 300,
+        "hist_bins": 2000,
+        "peak_search_radius": 200,
+        "peak_prominence": 10,
+        "peak_width": 3,
+        "nominal_adc": {"Po210": 5200, "Po218": 6000, "Po214": 7600},
+        "fit_window_adc": 50,
+        "use_emg": false,
+        "init_sigma_adc": 10.0,
+        "init_tau_adc": 0.0
+    },
     "spectral_fit": {
         "do_spectral_fit": true,
         "spectral_binning_mode": "adc",
@@ -27,8 +40,10 @@
         "fix_N0_Po218": false,
         "N0_Po218_value": 0.0,
         "fit_Po218_simul": true,
-        "efficiency_Po214": 0.40,
-        "efficiency_Po218": 0.20,
+        "window_Po214": [7.4, 7.9],
+        "window_Po218": [5.8, 6.3],
+        "eff_Po214": [0.40, 0.0],
+        "eff_Po218": [0.20, 0.0],
         "settling_time_s": 10800,
         "confidence_level": 0.95
     },


### PR DESCRIPTION
## Summary
- support calibration options via config
- specify energy windows for decay fit parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684021c8adf4832b9c53122388db6787