### PR TITLE
Merge plotting opts into time-series plotting

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -508,13 +508,15 @@ def main():
 
     for iso, pdata in time_plot_data.items():
         try:
+            plot_cfg = dict(cfg.get("time_fit", {}))
+            plot_cfg.update(cfg.get("plotting", {}))
             _ = plot_time_series(
                 all_timestamps=pdata["events_times"],
                 all_energies=pdata["events_energy"],
                 fit_results=pdata["fit_dict"],
                 t_start=t0_global,
                 t_end=events["timestamp"].max(),
-                config=cfg["time_fit"],
+                config=plot_cfg,
                 out_png=os.path.join(out_dir, f"time_series_{iso}.png"),
             )
         except Exception as e:

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -1,0 +1,72 @@
+import json
+import sys
+from pathlib import Path
+import pandas as pd
+import numpy as np
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+
+
+def test_plot_time_series_receives_merged_config(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False},
+        "time_fit": {
+            "do_time_fit": True,
+            "window_Po214": [7.5, 8.0],
+            "window_Po218": None,
+        },
+        "systematics": {"enable": False},
+        "plotting": {
+            "plot_time_binning_mode": "fd",
+            "plot_save_formats": ["png"],
+        },
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame(
+        {
+            "fUniqueID": [1],
+            "fBits": [0],
+            "timestamp": [1000],
+            "adc": [7600],
+            "fchannel": [1],
+        }
+    )
+    data_path = tmp_path / "data.csv"
+    df.to_csv(data_path, index=False)
+
+    # Patch heavy functions with no-op versions
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "fit_decay", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+
+    received = {}
+
+    def fake_plot_time_series(*args, **kwargs):
+        received.update(kwargs)
+        Path(kwargs["out_png"]).touch()
+        return None
+
+    monkeypatch.setattr(analyze, "plot_time_series", fake_plot_time_series)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert received["config"]["plot_time_binning_mode"] == "fd"
+    assert received["config"]["window_Po214"] == [7.5, 8.0]


### PR DESCRIPTION
## Summary
- merge `cfg['time_fit']` and `cfg.get('plotting', {})` before calling `plot_time_series`
- add regression test ensuring analyze passes merged config to plotting

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684107f7fbf8832b80d8fd637164d390