### PR TITLE
Add random seed CLI option

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -161,6 +161,11 @@ def parse_args():
         action="store_true",
         help="Write *_ts.json files containing binned time-series data",
     )
+    p.add_argument(
+        "--seed",
+        type=int,
+        help="Override random seed used by analysis algorithms",
+    )
     return p.parse_args()
 
 
@@ -203,6 +208,9 @@ def main():
             print(f"ERROR: Could not load systematics JSON '{args.systematics_json}': {e}")
             sys.exit(1)
 
+    if args.seed is not None:
+        cfg.setdefault("pipeline", {})["random_seed"] = int(args.seed)
+
 
     if args.time_bin_mode:
         cfg.setdefault("plotting", {})["plot_time_binning_mode"] = args.time_bin_mode
@@ -233,11 +241,13 @@ def main():
     )
 
     seed = cfg.get("pipeline", {}).get("random_seed")
+    seed_used = None
     if seed is not None:
         try:
             seed_int = int(seed)
             np.random.seed(seed_int)
             random.seed(seed_int)
+            seed_used = seed_int
         except Exception:
             logging.warning(f"Invalid random_seed '{seed}' ignored")
 
@@ -805,6 +815,7 @@ def main():
         "burst_filter": {"removed_events": int(n_removed_burst)},
         "adc_drift_rate": drift_rate,
         "efficiency": efficiency_results,
+        "random_seed": seed_used,
         "git_commit": commit,
         "cli_sha256": cli_sha256,
         "cli_args": cli_args,

--- a/readme.txt
+++ b/readme.txt
@@ -29,7 +29,7 @@ python analyze.py --config config.json --input merged_data.csv \
     [--output_dir results] [--job-id MYRUN] \
     [--efficiency-json eff.json] [--systematics-json syst.json] \
     [--spike-count N --spike-count-err S] [--slope RATE] \
-    [--settle-s SEC] [--debug] \
+    [--settle-s SEC] [--debug] [--seed SEED] \
     [--time-bin-mode fixed --time-bin-width 3600] [--dump-ts-json]
 ```
 
@@ -98,8 +98,8 @@ histogram counts to a `*_ts.json` file alongside the plot.
 Additional convenience flags include `--spike-count` (with optional
 `--spike-count-err`) to override spike efficiency inputs, `--slope` to
 apply a linear ADC drift correction, `--settle-s` to skip the initial
-settling period in the decay fit and `--debug` to increase log
-verbosity.
+settling period in the decay fit, `--seed` to set the random seed used
+by the analysis and `--debug` to increase log verbosity.
 
 When the spectrum is binned in raw ADC channels (`"spectral_binning_mode": "adc"`),
 the bin edges are internally converted to energy using the calibration

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -562,3 +562,55 @@ def test_settle_s_cli(tmp_path, monkeypatch):
 
     assert captured["times"] == [10.0]
 
+
+def test_seed_cli_sets_random_seed(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+
+    captured = {}
+    def fake_write(out_dir, summary, timestamp=None):
+        captured["summary"] = summary
+        d = Path(out_dir) / "x"
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+        "--seed",
+        "123",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert captured["summary"]["random_seed"] == 123
+


### PR DESCRIPTION
## Summary
- support `--seed` option in `analyze.py`
- pass the CLI seed through to the config before RNG init
- record the actual random seed in `summary.json`
- document the new option in the usage section
- test that `--seed` affects the summary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842620ab39c832b84f4e2dd3dd08075