### PR TITLE
Add CLI overrides for efficiency and plotting

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -25,7 +25,10 @@ pip install -r requirements.txt
 ## Usage
 
 ```bash
-python analyze.py --config config.json --input merged_data.csv [--output_dir results] [--job-id MYRUN]
+python analyze.py --config config.json --input merged_data.csv \
+    [--output_dir results] [--job-id MYRUN] \
+    [--efficiency-json eff.json] [--systematics-json syst.json] \
+    [--time-bin-mode fixed --time-bin-width 3600] [--dump-ts-json]
 ```
 
 ## Output
@@ -82,6 +85,11 @@ micro filter followed by the rate veto.  The default mode is `rate`.
 `time_bins_fallback` under the `plotting` section sets the number of
 histogram bins to use when the automatic Freedman&ndash;Diaconis rule
 fails, typically due to zero IQR.  The default is `1`.
+
+The CLI options `--time-bin-mode` and `--time-bin-width` override
+`plot_time_binning_mode` and `plot_time_bin_width_s` in the configuration
+to control the time-series histogram. Passing `--dump-ts-json` writes the
+histogram counts to a `*_ts.json` file alongside the plot.
 
 When the spectrum is binned in raw ADC channels (`"spectral_binning_mode": "adc"`),
 the bin edges are internally converted to energy using the calibration
@@ -197,6 +205,11 @@ with entries such as:
 
 `analyze.py` stores the calculated values and their BLUE combination in
 `summary.json` under the `efficiency` key.
+
+The option `--efficiency-json PATH` may be supplied on the command line to
+load the efficiency section from a separate file instead of embedding it
+directly in the main configuration.  Similarly `--systematics-json PATH`
+overrides the `systematics` section.
 
 
 ## Running Tests

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -205,3 +205,177 @@ def test_job_id_overrides_results_folder(tmp_path, monkeypatch):
     analyze.main()
 
     assert recorded["folder"].name == "JOB123"
+
+
+def test_efficiency_json_cli(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": True,
+            "window_Po214": [7.5, 8.0],
+            "hl_Po214": [1.0, 0.0],
+            "eff_Po214": [1.0, 0.0],
+            "flags": {},
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "c.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    data = tmp_path / "d.csv"
+    df.to_csv(data, index=False)
+
+    eff = {"spike": {"counts": 10, "activity_bq": 5, "live_time_s": 100}}
+    eff_path = tmp_path / "eff.json"
+    with open(eff_path, "w") as f:
+        json.dump(eff, f)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+
+    called = {}
+
+    def fake_calc(counts, act, live):
+        called["vals"] = (counts, act, live)
+        return 0.1
+
+    import efficiency
+    monkeypatch.setattr(efficiency, "calc_spike_efficiency", fake_calc)
+    monkeypatch.setattr(efficiency, "calc_assay_efficiency", lambda *a, **k: 0.1)
+    monkeypatch.setattr(efficiency, "calc_decay_efficiency", lambda *a, **k: 0.1)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data),
+        "--output_dir",
+        str(tmp_path),
+        "--efficiency-json",
+        str(eff_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert called.get("vals") == (10, 5, 100)
+
+
+def test_systematics_json_cli(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": True, "window_Po214": [7.4,7.9], "hl_Po214": [1.0,0.0], "eff_Po214": [1.0,0.0], "flags": {}},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "c2.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1800], "fchannel": [1]})
+    data = tmp_path / "d.csv"
+    df.to_csv(data, index=False)
+
+    sys_cfg = {"enable": True, "sigma_shifts": {}, "scan_keys": []}
+    sys_path = tmp_path / "sys.json"
+    with open(sys_path, "w") as f:
+        json.dump(sys_cfg, f)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {"E":0.0})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+
+    called = {}
+    def fake_scan(*a, **k):
+        called["scan"] = True
+        return ({}, 0.0)
+
+    monkeypatch.setattr(analyze, "scan_systematics", fake_scan)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data),
+        "--output_dir",
+        str(tmp_path),
+        "--systematics-json",
+        str(sys_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert called.get("scan") is True
+
+
+def test_time_bin_cli(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": True,
+            "window_Po214": [7.5, 8.0],
+            "hl_Po214": [1.0, 0.0],
+            "eff_Po214": [1.0, 0.0],
+            "flags": {},
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+
+    captured = {}
+
+    def fake_plot_ts(*args, **kwargs):
+        captured.update(kwargs)
+        Path(kwargs["out_png"]).touch()
+        return None
+
+    monkeypatch.setattr(analyze, "plot_time_series", fake_plot_ts)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+        "--time-bin-mode",
+        "fixed",
+        "--time-bin-width",
+        "5",
+        "--dump-ts-json",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert captured["config"]["plot_time_binning_mode"] == "fixed"
+    assert captured["config"]["plot_time_bin_width_s"] == 5.0
+    assert captured["config"]["dump_time_series_json"] is True


### PR DESCRIPTION
## Summary
- support additional command-line arguments in `analyze.py`
- allow overriding efficiency, systematics and time series settings
- document new options in `readme.txt`
- test CLI overrides for efficiency JSON, systematics JSON and time bin configuration

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684238249264832b8ec240656bac0819