### PR TITLE
Fix bound handling for fixed spectrum parameters

### DIFF
--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -97,3 +97,28 @@ def test_fit_spectrum_use_emg_flag():
 
     # The function currently ignores tau_Po218; outputs should match closely
     assert pytest.approx(out_no_emg["S_Po218"], rel=1e-6) == out_emg["S_Po218"]
+
+
+def test_fit_spectrum_fixed_parameter_bounds():
+    """Fixing a parameter should not trigger a bound error."""
+    rng = np.random.default_rng(1)
+    energies = np.concatenate([
+        rng.normal(5.3, 0.05, 100),
+        rng.normal(6.0, 0.05, 100),
+        rng.normal(7.7, 0.05, 100),
+    ])
+
+    priors = {
+        "sigma_E": (0.05, 0.01),
+        "mu_Po210": (5.3, 0.0),
+        "S_Po210": (100, 10),
+        "mu_Po218": (6.0, 0.1),
+        "S_Po218": (100, 10),
+        "mu_Po214": (7.7, 0.1),
+        "S_Po214": (100, 10),
+        "b0": (0.0, 1.0),
+        "b1": (0.0, 1.0),
+    }
+
+    out = fit_spectrum(energies, priors, flags={"fix_mu_Po210": True})
+    assert "mu_Po210" in out


### PR DESCRIPTION
## Summary
- avoid equal lower/upper bounds by using a tiny epsilon
- document behavior in `fit_spectrum` docstring
- test spectral fit with a fixed parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840a1c68f84832ba0e4edb712bf536d