### PR TITLE
Remove unused math import

### DIFF
--- a/fitting.py
+++ b/fitting.py
@@ -3,7 +3,6 @@
 # -----------------------------------------------------
 
 import numpy as np
-from math import exp, log
 from iminuit import Minuit
 from scipy.optimize import curve_fit
 


### PR DESCRIPTION
## Summary
- remove leftover `math` import from fitting

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840fa764140832b85609e2d00353cbd