### PR TITLE
Handle pandas scalars in utils.to_native

### DIFF
--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -82,3 +82,18 @@ def test_write_summary_and_copy_config(tmp_path):
         json.dump(cfg, f)
     dest = copy_config(str(outdir), str(cp))
     assert Path(dest).exists()
+
+
+def test_write_summary_with_nullable_integers(tmp_path):
+    series = pd.Series([1, pd.NA], dtype="Int64")
+    summary = {"present": series.iloc[0], "missing": series.iloc[1], "list": series.tolist()}
+    outdir = tmp_path / "out2"
+    ts = "19700101T000001Z"
+    results = write_summary(str(outdir), summary, ts)
+    summary_path = Path(results) / "summary.json"
+    assert summary_path.exists()
+    with open(summary_path, "r", encoding="utf-8") as f:
+        loaded = json.load(f)
+    assert loaded["present"] == 1
+    assert loaded["missing"] is None
+    assert loaded["list"] == [1, None]

--- a/utils.py
+++ b/utils.py
@@ -3,6 +3,11 @@
 import numpy as np
 from scipy.signal import find_peaks
 
+try:
+    import pandas as pd
+except Exception:  # pragma: no cover - pandas is optional for utils
+    pd = None
+
 __all__ = ["to_native", "find_adc_peaks"]
 
 
@@ -15,7 +20,15 @@ def to_native(obj):
         return {to_native(k): to_native(v) for k, v in obj.items()}
     elif isinstance(obj, list):
         return [to_native(x) for x in obj]
-    elif isinstance(obj, np.generic):
+    if pd is not None:
+        # Handle pandas scalar types
+        if obj is pd.NA:
+            return None
+        elif isinstance(obj, (pd.Timestamp, pd.Timedelta)):
+            return obj.isoformat()
+        elif isinstance(obj, (pd.Series, pd.Index)):
+            return [to_native(x) for x in obj.tolist()]
+    if isinstance(obj, np.generic):
         return obj.item()
     elif isinstance(obj, np.ndarray):
         # Convert array into list of native types


### PR DESCRIPTION
## Summary
- extend `utils.to_native` to also convert common pandas scalar types so JSON
  serialization doesn't break
- add a regression test that writes a summary with nullable integers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68421f05c9d0832bbbfb751e3e978b59