### PR TITLE
Implement burst filter for event cleaning

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -57,7 +57,13 @@ import numpy as np
 import pandas as pd
 
 # ‣ Import our supporting modules (all must live in the same folder).
-from io_utils import load_config, copy_config, load_events, write_summary
+from io_utils import (
+    load_config,
+    copy_config,
+    load_events,
+    write_summary,
+    apply_burst_filter,
+)
 from calibration import derive_calibration_constants, derive_calibration_constants_auto
 from fitting import fit_spectrum, fit_time_series
 from plot_utils import plot_spectrum, plot_time_series
@@ -147,6 +153,9 @@ def main():
         events["timestamp"] = pd.to_datetime(events["timestamp"]).astype(np.int64) / 1e9
 
     events["timestamp"] = events["timestamp"].astype(float)
+
+    # Apply burst filter before any analysis
+    events, n_burst_removed = apply_burst_filter(events, cfg)
 
     # Global t₀ reference = earliest event
     t0_global = events["timestamp"].min()
@@ -523,6 +532,7 @@ def main():
         "time_fit": time_fit_results,
         "systematics": systematics_results,
         "baseline": baseline_info,
+        "burst_removed": int(n_burst_removed),
     }
 
     out_dir = write_summary(args.output_dir, summary, now_str)

--- a/config.json
+++ b/config.json
@@ -3,6 +3,11 @@
         "log_level": "INFO",
         "random_seed": null
     },
+    "burst_filter": {
+        "burst_window_size_s": 60,
+        "rolling_median_window": 11,
+        "burst_multiplier": 5
+    },
     "calibration": {
         "method": "auto",
         "noise_cutoff": 300,


### PR DESCRIPTION
## Summary
- add burst filtering configuration
- implement `apply_burst_filter` in `io_utils`
- integrate burst filter into main analysis pipeline
- report removed events in summary JSON
- test burst filter logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68421ef0f3d0832bb8ecd7ffc5174422