### PR TITLE
Fix ADC spectral bin edges conversion

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -242,7 +242,7 @@ def main():
             bins = nbins
             bin_edges = None
         else:
-            # “1 ADC channel per bin”
+            # "ADC" binning mode → fixed width in raw channels
             width = 1
             if bin_cfg is not None:
                 width = bin_cfg.get("adc_bin_width", 1)
@@ -251,7 +251,10 @@ def main():
             adc_min = events["adc"].min()
             adc_max = events["adc"].max()
             bins = int(np.ceil((adc_max - adc_min + 1) / width))
-            bin_edges = np.arange(adc_min, adc_min + bins * width + 1, width)
+
+            # Build edges in ADC units then convert to energy for plotting
+            bin_edges_adc = np.arange(adc_min, adc_min + bins * width + 1, width)
+            bin_edges = bin_edges_adc * a + c
 
         # Find approximate ADC centroids for Po‐210, Po‐218, Po‐214
         expected_peaks = cfg["spectral_fit"].get(
@@ -325,7 +328,7 @@ def main():
             print(f"WARNING: Spectral fit failed → {e}")
             spectrum_results = {}
 
-        # Store plotting inputs to generate the figure after summary writing
+        # Store plotting inputs (bin_edges now in energy units)
         spec_plot_data = {
             "energies": events["energy_MeV"].values,
             "fit_vals": spec_fit_out if spectrum_results else None,

--- a/readme.txt
+++ b/readme.txt
@@ -42,6 +42,11 @@ The analysis writes results to `<output_dir>/<timestamp>/` including:
 histogram bins to use when the automatic Freedman&ndash;Diaconis rule
 fails, typically due to zero IQR.  The default is `1`.
 
+When the spectrum is binned in raw ADC channels (`"spectral_binning_mode": "adc"`),
+the bin edges are internally converted to energy using the calibration
+slope and intercept before plotting.  This ensures `spectrum.png`
+reflects the calibrated energy scale regardless of binning mode.
+
 ## Running Tests
 
 Install the required Python packages and run the test suite with `pytest`.


### PR DESCRIPTION
## Summary
- convert ADC histogram edges to energy units in `analyze.py`
- note that ADC-mode bins are converted to energy in docs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410530c064832bb9f816d5485666eb