### PR TITLE
Remove residual plot option

### DIFF
--- a/config.json
+++ b/config.json
@@ -65,7 +65,6 @@
         "plot_time_binning_mode": "auto",
         "plot_time_bin_width_s": 3600,
         "time_bins_fallback": 1,  // fallback number of time bins
-        "plot_save_formats": ["png", "pdf"],
-        "plot_show_residuals": true
+        "plot_save_formats": ["png", "pdf"]
     }
 }


### PR DESCRIPTION
## Summary
- remove `plot_show_residuals` from the plotting config

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684107f8b620832b8b145cc738e5bcde