### PR TITLE
Add nominal_adc customization for auto calibration

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -165,7 +165,8 @@ def main():
                 adc_vals,
                 noise_cutoff = cfg["calibration"].get("noise_cutoff", 300),
                 hist_bins    = cfg["calibration"].get("hist_bins", 2000),
-                peak_search_radius = cfg["calibration"].get("peak_search_radius", 200)
+                peak_search_radius = cfg["calibration"].get("peak_search_radius", 200),
+                nominal_adc = cfg["calibration"].get("nominal_adc")
             )
         else:
             # Two‐point calibration as given in config

--- a/calibration.py
+++ b/calibration.py
@@ -209,7 +209,13 @@ def derive_calibration_constants(adc_values, config):
     return out
 
 
-def derive_calibration_constants_auto(adc_values, noise_cutoff=300, hist_bins=2000, peak_search_radius=200):
+def derive_calibration_constants_auto(
+    adc_values,
+    noise_cutoff=300,
+    hist_bins=2000,
+    peak_search_radius=200,
+    nominal_adc=None,
+):
     """Simple auto-calibration using default configuration.
 
     Parameters
@@ -222,6 +228,11 @@ def derive_calibration_constants_auto(adc_values, noise_cutoff=300, hist_bins=20
         Number of histogram bins.
     peak_search_radius : int
         Window around nominal peaks used for matching.
+    nominal_adc : dict
+        Expected ADC centroids for each isotope.  Keys should be
+        ``"Po210"``, ``"Po218"`` and ``"Po214"``.  If ``None`` a
+        reasonable default of ``{"Po210": 1250, "Po218": 1400, "Po214": 1800}``
+        is used.
     """
     if len(adc_values) == 0:
         raise RuntimeError("No ADC values provided")
@@ -230,11 +241,14 @@ def derive_calibration_constants_auto(adc_values, noise_cutoff=300, hist_bins=20
     mask = adc_arr >= noise_cutoff
     adc_arr = adc_arr[mask]
 
+    if nominal_adc is None:
+        nominal_adc = {"Po210": 1250, "Po218": 1400, "Po214": 1800}
+
     config = {
         "calibration": {
             "peak_prominence": 10,
             "peak_width": 3,
-            "nominal_adc": {"Po210": 5200, "Po218": 6000, "Po214": 7600},
+            "nominal_adc": nominal_adc,
             # parameter renamed to ``peak_search_radius`` to match config.json
             "peak_search_radius": peak_search_radius,
             "fit_window_adc": 50,

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,11 @@ The analysis writes results to `<output_dir>/<timestamp>/` including:
 
 ## Configuration
 
+`nominal_adc` under the `calibration` section sets the expected raw ADC
+centroids for Po‑210, Po‑218 and Po‑214 when using automatic calibration.
+If omitted, defaults of `{"Po210": 1250, "Po218": 1400, "Po214": 1800}`
+are used.
+
 `time_bins_fallback` under the `plotting` section sets the number of
 histogram bins to use when the automatic Freedman&ndash;Diaconis rule
 fails, typically due to zero IQR.  The default is `1`.


### PR DESCRIPTION
## Summary
- allow `derive_calibration_constants_auto` to take `nominal_adc`
- pass `cfg['calibration'].get('nominal_adc')` from `analyze.py`
- default to `{Po210: 1250, Po218: 1400, Po214: 1800}`
- document `nominal_adc` in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410fce027c832ba1c45a57ee6aa494