### PR TITLE
Add burst filter modes with micro-burst veto

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -99,6 +99,12 @@ def parse_args():
             "listed in `baseline` of the summary."
         ),
     )
+    p.add_argument(
+        "--burst-mode",
+        default="rate",
+        choices=["none", "micro", "rate", "both"],
+        help="Burst filtering mode to pass to apply_burst_filter",
+    )
     return p.parse_args()
 
 
@@ -155,7 +161,7 @@ def main():
     events["timestamp"] = events["timestamp"].astype(float)
 
     # Optional burst filter to remove high-rate clusters
-    events, n_removed_burst = apply_burst_filter(events, cfg)
+    events, n_removed_burst = apply_burst_filter(events, cfg, mode=args.burst_mode)
 
     # Global t₀ reference
     t0_cfg = cfg.get("analysis", {}).get("analysis_start_time")

--- a/config.json
+++ b/config.json
@@ -9,7 +9,9 @@
     "burst_filter": {
         "burst_window_size_s": 60,
         "rolling_median_window": 5,
-        "burst_multiplier": 5
+        "burst_multiplier": 5,
+        "micro_window_size_s": 1,
+        "micro_count_threshold": 3
     },
     "calibration": {
         "method": "auto",

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,14 @@ time origin for decay fitting and time-series plots.  Provide an
 ISO‑8601 string such as `"2020-01-01T00:00:00Z"`.  When omitted the first
 event timestamp is used.
 
+`burst_filter` controls removal of short high-rate clusters.  The
+command-line option `--burst-mode` chooses the strategy:
+`none` disables the filter, `micro` applies a short sliding-window veto
+defined by `micro_window_size_s` and `micro_count_threshold`, `rate`
+uses the rolling-median threshold (`burst_window_size_s`,
+`rolling_median_window`, `burst_multiplier`) and `both` applies the
+micro filter followed by the rate veto.  The default mode is `rate`.
+
 `time_bins_fallback` under the `plotting` section sets the number of
 histogram bins to use when the automatic Freedman&ndash;Diaconis rule
 fails, typically due to zero IQR.  The default is `1`.

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -138,3 +138,50 @@ def test_apply_burst_filter_with_burst():
     filtered, removed = apply_burst_filter(df, cfg)
     assert removed == 60
     assert len(filtered) == len(times) - 60
+
+
+def test_apply_burst_filter_mode_none():
+    df = pd.DataFrame(
+        {
+            "fUniqueID": range(10),
+            "fBits": [0] * 10,
+            "timestamp": [0] * 10,
+            "adc": [1000] * 10,
+            "fchannel": [1] * 10,
+        }
+    )
+    cfg = {
+        "burst_filter": {
+            "burst_window_size_s": 1,
+            "rolling_median_window": 1,
+            "burst_multiplier": 2,
+            "micro_window_size_s": 0.1,
+            "micro_count_threshold": 2,
+        }
+    }
+    filtered, removed = apply_burst_filter(df, cfg, mode="none")
+    assert len(filtered) == len(df)
+    assert removed == 0
+
+
+def test_apply_burst_filter_micro_burst():
+    times = np.concatenate([np.arange(10), np.full(4, 20)])
+    df = pd.DataFrame(
+        {
+            "fUniqueID": range(len(times)),
+            "fBits": [0] * len(times),
+            "timestamp": times,
+            "adc": [1000] * len(times),
+            "fchannel": [1] * len(times),
+        }
+    )
+    cfg = {
+        "burst_filter": {
+            "micro_window_size_s": 1,
+            "micro_count_threshold": 3,
+        }
+    }
+    filtered, removed = apply_burst_filter(df, cfg, mode="micro")
+    assert removed == 4
+    assert len(filtered) == len(times) - 4
+


### PR DESCRIPTION
## Summary
- expand `apply_burst_filter` with `mode` argument and micro-burst logic
- expose `--burst-mode` CLI option in `analyze.py`
- document burst filtering options in `readme.txt`
- extend configuration with micro-burst parameters
- add unit tests for new burst filter behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68422b847de4832b8f2d2d301bb3183e