### PR TITLE
Fix systematics wrapper to return full fit result

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -411,7 +411,9 @@ def main():
                     t0=0.0,
                     t_end=filtered_end
                 )
-                return out.get("eff", np.nan)
+                # Return the full fit result so scan_systematics can
+                # extract whichever parameter it needs.
+                return out
 
             try:
                 deltas, total_unc = scan_systematics(

--- a/tests/test_systematics.py
+++ b/tests/test_systematics.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+from systematics import scan_systematics
+
+
+def test_scan_systematics_with_dict_result():
+    # Priors for two parameters
+    priors = {
+        "p1": (1.0, 0.1),
+        "p2": (2.0, 0.2),
+    }
+
+    sigma_dict = {"p1": 0.5, "p2": 0.25}
+    keys = ["p1", "p2"]
+
+    def dummy_fit(p):
+        # Simple deterministic function returning parameter means plus 1
+        return {k: v[0] + 1 for k, v in p.items()}
+
+    deltas, total_unc = scan_systematics(dummy_fit, priors, sigma_dict, keys)
+    assert deltas["p1"] == pytest.approx(0.5)
+    assert deltas["p2"] == pytest.approx(0.25)
+    # Total uncertainty should be sqrt(0.5^2 + 0.25^2)
+    expected_unc = (0.5**2 + 0.25**2) ** 0.5
+    assert total_unc == pytest.approx(expected_unc)


### PR DESCRIPTION
## Summary
- return entire decay fit output in `analyze.fit_wrapper`
- add regression test for `scan_systematics` handling dict results

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684055812e94832bb60fd1fd54ed6a51