### PR TITLE
Add configurable line style for time series plotting

### DIFF
--- a/config.json
+++ b/config.json
@@ -66,6 +66,7 @@
         "plot_time_binning_mode": "auto",
         "plot_time_bin_width_s": 3600,
         "plot_save_formats": ["png", "pdf"],
-        "plot_show_residuals": true
+        "plot_show_residuals": true,
+        "plot_time_style": "hist"
     }
 }

--- a/plot_utils.py
+++ b/plot_utils.py
@@ -82,6 +82,9 @@ def plot_time_series(
     centers = 0.5 * (edges[:-1] + edges[1:])
     bin_widths = np.diff(edges)
 
+    # Select drawing style for the data histogram
+    time_style = str(config.get("plot_time_style", "hist")).lower()
+
     # 2) Plot each isotope s histogram + overlay the model:
     plt.figure(figsize=(8, 6))
     colors = {"Po214": "tab:red", "Po218": "tab:blue"}
@@ -99,13 +102,21 @@ def plot_time_series(
 
         # Histogram of observed counts:
         counts_iso, _ = np.histogram(t_iso_rel, bins=edges)
-        plt.step(
-            centers,
-            counts_iso,
-            where="mid",
-            color=colors[iso],
-            label=f"Data {iso}",
-        )
+        if time_style == "lines":
+            plt.plot(
+                centers,
+                counts_iso,
+                color=colors[iso],
+                label=f"Data {iso}",
+            )
+        else:
+            plt.step(
+                centers,
+                counts_iso,
+                where="mid",
+                color=colors[iso],
+                label=f"Data {iso}",
+            )
 
         # Overlay the continuous model curve (scaled to counts/bin):
         lam = np.log(2.0) / iso_params[iso]["half_life"]

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -14,6 +14,7 @@ def basic_config():
         "time_bin_mode": "fixed",
         "time_bin_s": 1.0,
         "dump_time_series_json": False,
+        "plot_time_style": "hist",
     }
 
 
@@ -46,4 +47,14 @@ def test_plot_time_series_none_fit_results(tmp_path):
         basic_config(),
         str(out_png),
     )
+    assert out_png.exists()
+
+
+def test_plot_time_series_lines_style(tmp_path):
+    cfg = basic_config()
+    cfg["plot_time_style"] = "lines"
+    times = np.array([1000.0, 1001.0])
+    energies = np.array([7.6, 7.7])
+    out_png = tmp_path / "ts_lines.png"
+    plot_time_series(times, energies, None, 999.0, 1002.0, cfg, str(out_png))
     assert out_png.exists()


### PR DESCRIPTION
## Summary
- support `plot_time_style` option in `plot_time_series`
- document new option in `config.json`
- test plotting with the new `lines` style

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840fa7b16b8832b812774a81898f6f9