### PR TITLE
Pass nominal_adc into auto calibration

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -165,7 +165,8 @@ def main():
                 adc_vals,
                 noise_cutoff = cfg["calibration"].get("noise_cutoff", 300),
                 hist_bins    = cfg["calibration"].get("hist_bins", 2000),
-                peak_search_radius = cfg["calibration"].get("peak_search_radius", 200)
+                peak_search_radius = cfg["calibration"].get("peak_search_radius", 200),
+                nominal_adc = cfg["calibration"].get("nominal_adc")
             )
         else:
             # Two‐point calibration as given in config

--- a/calibration.py
+++ b/calibration.py
@@ -209,7 +209,13 @@ def derive_calibration_constants(adc_values, config):
     return out
 
 
-def derive_calibration_constants_auto(adc_values, noise_cutoff=300, hist_bins=2000, peak_search_radius=200):
+def derive_calibration_constants_auto(
+    adc_values,
+    noise_cutoff=300,
+    hist_bins=2000,
+    peak_search_radius=200,
+    nominal_adc=None,
+):
     """Simple auto-calibration using default configuration.
 
     Parameters
@@ -222,6 +228,8 @@ def derive_calibration_constants_auto(adc_values, noise_cutoff=300, hist_bins=20
         Number of histogram bins.
     peak_search_radius : int
         Window around nominal peaks used for matching.
+    nominal_adc : dict or None
+        Optional mapping of isotope -> ADC guess.
     """
     if len(adc_values) == 0:
         raise RuntimeError("No ADC values provided")
@@ -234,7 +242,11 @@ def derive_calibration_constants_auto(adc_values, noise_cutoff=300, hist_bins=20
         "calibration": {
             "peak_prominence": 10,
             "peak_width": 3,
-            "nominal_adc": {"Po210": 5200, "Po218": 6000, "Po214": 7600},
+            "nominal_adc": {
+                "Po210": 5200,
+                "Po218": 6000,
+                "Po214": 7600,
+            },
             # parameter renamed to ``peak_search_radius`` to match config.json
             "peak_search_radius": peak_search_radius,
             "fit_window_adc": 50,
@@ -243,6 +255,9 @@ def derive_calibration_constants_auto(adc_values, noise_cutoff=300, hist_bins=20
             "init_tau_adc": 1.0,
         }
     }
+
+    if nominal_adc is not None:
+        config["calibration"]["nominal_adc"] = dict(nominal_adc)
 
     # Run calibration with custom histogram binning and convert to legacy format
     res = calibrate_run(adc_arr, config, hist_bins=hist_bins)


### PR DESCRIPTION
## Summary
- expose `nominal_adc` through `derive_calibration_constants_auto`
- forward config entry to auto calibration in `analyze.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410fcfca1c832bb1f47497a98b5801