### PR TITLE
Add analysis_start_time support

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -148,8 +148,18 @@ def main():
 
     events["timestamp"] = events["timestamp"].astype(float)
 
-    # Global t₀ reference = earliest event
-    t0_global = events["timestamp"].min()
+    # Global t₀ reference
+    t0_cfg = cfg.get("analysis", {}).get("analysis_start_time")
+    if t0_cfg is not None:
+        try:
+            t0_global = pd.to_datetime(t0_cfg, utc=True).timestamp()
+        except Exception:
+            logging.warning(
+                f"Invalid analysis_start_time '{t0_cfg}' - using first event"
+            )
+            t0_global = events["timestamp"].min()
+    else:
+        t0_global = events["timestamp"].min()
 
     # ────────────────────────────────────────────────────────────
     # 3. Energy calibration

--- a/config.json
+++ b/config.json
@@ -3,6 +3,9 @@
         "log_level": "INFO",
         "random_seed": null
     },
+    "analysis": {
+        "analysis_start_time": null
+    },
     "calibration": {
         "method": "auto",
         "noise_cutoff": 300,

--- a/readme.txt
+++ b/readme.txt
@@ -47,6 +47,11 @@ centroids for Po‑210, Po‑218 and Po‑214 when using automatic calibration.
 If omitted, defaults of `{"Po210": 1250, "Po218": 1400, "Po214": 1800}`
 are used.
 
+`analysis_start_time` in the optional `analysis` section sets the global
+time origin for decay fitting and time-series plots.  Provide an
+ISO‑8601 string such as `"2020-01-01T00:00:00Z"`.  When omitted the first
+event timestamp is used.
+
 `time_bins_fallback` under the `plotting` section sets the number of
 histogram bins to use when the automatic Freedman&ndash;Diaconis rule
 fails, typically due to zero IQR.  The default is `1`.

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -77,3 +77,65 @@ def test_plot_time_series_receives_merged_config(tmp_path, monkeypatch):
     assert received["config"]["plot_time_binning_mode"] == "fd"
     assert received["config"]["window_Po214"] == [7.5, 8.0]
     assert received["config"]["overlay_isotopes"] is True
+
+
+def test_analysis_start_time_applied(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {},
+        "analysis": {"analysis_start_time": "1970-01-01T00:00:10Z"},
+        "calibration": {},
+        "spectral_fit": {
+            "do_spectral_fit": False,
+            "expected_peaks": {"Po210": 0, "Po218": 0, "Po214": 0},
+        },
+        "time_fit": {
+            "do_time_fit": True,
+            "window_Po214": [7.5, 8.0],
+            "window_Po218": None,
+            "hl_Po214": [1.0, 0.0],
+            "eff_Po214": [1.0, 0.0],
+            "flags": {},
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1],
+        "fBits": [0],
+        "timestamp": [15],
+        "adc": [7600],
+        "fchannel": [1],
+    })
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+
+    captured = {}
+
+    def fake_fit_time_series(times_dict, t_start, t_end, config):
+        captured["t_start"] = t_start
+        return {}
+
+    monkeypatch.setattr(analyze, "fit_time_series", fake_fit_time_series)
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert captured.get("t_start") == 10.0


### PR DESCRIPTION
## Summary
- add optional `analysis_start_time` config key
- parse `analysis_start_time` in `analyze.py`
- document new option in README
- test that time origin can be overridden

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68421efadee0832bb777bb69559a1d38