### PR TITLE
Read half-life values from config

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -88,6 +88,10 @@ connect bin centers with straight lines.
 calling `plot_time_series`.  When `true`, Po‑214 and Po‑218 are overlaid
 in the same plot instead of appearing separately.
 
+`plot_time_series` also reads `hl_Po214` and `hl_Po218` from the
+`time_fit` section when present.  These half-life values are used for the
+model overlay instead of built‑in defaults.
+
 `sig_N0_Po214` and `sig_N0_Po218` set the uncertainty on the prior for the
 initial activity `N0` when no baseline range is provided.
 


### PR DESCRIPTION
## Summary
- add `hl_Po214` and `hl_Po218` arguments to `plot_time_series`
- read half-lives from config (supports nested time_fit section)
- document half-life lookup in README
- test nested config behavior

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c83edb50832b8cae05092f9b1513