### PR TITLE
Allow N0 prior sigma from config

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -418,7 +418,8 @@ def main():
                 cfg["time_fit"].get(f"sig_N0_{iso}", np.sqrt(n0_count) if n0_count > 0 else 1.0)
             )
         else:
-            priors_time["N0"] = (0.0, 0.0)
+            sigma = cfg["time_fit"].get(f"sig_N0_{iso}", 1.0)
+            priors_time["N0"] = (0.0, sigma)
 
         # Store priors for use in systematics scanning
         priors_time_all[iso] = priors_time

--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,9 @@ parameters are scanned.
 plot.  Use `"steps"` (default) for a stepped histogram or `"lines"` to
 connect bin centers with straight lines.
 
+`sig_N0_Po214` and `sig_N0_Po218` set the uncertainty on the prior for the
+initial activity `N0` when no baseline range is provided.
+
 `settling_time_s` was removed from the `time_fit` section and is no
 longer needed.
 


### PR DESCRIPTION
## Summary
- use configured sigma when baseline isn't provided
- document `sig_N0_Po214` and `sig_N0_Po218` in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684128da10a0832bb4d5d94459fbf845