### PR TITLE
Add config key validation in load_config

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -29,17 +29,21 @@ def load_config(config_path):
     with open(config_path, "r", encoding="utf-8") as f:
         cfg = json.load(f)
 
-    # Basic validation: check for required top level keys
-    required_sections = [
-        "pipeline",
-        "spectral_fit",
-        "time_fit",
-        "systematics",
-        "plotting",
-    ]
-    for section in required_sections:
+    # Basic validation: check for required keys within each section
+    required_structure = {
+        "pipeline": ["log_level"],
+        "spectral_fit": ["expected_peaks"],
+        "time_fit": ["do_time_fit"],
+        "systematics": ["enable"],
+        "plotting": ["plot_save_formats"],
+    }
+
+    for section, keys in required_structure.items():
         if section not in cfg:
             raise KeyError(f"Missing required config section: '{section}'")
+        for key in keys:
+            if key not in cfg.get(section, {}):
+                raise KeyError(f"Missing key '{section}.{key}' in config")
 
     return cfg
 

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -10,7 +10,7 @@ import analyze
 
 def test_plot_time_series_receives_merged_config(tmp_path, monkeypatch):
     cfg = {
-        "pipeline": {},
+        "pipeline": {"log_level": "INFO"},
         "calibration": {},
         "spectral_fit": {
             "do_spectral_fit": False,
@@ -81,7 +81,7 @@ def test_plot_time_series_receives_merged_config(tmp_path, monkeypatch):
 
 def test_analysis_start_time_applied(tmp_path, monkeypatch):
     cfg = {
-        "pipeline": {},
+        "pipeline": {"log_level": "INFO"},
         "analysis": {"analysis_start_time": "1970-01-01T00:00:10Z"},
         "calibration": {},
         "spectral_fit": {

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -45,10 +45,12 @@ def test_load_config(tmp_path):
                 "eff_po218": 0.1,
             },
         },
-        "pipeline": {},
-        "spectral_fit": {},
-        "time_fit": {},
-        "plotting": {},
+        "pipeline": {"log_level": "INFO"},
+        "spectral_fit": {
+            "expected_peaks": {"Po210": 1250, "Po218": 1400, "Po214": 1800}
+        },
+        "time_fit": {"do_time_fit": True},
+        "plotting": {"plot_save_formats": ["png"]},
     }
     p = tmp_path / "cfg.json"
     with open(p, "w") as f:
@@ -56,6 +58,35 @@ def test_load_config(tmp_path):
     loaded = load_config(str(p))
     assert loaded["adc"]["min_channel"] == 0
     assert loaded["efficiency"]["eff_po214"] == 0.4
+
+
+def test_load_config_missing_key(tmp_path):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "spectral_fit": {},
+        "time_fit": {"do_time_fit": True},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    p = tmp_path / "cfg.json"
+    with open(p, "w") as f:
+        json.dump(cfg, f)
+    with pytest.raises(KeyError):
+        load_config(str(p))
+
+
+def test_load_config_missing_section(tmp_path):
+    cfg = {
+        "spectral_fit": {"expected_peaks": {"Po210": 1}},
+        "time_fit": {"do_time_fit": True},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    p = tmp_path / "cfg.json"
+    with open(p, "w") as f:
+        json.dump(cfg, f)
+    with pytest.raises(KeyError):
+        load_config(str(p))
 
 
 def test_load_events(tmp_path):


### PR DESCRIPTION
## Summary
- validate required keys when loading config
- expand unit tests for load_config success and failure
- update analyze config tests with minimal required keys

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68422b7a8edc832bb69d01c389e0a9d7