### PR TITLE
Allow custom half-life in plot_time_series

### DIFF
--- a/plot_utils.py
+++ b/plot_utils.py
@@ -32,12 +32,12 @@ def plot_time_series(
         "Po214": {
             "window": config.get("window_Po214"),
             "eff": float(config.get("eff_Po214", [1.0])[0]),
-            "half_life": PO214_HALF_LIFE_S,
+            "half_life": float(config.get("hl_Po214", [PO214_HALF_LIFE_S])[0]),
         },
         "Po218": {
             "window": config.get("window_Po218"),
             "eff": float(config.get("eff_Po218", [1.0])[0]),
-            "half_life": PO218_HALF_LIFE_S,
+            "half_life": float(config.get("hl_Po218", [PO218_HALF_LIFE_S])[0]),
         },
     }
     iso_list = [iso for iso, p in iso_params.items() if p["window"] is not None]


### PR DESCRIPTION
## Summary
- take `hl_Po214`/`hl_Po218` from config in `plot_time_series`
- test that custom half-life values are honoured when plotting

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68412d31b60c832b9521352323fd9204