### PR TITLE
Add lines style config for time series plots

### DIFF
--- a/config.json
+++ b/config.json
@@ -84,7 +84,7 @@
         "time_bins_fallback": 1,
         "plot_save_formats": ["png", "pdf"],
         "dump_time_series_json": false,
-        "plot_time_style": "steps",
+        "plot_time_style": "lines",
         "overlay_isotopes": false
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -86,7 +86,8 @@ parameters are scanned.
 
 `plot_time_style` chooses how the histogram is drawn in the time-series
 plot.  Use `"steps"` (default) for a stepped histogram or `"lines"` to
-connect bin centers with straight lines.
+connect bin centers with straight lines.  The line style is useful when
+overlaying multiple isotopes so one does not obscure the other.
 
 `overlay_isotopes` under `plotting` keeps both isotope windows intact
 when invoking `plot_time_series`.  When set to `true` the analysis does

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -154,3 +154,36 @@ def test_plot_time_series_nested_config(tmp_path, monkeypatch):
     expected = 0.1 * (1.0 - np.exp(-lam * centers))
     assert np.allclose(captured.get("y"), expected, rtol=1e-4)
 
+
+def test_plot_time_series_line_style(tmp_path, monkeypatch):
+    times = np.array([1000.2, 1000.8])
+    energies = np.array([7.7, 7.8])
+    cfg = basic_config()
+    cfg["plot_time_style"] = "lines"
+
+    called = {}
+
+    def fake_plot(*args, **kwargs):
+        called["plot"] = True
+        return type("obj", (), {})()
+
+    def fake_step(*args, **kwargs):
+        called["step"] = True
+        return type("obj", (), {})()
+
+    monkeypatch.setattr("plot_utils.plt.plot", fake_plot)
+    monkeypatch.setattr("plot_utils.plt.step", fake_step)
+    monkeypatch.setattr("plot_utils.plt.savefig", lambda *a, **k: None)
+
+    plot_time_series(
+        times,
+        energies,
+        None,
+        1000.0,
+        1001.0,
+        cfg,
+        str(tmp_path / "ts_lines.png"),
+    )
+
+    assert called.get("plot") and "step" not in called
+


### PR DESCRIPTION
## Summary
- document the `plot_time_style` config in `readme.txt`
- set example config to use `"lines"` style
- test that `plot_time_style='lines'` invokes `plt.plot`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e8493e5c832bb8165409ee378599