### PR TITLE
Add calibration sanity check

### DIFF
--- a/config.json
+++ b/config.json
@@ -18,6 +18,7 @@
         "use_emg": false,
         "init_sigma_adc": 10.0,
         "init_tau_adc": 1.0,
+        "sanity_tolerance_mev": 0.5,
         "known_energies": {"Po210": 5.304, "Po218": 6.002, "Po214": 7.687}
     },
     "spectral_fit": {

--- a/readme.txt
+++ b/readme.txt
@@ -48,6 +48,11 @@ centroids for Po‑210, Po‑218 and Po‑214 when using automatic calibration.
 If omitted, defaults of `{"Po210": 1250, "Po218": 1400, "Po214": 1800}`
 are used.
 
+`sanity_tolerance_mev` in the same section specifies how close the fitted
+peak energies must be to their known values.  The default of `0.5` MeV
+causes calibration to fail when any Po‑210, Po‑218 or Po‑214 centroid
+deviates by more than this amount.
+
 `analysis_start_time` in the optional `analysis` section sets the global
 time origin for decay fitting and time-series plots.  Provide an
 ISO‑8601 string such as `"2020-01-01T00:00:00Z"`.  When omitted the first


### PR DESCRIPTION
## Summary
- verify fitted peak energies during calibration
- store calibrated peak centroids in MeV
- expose `calibration.sanity_tolerance_mev` in the config and document it
- test that misidentified peaks raise a `RuntimeError`

## Testing
- `pip install -q numpy scipy matplotlib pandas iminuit pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842255ada98832bbe4b83bb8f08a2b7