### PR TITLE
Enable overlay time-series plotting

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -555,10 +555,19 @@ def main():
             other = "Po214" if iso == "Po218" else "Po218"
             if not overlay:
                 plot_cfg[f"window_{other}"] = None
+                ts_times = pdata["events_times"]
+                ts_energy = pdata["events_energy"]
+                fit_dict = pdata["fit_dict"]
+            else:
+                ts_times = events["timestamp"].values
+                ts_energy = events["energy_MeV"].values
+                fit_dict = {}
+                fit_dict.update(time_plot_data.get("Po214", {}).get("fit_dict", {}))
+                fit_dict.update(time_plot_data.get("Po218", {}).get("fit_dict", {}))
             _ = plot_time_series(
-                all_timestamps=pdata["events_times"],
-                all_energies=pdata["events_energy"],
-                fit_results=pdata["fit_dict"],
+                all_timestamps=ts_times,
+                all_energies=ts_energy,
+                fit_results=fit_dict,
                 t_start=t0_global,
                 t_end=events["timestamp"].max(),
                 config=plot_cfg,

--- a/readme.txt
+++ b/readme.txt
@@ -84,9 +84,10 @@ parameters are scanned.
 plot.  Use `"steps"` (default) for a stepped histogram or `"lines"` to
 connect bin centers with straight lines.
 
-`overlay_isotopes` under `plotting` keeps both energy windows when
-calling `plot_time_series`.  When `true`, Po‑214 and Po‑218 are overlaid
-in the same plot instead of appearing separately.
+`overlay_isotopes` under `plotting` keeps both isotope windows intact
+when invoking `plot_time_series`.  When set to `true` the analysis does
+not clear the other window, allowing Po‑214 and Po‑218 to be plotted
+together on a single overlay.
 
 `plot_time_series` also reads `hl_Po214` and `hl_Po218` from the
 `time_fit` section when present.  These half-life values are used for the


### PR DESCRIPTION
## Summary
- allow overlaying isotopes in `plot_time_series`
- document `overlay_isotopes` configuration option

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d6364d2c832b85284bf4cb4fc577