### PR TITLE
Add time_bins_fallback option

### DIFF
--- a/config.json
+++ b/config.json
@@ -65,6 +65,7 @@
         "plot_spectrum_binsize_adc": 1,
         "plot_time_binning_mode": "auto",
         "plot_time_bin_width_s": 3600,
+        "time_bins_fallback": 1,  // fallback number of time bins
         "plot_save_formats": ["png", "pdf"],
         "plot_show_residuals": true
     }

--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,12 @@ The analysis writes results to `<output_dir>/<timestamp>/` including:
 - `time_series_Po214.png` and `time_series_Po218.png` – decay time-series plots.
 - Optional `*_ts.json` files containing binned time series when enabled.
 
+## Configuration
+
+`time_bins_fallback` under the `plotting` section sets the number of
+histogram bins to use when the automatic Freedman&ndash;Diaconis rule
+fails, typically due to zero IQR.  The default is `1`.
+
 ## Running Tests
 
 Install the required Python packages and run the test suite with `pytest`.


### PR DESCRIPTION
## Summary
- support `time_bins_fallback` plotting option
- document fallback bin setting in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684102592f34832bb44271295d38b579