### PR TITLE
Fix spec_fit_out initialization

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -269,6 +269,7 @@ def main():
         priors_spec["b1"] = tuple(cfg["spectral_fit"].get("b1_prior", (0.0, 1.0)))
 
         # Launch the spectral fit
+        spec_fit_out = None
         try:
             spec_fit_out = fit_spectrum(
                 energies=events["energy_MeV"].values,


### PR DESCRIPTION
## Summary
- ensure `spec_fit_out` is defined before attempting the spectral fit

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404708e780832b949167d85fdd030f