### PR TITLE
Add radon half-life option for long fits

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -87,8 +87,26 @@ connect bin centers with straight lines.
 `sig_N0_Po214` and `sig_N0_Po218` set the uncertainty on the prior for the
 initial activity `N0` when no baseline range is provided.
 
+
 `settling_time_s` was removed from the `time_fit` section and is no
 longer needed.
+
+### Fitting Long Time Scales
+
+When the data covers months or more, the short half-lives of Po‑218 and
+Po‑214 no longer matter.  In that regime you may set `hl_Po214` and
+`hl_Po218` to the radon half-life (≈3.8 days) so they track the slowly
+varying radon concentration.  The configuration values are in seconds, so
+3.8 days corresponds to roughly `3.8 * 86400 ≈ 3.3e5` seconds.
+
+Example snippet:
+
+```json
+"time_fit": {
+    "hl_Po214": [328320, 0.0],
+    "hl_Po218": [328320, 0.0]
+}
+```
 
 
 ## Running Tests


### PR DESCRIPTION
## Summary
- document using radon half-life for Po-214 and Po-218
- provide example configuration snippet

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68412d2fef48832b8a3c642e5c5b2045