### PR TITLE
Pass timestamp when writing summary

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -437,7 +437,7 @@ def main():
         "baseline": baseline_info
     }
 
-    out_dir = write_summary(args.output_dir, summary)
+    out_dir = write_summary(args.output_dir, summary, now_str)
     copy_config(out_dir, args.config)
 
     # Generate plots now that the output directory exists

--- a/io_utils.py
+++ b/io_utils.py
@@ -75,15 +75,25 @@ def load_events(csv_path):
     return df
 
 
-def write_summary(output_dir, summary_dict):
+def write_summary(output_dir, summary_dict, timestamp=None):
     """
-    Write out summary_dict to JSON in:
-      <output_dir>/<timestamp_folder>/summary.json
-    and returns path to that folder.
+    Write out ``summary_dict`` to ``summary.json`` under a timestamped
+    directory and return the path to that directory.
+
+    Parameters
+    ----------
+    output_dir : str
+        Parent directory under which the results folder will be created.
+    summary_dict : dict
+        Data to serialise into ``summary.json``.
+    timestamp : str, optional
+        Timestamp string to use for the results folder.  If ``None`` a new
+        UTC timestamp will be generated.
     """
     # Create timestamped subfolder
-    now_str = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
-    results_folder = os.path.join(output_dir, now_str)
+    if timestamp is None:
+        timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    results_folder = os.path.join(output_dir, timestamp)
     ensure_dir(results_folder)
 
     summary_path = os.path.join(results_folder, "summary.json")

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -72,7 +72,8 @@ def test_load_events(tmp_path):
 def test_write_summary_and_copy_config(tmp_path):
     summary = {"a": 1, "b": 2}
     outdir = tmp_path / "out"
-    results = write_summary(str(outdir), summary)
+    ts = "19700101T000000Z"
+    results = write_summary(str(outdir), summary, ts)
     assert (Path(results) / "summary.json").exists()
     # Create dummy config and copy
     cfg = {"test": 1}


### PR DESCRIPTION
## Summary
- `write_summary` now accepts an optional `timestamp` argument
- use the provided timestamp in `analyze.py` when creating the results folder
- adjust tests to supply a fixed timestamp

## Testing
- `pip install -q numpy scipy matplotlib pytest pandas iminuit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684055802a54832ba8b115977e030a68