### PR TITLE
Add overlay_isotopes option

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -533,12 +533,15 @@ def main():
         except Exception as e:
             print(f"WARNING: Could not create spectrum plot: {e}")
 
+    overlay = cfg.get("plotting", {}).get("overlay_isotopes", False)
+
     for iso, pdata in time_plot_data.items():
         try:
             plot_cfg = dict(cfg.get("time_fit", {}))
             plot_cfg.update(cfg.get("plotting", {}))
             other = "Po214" if iso == "Po218" else "Po218"
-            plot_cfg[f"window_{other}"] = None
+            if not overlay:
+                plot_cfg[f"window_{other}"] = None
             _ = plot_time_series(
                 all_timestamps=pdata["events_times"],
                 all_energies=pdata["events_energy"],

--- a/config.json
+++ b/config.json
@@ -82,6 +82,7 @@
         "time_bins_fallback": 1,
         "plot_save_formats": ["png", "pdf"],
         "dump_time_series_json": false,
-        "plot_time_style": "steps"
+        "plot_time_style": "steps",
+        "overlay_isotopes": false
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,10 @@ parameters are scanned.
 plot.  Use `"steps"` (default) for a stepped histogram or `"lines"` to
 connect bin centers with straight lines.
 
+`overlay_isotopes` under `plotting` keeps both energy windows when
+calling `plot_time_series`.  When `true`, Po‑214 and Po‑218 are overlaid
+in the same plot instead of appearing separately.
+
 `sig_N0_Po214` and `sig_N0_Po218` set the uncertainty on the prior for the
 initial activity `N0` when no baseline range is provided.
 

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -26,6 +26,7 @@ def test_plot_time_series_receives_merged_config(tmp_path, monkeypatch):
         "plotting": {
             "plot_time_binning_mode": "fd",
             "plot_save_formats": ["png"],
+            "overlay_isotopes": True,
         },
     }
     cfg_path = tmp_path / "cfg.json"
@@ -73,3 +74,4 @@ def test_plot_time_series_receives_merged_config(tmp_path, monkeypatch):
 
     assert received["config"]["plot_time_binning_mode"] == "fd"
     assert received["config"]["window_Po214"] == [7.5, 8.0]
+    assert received["config"]["overlay_isotopes"] is True


### PR DESCRIPTION
## Summary
- allow overlaying Po-214 and Po-218 time series
- document `overlay_isotopes` flag in README
- test that `analyze` passes through the new option

## Testing
- `pip install -q numpy pandas scipy matplotlib pytest iminuit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68412d2f7ef0832ba50acf6205351e13