### PR TITLE
Fix time series energy extraction

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -422,6 +422,7 @@ def main():
         # Store inputs for plotting later
         time_plot_data[iso] = {
             "events_times": iso_events["timestamp"].values,
+            "events_energy": iso_events["energy_MeV"].values,
             "fit_dict": decay_out,
         }
 
@@ -504,7 +505,7 @@ def main():
         try:
             _ = plot_time_series(
                 all_timestamps=pdata["events_times"],
-                all_energies=events["energy_MeV"].values,
+                all_energies=pdata["events_energy"],
                 fit_results=pdata["fit_dict"],
                 t_start=t0_global,
                 t_end=events["timestamp"].max(),


### PR DESCRIPTION
## Summary
- store isotope energy arrays when preparing time plot data
- plot each isotope using its own energy array

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840a1c60c24832b9f3fed0e051c2684