### PR TITLE
Add time-series plotting options

### DIFF
--- a/config.json
+++ b/config.json
@@ -58,13 +58,16 @@
             "calibration_c_shift_abs": 0.05,
             "efficiency_Po214_shift_pct": 0.10,
             "efficiency_Po218_shift_pct": 0.10
-        }
+        },
+        "scan_keys": []
     },
     "plotting": {
         "plot_spectrum_binsize_adc": 1,
         "plot_time_binning_mode": "auto",
         "plot_time_bin_width_s": 3600,
         "time_bins_fallback": 1,  // fallback number of time bins
-        "plot_save_formats": ["png", "pdf"]
+        "plot_save_formats": ["png", "pdf"],
+        "dump_time_series_json": false,
+        "plot_time_style": "steps"
     }
 }

--- a/plot_utils.py
+++ b/plot_utils.py
@@ -100,13 +100,24 @@ def plot_time_series(
 
         # Histogram of observed counts:
         counts_iso, _ = np.histogram(t_iso_rel, bins=edges)
-        plt.step(
-            centers,
-            counts_iso,
-            where="mid",
-            color=colors[iso],
-            label=f"Data {iso}",
-        )
+        style = str(config.get("plot_time_style", "steps")).lower()
+        if style == "lines":
+            plt.plot(
+                centers,
+                counts_iso,
+                marker="o",
+                linestyle="-",
+                color=colors[iso],
+                label=f"Data {iso}",
+            )
+        else:
+            plt.step(
+                centers,
+                counts_iso,
+                where="mid",
+                color=colors[iso],
+                label=f"Data {iso}",
+            )
 
         # Overlay the continuous model curve (scaled to counts/bin):
         lam = np.log(2.0) / iso_params[iso]["half_life"]

--- a/readme.txt
+++ b/readme.txt
@@ -47,6 +47,17 @@ the bin edges are internally converted to energy using the calibration
 slope and intercept before plotting.  This ensures `spectrum.png`
 reflects the calibrated energy scale regardless of binning mode.
 
+`dump_time_series_json` under `plotting` saves a `*_ts.json` file
+containing the binned time-series data when set to `true`.
+
+`scan_keys` in the `systematics` section selects which fit parameters
+are varied during the systematic uncertainty scan.  By default no
+parameters are scanned.
+
+`plot_time_style` chooses how the histogram is drawn in the time-series
+plot.  Use `"steps"` (default) for a stepped histogram or `"lines"` to
+connect bin centers with straight lines.
+
 ## Running Tests
 
 Install the required Python packages and run the test suite with `pytest`.


### PR DESCRIPTION
## Summary
- support dumping time series json, scan key list and plot style options
- expose new keys in config.json
- document the new configuration options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410c3e8fb4832b9f12a82a3a9bb72f