### PR TITLE
Fix timezone warning

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -52,7 +52,7 @@ import sys
 import json
 import logging
 import random
-from datetime import datetime
+from datetime import datetime, timezone
 
 import numpy as np
 import pandas as pd
@@ -124,7 +124,7 @@ def main():
             logging.warning(f"Invalid random_seed '{seed}' ignored")
 
     # Timestamp for this analysis run
-    now_str = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    now_str = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
 
 


### PR DESCRIPTION
## Summary
- import `timezone` alongside `datetime`
- use timezone-aware `datetime.now(timezone.utc)` instead of `datetime.utcnow`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840a1c800c0832b85fc2b85ca0382e0