### PR TITLE
Add visualization helpers and integrate

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -70,6 +70,7 @@ from io_utils import (
 from calibration import derive_calibration_constants, derive_calibration_constants_auto
 from fitting import fit_spectrum, fit_time_series
 from plot_utils import plot_spectrum, plot_time_series
+from visualize import cov_heatmap, efficiency_bar
 from systematics import scan_systematics
 from utils import find_adc_peaks
 
@@ -659,10 +660,11 @@ def main():
         efficiency_results["sources"] = sources
         if vals:
             try:
-                comb_val, comb_err, _ = blue_combine(vals, errs)
+                comb_val, comb_err, weights = blue_combine(vals, errs)
                 efficiency_results["combined"] = {
                     "value": float(comb_val),
                     "error": float(comb_err),
+                    "weights": weights.tolist(),
                 }
             except Exception as e:
                 print(f"WARNING: BLUE combination failed -> {e}")
@@ -731,6 +733,24 @@ def main():
             )
         except Exception as e:
             print(f"WARNING: Could not create time-series plot for {iso} -> {e}")
+
+    # Additional visualizations
+    if efficiency_results.get("sources"):
+        try:
+            errs_arr = np.array([s.get("error", 0.0) for s in efficiency_results["sources"].values()])
+            if errs_arr.size > 0:
+                cov = np.diag(errs_arr ** 2)
+                cov_heatmap(
+                    cov,
+                    os.path.join(out_dir, "eff_cov.png"),
+                    labels=list(efficiency_results["sources"].keys()),
+                )
+            efficiency_bar(
+                efficiency_results,
+                os.path.join(out_dir, "efficiency.png"),
+            )
+        except Exception as e:
+            print(f"WARNING: Could not create efficiency plots -> {e}")
 
     print(f"Analysis complete. Results written to -> {out_dir}")
 

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,8 @@ The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--j
 - `spectrum.png` – spectrum plot with fitted peaks.
 - `time_series_Po214.png` and `time_series_Po218.png` – decay time-series plots.
 - Optional `*_ts.json` files containing binned time series when enabled.
