### PR TITLE
Fix spectral-fit bounds and plotting

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -52,7 +52,7 @@ import sys
 import json
 import logging
 import random
-from datetime import datetime
+from datetime import datetime, timezone
 
 import numpy as np
 import pandas as pd
@@ -124,7 +124,7 @@ def main():
             logging.warning(f"Invalid random_seed '{seed}' ignored")
 
     # Timestamp for this analysis run
-    now_str = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    now_str = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
 
 
@@ -293,7 +293,8 @@ def main():
             mu_amp = max(raw_count, 1.0)
             sigma_amp = max(
                 np.sqrt(mu_amp),
-                cfg["spectral_fit"].get("amp_prior_scale", 1.0) * mu_amp
+                cfg["spectral_fit"].get("amp_prior_scale", 1.0) * mu_amp,
+                1.0,
             )
             priors_spec[f"S_{peak}"] = (mu_amp, sigma_amp)
 
@@ -500,11 +501,13 @@ def main():
         except Exception as e:
             print(f"WARNING: Could not create spectrum plot: {e}")
 
+    all_ts = events["timestamp"].values
+    all_en = events["energy_MeV"].values
     for iso, pdata in time_plot_data.items():
         try:
             _ = plot_time_series(
-                all_timestamps=pdata["events_times"],
-                all_energies=events["energy_MeV"].values,
+                all_timestamps=all_ts,
+                all_energies=all_en,
                 fit_results=pdata["fit_dict"],
                 t_start=t0_global,
                 t_end=events["timestamp"].max(),

--- a/fitting.py
+++ b/fitting.py
@@ -111,8 +111,9 @@ def fit_spectrum(energies, priors, flags=None):
         mean, sig = p(name, 1.0)
         p0.append(mean)
         if flags.get(f"fix_{name}", False) or sig == 0:
-            bounds_lo.append(mean)
-            bounds_hi.append(mean)
+            eps = 1e-8
+            bounds_lo.append(mean - eps)
+            bounds_hi.append(mean + eps)
         else:
             delta = 5 * sig if np.isfinite(sig) else np.inf
             bounds_lo.append(mean - delta)


### PR DESCRIPTION
## Summary
- ensure timezone-aware timestamps using `datetime.now(timezone.utc)`
- keep amplitude prior sigma >=1
- avoid zero-width bounds in `fit_spectrum`
- plot time series using all events to avoid array mismatch

## Testing
- `pip install -q numpy pandas scipy matplotlib iminuit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f8d29b428832b99962a4a99079192