### PR TITLE
Add --job-id option

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -86,7 +86,7 @@ def parse_args():
         "--output_dir",
         "-o",
         required=True,
-        help="Directory under which to create a timestamped analysis folder",
+        help="Directory under which to create a timestamped analysis folder (override with --job-id)",
     )
     p.add_argument(
         "--baseline_range",
@@ -104,6 +104,10 @@ def parse_args():
         default="rate",
         choices=["none", "micro", "rate", "both"],
         help="Burst filtering mode to pass to apply_burst_filter",
+    )
+    p.add_argument(
+        "--job-id",
+        help="Optional identifier used for the results folder instead of the timestamp",
     )
     return p.parse_args()
 
@@ -551,7 +555,7 @@ def main():
         "burst_filter": {"removed_events": int(n_removed_burst)},
     }
 
-    out_dir = write_summary(args.output_dir, summary, now_str)
+    out_dir = write_summary(args.output_dir, summary, args.job_id or now_str)
     copy_config(out_dir, args.config)
 
     # Generate plots now that the output directory exists

--- a/readme.txt
+++ b/readme.txt
@@ -24,12 +24,12 @@ pip install -r requirements.txt
 ## Usage
 
 ```bash
-python analyze.py --config config.json --input merged_data.csv [--output_dir results]
+python analyze.py --config config.json --input merged_data.csv [--output_dir results] [--job-id MYRUN]
 ```
 
 ## Output
 
-The analysis writes results to `<output_dir>/<timestamp>/` including:
+The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--job-id` is given the folder `<output_dir>/<job-id>/` is used instead. The directory includes:
 
 - `summary.json` – calibration and fit summary.
 - `config_used.json` – copy of the configuration used.

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -139,3 +139,69 @@ def test_analysis_start_time_applied(tmp_path, monkeypatch):
     analyze.main()
 
     assert captured.get("t_start") == 10.0
+
+
+def test_job_id_overrides_results_folder(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {
+            "do_spectral_fit": False,
+            "expected_peaks": {"Po210": 1250, "Po218": 1400, "Po214": 1800},
+        },
+        "time_fit": {
+            "do_time_fit": True,
+            "window_Po214": [7.5, 8.0],
+            "window_Po218": None,
+            "hl_Po214": [1.0, 0.0],
+            "eff_Po214": [1.0, 0.0],
+            "flags": {},
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1],
+        "fBits": [0],
+        "timestamp": [0],
+        "adc": [1000],
+        "fchannel": [1],
+    })
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+
+    recorded = {}
+
+    def fake_write_summary(out_dir, summary, timestamp=None):
+        recorded["folder"] = Path(out_dir) / timestamp
+        recorded["folder"].mkdir(parents=True, exist_ok=True)
+        return str(recorded["folder"])
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write_summary)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+        "--job-id",
+        "JOB123",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert recorded["folder"].name == "JOB123"


### PR DESCRIPTION
## Summary
- allow overriding the timestamped folder by adding a `--job-id` option
- document custom results folder usage
- test that the new flag controls the output folder

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68422d48d004832b8f1c400db10cf3ee