### PR TITLE
Add count rate conversion helpers

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -11,7 +11,8 @@ This repository provides a complete pipeline to analyze electrostatic radon moni
 - `fitting.py`: Unbinned likelihood fit for Po-214 (and optional Po-218).
 - `systematics.py`: Scan for systematic uncertainties (optional).
 - `plot_utils.py`: Plotting routines for spectrum and time-series.
-- `utils.py`: Miscellaneous utilities (time conversion, JSON validation).
+- `utils.py`: Miscellaneous utilities (time conversion, JSON validation,
+  count-rate conversions).
 - `tests/`: `pytest` unit tests for calibration, fitting, and I/O.
 
 ## Installation
@@ -132,6 +133,21 @@ Example snippet:
     "sig_N0_Po214": 1.0,
     "sig_N0_Po218": 1.0
 }
+```
+
+## Utility Conversions
+
+`utils.py` provides simple helpers to convert count rates:
+
+- `cps_to_cpd(rate_cps)` converts counts/s to counts/day.
+- `cps_to_bq(rate_cps, volume_liters=None)` returns the activity in Bq, or
+  Bq/m^3 when a detector volume is supplied.
+
+You can invoke these from the command line:
+
+```bash
+python utils.py 0.5 --to cpd
+python utils.py 0.5 --to bq --volume_liters 10
 ```
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from utils import cps_to_cpd, cps_to_bq
+
+
+def test_cps_to_cpd():
+    assert cps_to_cpd(1.0) == pytest.approx(86400.0)
+
+
+def test_cps_to_bq_volume():
+    # 2 cps in 10 L -> 2/(0.01 m^3) = 200 Bq/m^3
+    assert cps_to_bq(2.0, volume_liters=10.0) == pytest.approx(200.0)
+
+
+def test_cps_to_bq_simple():
+    assert cps_to_bq(3.5) == pytest.approx(3.5)


### PR DESCRIPTION
## Summary
- add `cps_to_cpd` and `cps_to_bq` in `utils.py`
- expose them via CLI when running `utils.py`
- document new helpers and usage in `readme.txt`
- add unit tests for the conversions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68421f0dad34832b991089cc647fd5cf