### PR TITLE
Add git metadata to analysis summary

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -52,6 +52,8 @@ import sys
 import logging
 import random
 from datetime import datetime, timezone
+import subprocess
+import hashlib
 
 import numpy as np
 import pandas as pd
@@ -113,6 +115,16 @@ def parse_args():
 
 
 def main():
+    cli_args = sys.argv[:]
+    cli_sha256 = hashlib.sha256(" ".join(cli_args).encode("utf-8")).hexdigest()
+    try:
+        commit = (
+            subprocess.check_output(["git", "rev-parse", "HEAD"], encoding="utf-8")
+            .strip()
+        )
+    except Exception:
+        commit = "unknown"
+
     args = parse_args()
 
     # ────────────────────────────────────────────────────────────
@@ -553,6 +565,9 @@ def main():
         "systematics": systematics_results,
         "baseline": baseline_info,
         "burst_filter": {"removed_events": int(n_removed_burst)},
+        "git_commit": commit,
+        "cli_sha256": cli_sha256,
+        "cli_args": cli_args,
     }
 
     out_dir = write_summary(args.output_dir, summary, args.job_id or now_str)

--- a/tests/test_cli_metadata.py
+++ b/tests/test_cli_metadata.py
@@ -1,0 +1,66 @@
+import json
+import sys
+from pathlib import Path
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+
+
+def test_summary_includes_git_and_cli(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1],
+        "fBits": [0],
+        "timestamp": [0],
+        "adc": [1000],
+        "fchannel": [1],
+    })
+    data_path = tmp_path / "data.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+
+    captured = {}
+
+    def fake_write_summary(out_dir, summary, timestamp=None):
+        captured["summary"] = summary
+        d = Path(out_dir) / (timestamp or "x")
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write_summary)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    summary = captured.get("summary")
+    assert summary is not None
+    assert "git_commit" in summary
+    assert "cli_sha256" in summary
+    assert "cli_args" in summary


### PR DESCRIPTION
## Summary
- capture git commit hash and CLI hash in `analyze.main`
- store `cli_args`, `cli_sha256`, and `git_commit` in the summary JSON
- test that these fields appear in the summary

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842326df914832bbaa69059779410bb