### PR TITLE
Add config options for time fit guesses

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -430,6 +430,8 @@ def main():
                 "fix_background_b", False
             ),
             "fit_initial": not cfg["time_fit"]["flags"].get(f"fix_N0_{iso}", False),
+            "background_guess": cfg["time_fit"].get("background_guess", 0.0),
+            "n0_guess_fraction": cfg["time_fit"].get("n0_guess_fraction", 0.1),
         }
 
         # Run time-series fit
@@ -489,6 +491,8 @@ def main():
                     "fit_initial": not cfg["time_fit"]["flags"].get(
                         f"fix_N0_{iso}", False
                     ),
+                    "background_guess": cfg["time_fit"].get("background_guess", 0.0),
+                    "n0_guess_fraction": cfg["time_fit"].get("n0_guess_fraction", 0.1),
                 }
                 out = fit_time_series(
                     times_dict,

--- a/config.json
+++ b/config.json
@@ -62,6 +62,8 @@
         "bkg_Po218": [0.0, 0.0],
         "sig_N0_Po214": 1.0,
         "sig_N0_Po218": 1.0,
+        "background_guess": 0.0,
+        "n0_guess_fraction": 0.1,
         "flags": {
             "fix_background_b": false,
             "fix_N0_Po218": false

--- a/fitting.py
+++ b/fitting.py
@@ -325,6 +325,9 @@ def fit_time_series(times_dict, t_start, t_end, config):
     initial_guesses = []
     limits = {}
 
+    background_guess = float(config.get("background_guess", 0.0))
+    n0_guess_frac = float(config.get("n0_guess_fraction", 0.1))
+
     idx = 0
     for iso in iso_list:
         #    E_iso
@@ -342,15 +345,15 @@ def fit_time_series(times_dict, t_start, t_end, config):
         #    B_iso (if not fixed)
         if not fix_b_map[iso]:
             param_indices[f"B_{iso}"] = idx
-            initial_guesses.append(float(config.get("background_guess", 0.0)))
+            initial_guesses.append(background_guess)
             limits[f"B_{iso}"] = (0.0, None)
             idx += 1
 
         #    N0_iso (if not fixed)
         if not fix_n0_map[iso]:
             param_indices[f"N0_{iso}"] = idx
-            # N0 guess = 10% of total events (very rough) or zero
-            guess_N0 = Ntot * 0.1 if Ntot > 0 else 0.0
+            # N0 guess = fraction of total events (very rough) or zero
+            guess_N0 = Ntot * n0_guess_frac if Ntot > 0 else 0.0
             initial_guesses.append(guess_N0)
             limits[f"N0_{iso}"] = (0.0, None)
             idx += 1


### PR DESCRIPTION
## Summary
- allow configuration of default time fit guesses
- pass new settings when running decay fits
- add corresponding options in default `config.json`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841fbc8d534832b910a283f3c864310