### PR TITLE
Read time-fit half-lives

### DIFF
--- a/plot_utils.py
+++ b/plot_utils.py
@@ -41,10 +41,10 @@ def plot_time_series(
         fit_results = {}
 
     def _cfg_get(cfg, key, default=None):
-        if isinstance(cfg, dict) and key in cfg:
-            return cfg[key]
         if isinstance(cfg, dict) and "time_fit" in cfg and key in cfg["time_fit"]:
             return cfg["time_fit"][key]
+        if isinstance(cfg, dict) and key in cfg:
+            return cfg[key]
         return default
 
     # Determine half-lives with precedence: explicit argument -> config -> default


### PR DESCRIPTION
## Summary
- pick hl_Po214/hl_Po218 from `config['time_fit']` before checking top-level values
- rely on these values for the overlay curves

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841cf950e08832ba339ee6c0e4d7007