### PR TITLE
Fix typing annotation in systematics module

### DIFF
--- a/systematics.py
+++ b/systematics.py
@@ -1,12 +1,12 @@
 import math
-from typing import Callable, Dict, Tuple
+from typing import Callable, Dict, Tuple, List
 
 
 def scan_systematics(
     fit_func: Callable,
     priors: Dict[str, Tuple[float, float]],
     sigma_dict: Dict[str, float],
-    keys: [str],
+    keys: List[str],
 ) -> Tuple[Dict[str, float], float]:
     """Scan parameter level systematics as per the imported implementation."""
     central = fit_func(priors)


### PR DESCRIPTION
## Summary
- import `List` from typing
- update `scan_systematics` argument annotation to `List[str]`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841cf984cc8832b92ee05f1013d4462