### PR TITLE
Remove unused import

### DIFF
--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -3,7 +3,6 @@ import sys
 from pathlib import Path
 import pandas as pd
 import numpy as np
-import types
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze


### PR DESCRIPTION
## Summary
- clean up tests by removing an unused `types` import

## Testing
- `pip install -r requirements.txt`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6841c84369e8832b9b36d024906d8e27