### PR TITLE
Use half-life from time_fit section

### DIFF
--- a/plot_utils.py
+++ b/plot_utils.py
@@ -47,9 +47,12 @@ def plot_time_series(
             return cfg[key]
         return default
 
-    # Determine half-lives with precedence: explicit argument -> config -> default
+    # Determine half-lives with precedence: explicit arg -> config["time_fit"] -> default
     def _hl_from_config(cfg, key, default):
-        val = _cfg_get(cfg, key)
+        if isinstance(cfg, dict) and "time_fit" in cfg and key in cfg["time_fit"]:
+            val = cfg["time_fit"][key]
+        else:
+            val = None
         if val is None:
             return default
         if isinstance(val, (list, tuple)):

--- a/readme.txt
+++ b/readme.txt
@@ -89,9 +89,11 @@ when invoking `plot_time_series`.  When set to `true` the analysis does
 not clear the other window, allowing Po‑214 and Po‑218 to be plotted
 together on a single overlay.
 
-`plot_time_series` also reads `hl_Po214` and `hl_Po218` from the
-`time_fit` section when present.  These half-life values are used for the
-model overlay instead of built‑in defaults.
+`plot_time_series` takes its half-life values from the `time_fit` section.
+Specify `hl_Po214` and `hl_Po218` there to override the defaults of
+`1.64e-4` s (Po‑214) and `183` s (Po‑218) used when the keys are absent.
+These custom half-lives control the decay model drawn over the
+time-series histogram.
 
 `sig_N0_Po214` and `sig_N0_Po218` set the uncertainty on the prior for the
 initial activity `N0` when no baseline range is provided.  Without a baseline,

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -93,7 +93,7 @@ def test_plot_time_series_custom_half_life(tmp_path, monkeypatch):
     times = np.array([1000.1, 1000.2, 1001.1, 1001.8])
     energies = np.array([7.6, 7.7, 7.8, 7.7])
     cfg = basic_config()
-    cfg["hl_Po214"] = [2.0]
+    cfg["time_fit"] = {"hl_Po214": [2.0]}
 
     captured = {}
 


### PR DESCRIPTION
## Summary
- fetch custom half-life values from `config['time_fit']`
- document how to override the half-lives used in `plot_time_series`
- update unit tests for new configuration style

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d98a8460832b881ad0d69098c6a8