### PR TITLE
Update test instructions

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -136,13 +136,7 @@ Example snippet:
 
 ## Running Tests
 
-Install the required Python packages and run the test suite with `pytest`.
-The tests rely on `numpy`, `pandas`, `scipy`, `matplotlib`, `iminuit`, and
-`pytest` which are all listed in `requirements.txt`.
-
-Note that you must run `pip install -r requirements.txt` before executing `pytest`.
-
-Make sure the packages listed in `requirements.txt` are installed before executing `pytest`.
+Install the required Python packages before running `pytest`. The packages listed in `requirements.txt` must be installed:
 ```bash
 pip install -r requirements.txt
 pytest -v


### PR DESCRIPTION
## Summary
- update Running Tests section to explicitly mention installing requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6841e84c363c832b94dd624c8feccb60