### PR TITLE
Document N0 prior option

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -89,7 +89,9 @@ calling `plot_time_series`.  When `true`, Po‑214 and Po‑218 are overlaid
 in the same plot instead of appearing separately.
 
 `sig_N0_Po214` and `sig_N0_Po218` set the uncertainty on the prior for the
-initial activity `N0` when no baseline range is provided.
+initial activity `N0` when no baseline range is provided.  Instead of fixing
+`N0` strictly to zero, the time-series fit now uses a Gaussian prior centered at
+zero with this width.
 
 
 `settling_time_s` was removed from the `time_fit` section and is no


### PR DESCRIPTION
## Summary
- explain how `sig_N0_{iso}` controls the prior for `N0` when no baseline is provided

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c83d2244832ba089b075f7191dde