+- `efficiency.png` – bar chart of individual efficiencies and the BLUE result.
+- `eff_cov.png` – heatmap of the efficiency covariance matrix.
 
 The `time_fit` routine currently fits only Po‑214 and Po‑218.  Supporting
 Po‑210 would require adding its half‑life and detection efficiency to the

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -61,6 +61,8 @@ def test_plot_time_series_receives_merged_config(tmp_path, monkeypatch):
         return None
 
     monkeypatch.setattr(analyze, "plot_time_series", fake_plot_time_series)
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
 
     args = [
         "analyze.py",
@@ -125,6 +127,8 @@ def test_analysis_start_time_applied(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit_time_series)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
 
     args = [
         "analyze.py",
@@ -179,6 +183,8 @@ def test_job_id_overrides_results_folder(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
 
     recorded = {}
 
@@ -297,6 +303,8 @@ def test_systematics_json_cli(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {"E":0.0})
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
 
     called = {}
     def fake_scan(*a, **k):
@@ -358,6 +366,8 @@ def test_time_bin_cli(tmp_path, monkeypatch):
         return None
 
     monkeypatch.setattr(analyze, "plot_time_series", fake_plot_ts)
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
 
     args = [
         "analyze.py",

--- a/tests/test_cli_metadata.py
+++ b/tests/test_cli_metadata.py
@@ -35,6 +35,8 @@ def test_summary_includes_git_and_cli(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
 
     captured = {}
 

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from visualize import cov_heatmap, efficiency_bar
+
+
+def test_cov_heatmap(tmp_path):
+    cov = np.array([[1.0, 0.5], [0.5, 2.0]])
+    out = tmp_path / "cov.png"
+    cov_heatmap(cov, str(out), labels=["a", "b"])
+    assert out.exists()
+
+
+def test_efficiency_bar_annotations(tmp_path, monkeypatch):
+    eff = {
+        "sources": {
+            "spike": {"value": 0.8, "error": 0.1},
+            "assay": {"value": 0.7, "error": 0.05},
+        },
+        "combined": {"value": 0.75, "error": 0.05, "weights": [0.6, 0.4]},
+    }
+
+    texts = []
+    monkeypatch.setattr("visualize.plt.text", lambda *a, **k: texts.append(a[2]))
+    monkeypatch.setattr("visualize.plt.savefig", lambda path, **k: Path(path).touch())
+
+    out = tmp_path / "eff.png"
+    efficiency_bar(eff, str(out))
+    assert out.exists()
+    assert any("0.6" in t for t in texts) and any("0.4" in t for t in texts)

--- a/visualize.py
+++ b/visualize.py
@@ -1,0 +1,62 @@
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+
+__all__ = ["cov_heatmap", "efficiency_bar"]
+
+
+def cov_heatmap(cov_matrix, out_png, labels=None):
+    """Plot a correlation heatmap from a covariance matrix."""
+    cov = np.asarray(cov_matrix, dtype=float)
+    if cov.ndim != 2 or cov.shape[0] != cov.shape[1]:
+        raise ValueError("cov_matrix must be square")
+    n = cov.shape[0]
+    std = np.sqrt(np.diag(cov))
+    with np.errstate(divide="ignore", invalid="ignore"):
+        corr = cov / np.outer(std, std)
+    corr = np.nan_to_num(corr)
+    if labels is None:
+        labels = [str(i) for i in range(n)]
+    plt.figure(figsize=(4 + 0.5 * n, 3 + 0.5 * n))
+    im = plt.imshow(corr, vmin=-1, vmax=1, cmap="viridis")
+    plt.colorbar(im, label="Correlation")
+    plt.xticks(range(n), labels, rotation=45, ha="right")
+    plt.yticks(range(n), labels)
+    for i in range(n):
+        for j in range(n):
+            plt.text(j, i, f"{corr[i,j]:.2f}", ha="center", va="center", color="white" if abs(corr[i,j])>0.5 else "black", fontsize=8)
+    plt.tight_layout()
+    os.makedirs(os.path.dirname(out_png), exist_ok=True)
+    plt.savefig(out_png, dpi=300)
+    plt.close()
+    return corr
+
+
+def efficiency_bar(eff_dict, out_png):
+    """Bar chart of efficiency sources annotated with BLUE weights."""
+    sources = eff_dict.get("sources", {})
+    names = list(sources.keys())
+    values = [sources[n].get("value", 0.0) for n in names]
+    errors = [sources[n].get("error", 0.0) for n in names]
+    weights = eff_dict.get("combined", {}).get("weights")
+
+    if "combined" in eff_dict:
+        names.append("BLUE")
+        values.append(eff_dict["combined"].get("value", 0.0))
+        errors.append(eff_dict["combined"].get("error", 0.0))
+
+    x = np.arange(len(names))
+    plt.figure(figsize=(6, 4))
+    plt.bar(x, values, yerr=errors, capsize=4, color="tab:blue", alpha=0.7)
+    plt.xticks(x, names, rotation=45, ha="right")
+    plt.ylabel("Efficiency")
+    plt.title("Efficiency Estimates")
+
+    if weights is not None:
+        for i, w in enumerate(weights):
+            plt.text(i, values[i] + errors[i], f"{w:.2f}", ha="center", va="bottom", fontsize=8)
+    plt.tight_layout()
+    os.makedirs(os.path.dirname(out_png), exist_ok=True)
+    plt.savefig(out_png, dpi=300)
+    plt.close()
+    return None


### PR DESCRIPTION
## Summary
- add `cov_heatmap` and `efficiency_bar` utilities
- store BLUE weights and plot efficiency/covariance in `analyze`
- update tests to handle new plotting calls
- document new output images

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68423db42ab0832ba7a60dc5a8ae2162