### PR TITLE
Update plot_time_series half‑life logic

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -550,11 +550,11 @@ def main():
 
     for iso, pdata in time_plot_data.items():
         try:
-            plot_cfg = dict(cfg.get("time_fit", {}))
+            plot_cfg = {"time_fit": dict(cfg.get("time_fit", {}))}
             plot_cfg.update(cfg.get("plotting", {}))
             other = "Po214" if iso == "Po218" else "Po218"
             if not overlay:
-                plot_cfg[f"window_{other}"] = None
+                plot_cfg["time_fit"][f"window_{other}"] = None
             _ = plot_time_series(
                 all_timestamps=pdata["events_times"],
                 all_energies=pdata["events_energy"],

--- a/plot_utils.py
+++ b/plot_utils.py
@@ -32,9 +32,9 @@ def plot_time_series(
     config:         JSON dict or nested configuration
     out_png:        output path for the PNG file
     hl_Po214, hl_Po218: optional half-life values in seconds. If not
-        provided, these are looked up in ``config`` (first at the top
-        level and then under ``time_fit``) and finally fall back to the
-        built-in defaults.
+        provided, these are read from ``config['time_fit']`` when that
+        section is present and otherwise fall back to the built-in
+        defaults.
     """
 
     if fit_results is None:
@@ -49,11 +49,16 @@ def plot_time_series(
 
     # Determine half-lives with precedence: explicit argument -> config -> default
     def _hl_from_config(cfg, key, default):
-        val = _cfg_get(cfg, key)
+        if not isinstance(cfg, dict):
+            return default
+        tf_cfg = cfg.get("time_fit")
+        if not isinstance(tf_cfg, dict):
+            return default
+        val = tf_cfg.get(key)
         if val is None:
             return default
         if isinstance(val, (list, tuple)):
-            return float(val[0])
+            val = val[0]
         return float(val)
 
     hl_p214 = hl_Po214 if hl_Po214 is not None else _hl_from_config(

--- a/readme.txt
+++ b/readme.txt
@@ -88,9 +88,9 @@ connect bin centers with straight lines.
 calling `plot_time_series`.  When `true`, Po‑214 and Po‑218 are overlaid
 in the same plot instead of appearing separately.
 
-`plot_time_series` also reads `hl_Po214` and `hl_Po218` from the
-`time_fit` section when present.  These half-life values are used for the
-model overlay instead of built‑in defaults.
+`plot_time_series` reads `hl_Po214` and `hl_Po218` from the `time_fit`
+section.  These half-life values override the built‑in defaults and
+values at the top level are ignored.
 
 `sig_N0_Po214` and `sig_N0_Po218` set the uncertainty on the prior for the
 initial activity `N0` when no baseline range is provided.  Without a baseline,

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -72,5 +72,5 @@ def test_plot_time_series_receives_merged_config(tmp_path, monkeypatch):
     analyze.main()
 
     assert received["config"]["plot_time_binning_mode"] == "fd"
-    assert received["config"]["window_Po214"] == [7.5, 8.0]
+    assert received["config"]["time_fit"]["window_Po214"] == [7.5, 8.0]
     assert received["config"]["overlay_isotopes"] is True

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -92,8 +92,13 @@ def test_plot_spectrum_save_formats(tmp_path):
 def test_plot_time_series_custom_half_life(tmp_path, monkeypatch):
     times = np.array([1000.1, 1000.2, 1001.1, 1001.8])
     energies = np.array([7.6, 7.7, 7.8, 7.7])
-    cfg = basic_config()
-    cfg["hl_Po214"] = [2.0]
+    cfg = {"time_fit": basic_config()}
+    cfg["time_fit"]["hl_Po214"] = [2.0]
+    cfg.update({
+        "time_bin_mode": "fixed",
+        "time_bin_s": 1.0,
+        "dump_time_series_json": False,
+    })
 
     captured = {}
 


### PR DESCRIPTION
## Summary
- look up `hl_Po214` and `hl_Po218` in `config['time_fit']`
- pass nested configuration when calling `plot_time_series`
- clarify README
- adjust tests for new behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d6326464832ba713a3f6d3e7c187