### PR TITLE
Add binning options to fit_spectrum

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -315,11 +315,14 @@ def main():
         # Launch the spectral fit
         spec_fit_out = None
         try:
-            spec_fit_out = fit_spectrum(
-                energies=events["energy_MeV"].values,
-                priors=priors_spec,
-                flags=spec_flags,
-            )
+            fit_kwargs = {
+                "energies": events["energy_MeV"].values,
+                "priors": priors_spec,
+                "flags": spec_flags,
+            }
+            if cfg["spectral_fit"].get("use_plot_bins_for_fit", False):
+                fit_kwargs.update({"bins": bins, "bin_edges": bin_edges})
+            spec_fit_out = fit_spectrum(**fit_kwargs)
             spectrum_results = spec_fit_out
         except Exception as e:
             print(f"WARNING: Spectral fit failed → {e}")

--- a/config.json
+++ b/config.json
@@ -31,6 +31,7 @@
         "sigma_E_prior_source": 0.15,
         "peak_search_prominence": 50,
         "peak_search_width_adc": 5
+        ,"use_plot_bins_for_fit": false
     },
     "time_fit": {
         "do_time_fit": true,

--- a/fitting.py
+++ b/fitting.py
@@ -58,7 +58,7 @@ def fit_decay(times, priors, t0=0.0, t_end=None, flags=None):
     }
 
 
-def fit_spectrum(energies, priors, flags=None):
+def fit_spectrum(energies, priors, flags=None, bins=None, bin_edges=None):
     """Fit three Gaussian peaks with a linear background to the spectrum.
 
     Parameters
@@ -71,6 +71,13 @@ def fit_spectrum(energies, priors, flags=None):
         Flags such as ``{"fix_sigma_E": True}`` to fix parameters. Fixed
         parameters are implemented by constraining the optimizer to a tiny
         interval (``±1e-12``) around the provided mean value.
+    bins : int or sequence, optional
+        Number of bins or bin edges to use when histogramming the input
+        energies.  Ignored if ``bin_edges`` is provided.  If both ``bins``
+        and ``bin_edges`` are ``None``, the Freedman--Diaconis rule is used.
+    bin_edges : array-like, optional
+        Explicit bin edges for histogramming the energies.  Takes precedence
+        over ``bins`` when given.
 
     Returns
     -------
@@ -85,8 +92,14 @@ def fit_spectrum(energies, priors, flags=None):
     if e.size == 0:
         raise RuntimeError("No energies provided to fit_spectrum")
 
-    # Histogram for chi2 fit using Freedman-Diaconis rule
-    hist, edges = np.histogram(e, bins="fd")
+    # Histogram according to provided binning parameters
+    if bin_edges is not None:
+        hist, edges = np.histogram(e, bins=np.asarray(bin_edges))
+    elif bins is not None:
+        hist, edges = np.histogram(e, bins=bins)
+    else:
+        # Default: Freedman-Diaconis rule
+        hist, edges = np.histogram(e, bins="fd")
     centers = 0.5 * (edges[:-1] + edges[1:])
     width = edges[1] - edges[0]
 

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -122,3 +122,34 @@ def test_fit_spectrum_fixed_parameter_bounds():
 
     out = fit_spectrum(energies, priors, flags={"fix_mu_Po210": True})
     assert "mu_Po210" in out
+
+
+def test_fit_spectrum_custom_bins_and_edges():
+    """Providing custom binning should not break the fit."""
+    rng = np.random.default_rng(2)
+    energies = np.concatenate([
+        rng.normal(5.3, 0.05, 150),
+        rng.normal(6.0, 0.05, 150),
+        rng.normal(7.7, 0.05, 150),
+    ])
+
+    priors = {
+        "sigma_E": (0.05, 0.01),
+        "mu_Po210": (5.3, 0.1),
+        "S_Po210": (150, 15),
+        "mu_Po218": (6.0, 0.1),
+        "S_Po218": (150, 15),
+        "mu_Po214": (7.7, 0.1),
+        "S_Po214": (150, 15),
+        "b0": (0.0, 1.0),
+        "b1": (0.0, 1.0),
+    }
+
+    # Using integer number of bins
+    out_bins = fit_spectrum(energies, priors, bins=30)
+    assert "sigma_E" in out_bins
+
+    # Using explicit bin edges
+    edges = np.linspace(5.0, 8.0, 25)
+    out_edges = fit_spectrum(energies, priors, bin_edges=edges)
+    assert "sigma_E" in out_edges


### PR DESCRIPTION
## Summary
- allow `fit_spectrum` to take optional `bins` and `bin_edges`
- pass binning choice in `analyze.py` when enabled in config
- add corresponding key in example `config.json`
- test new behavior for custom bins and edges

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684105313e04832baeefa23e80448099