### PR TITLE
Require expected peaks in config

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -256,6 +256,9 @@ def main():
 
         # Find approximate ADC centroids for Po‐210, Po‐218, Po‐214
 
+        if "expected_peaks" not in cfg.get("spectral_fit", {}):
+            raise KeyError("'spectral_fit.expected_peaks' must be provided in the configuration")
+
         expected_peaks = cfg["spectral_fit"]["expected_peaks"]
 
         # `find_adc_peaks` will return a dict: e.g. { "Po210": adc_centroid, … }

--- a/config.json
+++ b/config.json
@@ -43,7 +43,7 @@
         "peak_search_prominence": 50,
         "peak_search_width_adc": 5,
         "use_plot_bins_for_fit": false,
-        "expected_peaks": {"Po210": 5300, "Po218": 6000, "Po214": 7690},
+        "expected_peaks": {"Po210": 1250, "Po218": 1400, "Po214": 1800},
         "mu_bounds": {
             "Po210": null,
             "Po218": null,

--- a/readme.txt
+++ b/readme.txt
@@ -74,8 +74,8 @@ fit.  Important keys include:
   search are clamped to this range before the fit starts.
 
 - `expected_peaks` – approximate ADC centroids used to locate the
-  Po‑210, Po‑218 and Po‑214 peaks before fitting. Typical values are
-  `{"Po210": 5300, "Po218": 6000, "Po214": 7690}`.
+  Po‑210, Po‑218 and Po‑214 peaks before fitting. The default is
+  `{"Po210": 1250, "Po218": 1400, "Po214": 1800}`.
 
 `dump_time_series_json` under `plotting` saves a `*_ts.json` file
 containing the binned time-series data when set to `true`.

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -14,7 +14,7 @@ def test_plot_time_series_receives_merged_config(tmp_path, monkeypatch):
         "calibration": {},
         "spectral_fit": {
             "do_spectral_fit": False,
-            "expected_peaks": {"Po210": 5300, "Po218": 6000, "Po214": 7690},
+            "expected_peaks": {"Po210": 1250, "Po218": 1400, "Po214": 1800},
         },
         "time_fit": {
             "do_time_fit": True,


### PR DESCRIPTION
## Summary
- set new `expected_peaks` defaults in `config.json`
- enforce presence of this key in `analyze.py`
- document defaults in README
- adjust test for new config value

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e8472d18832b9e10800a19e64bed