### PR TITLE
Improve time-series plotting fallback logic

### DIFF
--- a/plot_utils.py
+++ b/plot_utils.py
@@ -19,11 +19,14 @@ def plot_time_series(
     """
     all_timestamps: 1D np.ndarray of absolute UNIX times (s)
     all_energies:   1D np.ndarray of energies (MeV)
-    fit_results:    dict from fit_time_series(...)
+    fit_results:    dict from fit_time_series(...) or fit_decay(...)
     t_start, t_end: floats (absolute UNIX times) for the fit window
     config:         JSON dict
     out_png:        output path for the PNG file
     """
+
+    if fit_results is None:
+        fit_results = {}
 
     iso_params = {
         "Po214": {
@@ -99,9 +102,9 @@ def plot_time_series(
         lam = np.log(2.0) / iso_params[iso]["half_life"]
         eff = iso_params[iso]["eff"]
 
-        E_iso = fit_results.get(f"E_{iso}", 0.0)
-        B_iso = fit_results.get(f"B_{iso}", 0.0)
-        N0_iso = fit_results.get(f"N0_{iso}", 0.0)
+        E_iso = fit_results.get(f"E_{iso}", fit_results.get("E", 0.0))
+        B_iso = fit_results.get(f"B_{iso}", fit_results.get("B", 0.0))
+        N0_iso = fit_results.get(f"N0_{iso}", fit_results.get("N0", 0.0))
 
         # r_iso(t_rel) = eff * [E*(1 - exp(-lam*t_rel)) + lam*N0*exp(-lam*t_rel)] + B
         r_rel = (

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -1,0 +1,49 @@
+import numpy as np
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from plot_utils import plot_time_series
+
+
+def basic_config():
+    return {
+        "window_Po214": [7.5, 8.0],
+        "eff_Po214": [1.0],
+        "window_Po218": None,
+        "time_bin_mode": "fixed",
+        "time_bin_s": 1.0,
+        "dump_time_series_json": False,
+    }
+
+
+def test_plot_time_series_fallback(tmp_path):
+    times = np.array([1001.0, 1002.0, 1003.0])
+    energies = np.array([7.7, 7.8, 7.6])
+    out_png = tmp_path / "ts.png"
+    plot_time_series(
+        times,
+        energies,
+        {"E": 0.1, "B": 0.0, "N0": 0.0},
+        1000.0,
+        1005.0,
+        basic_config(),
+        str(out_png),
+    )
+    assert out_png.exists()
+
+
+def test_plot_time_series_none_fit_results(tmp_path):
+    times = np.array([1001.0, 1002.0])
+    energies = np.array([7.6, 7.8])
+    out_png = tmp_path / "ts2.png"
+    plot_time_series(
+        times,
+        energies,
+        None,
+        1000.0,
+        1005.0,
+        basic_config(),
+        str(out_png),
+    )
+    assert out_png.exists()


### PR DESCRIPTION
## Summary
- support `None` fit_results in `plot_time_series`
- fall back to generic `E`, `B`, `N0` when isotope-specific keys absent
- add tests covering fallback behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684059ac98f4832bbc83dba4fe24692a