### PR TITLE
Fix radon activity handling of missing errors

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -65,6 +65,10 @@ def compute_radon_activity(
         sigma = math.sqrt(1.0 / (w1 + w2))
         return A, sigma
 
+    if len(values) == 2 and any(w is not None for w in weights):
+        idx = 0 if weights[0] is not None else 1
+        return values[idx], math.sqrt(1.0 / weights[idx])
+
     # Only one valid value or missing errors
     A = values[0]
     sigma = math.sqrt(1.0 / weights[0]) if weights[0] is not None else 0.0

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -16,6 +16,18 @@ def test_compute_radon_activity_weighted():
     assert s == pytest.approx(err)
 
 
+def test_compute_radon_activity_only_214_error():
+    a, s = compute_radon_activity(10.0, None, 1.0, 12.0, 2.0, 1.0)
+    assert a == pytest.approx(12.0)
+    assert s == pytest.approx(2.0)
+
+
+def test_compute_radon_activity_only_218_error():
+    a, s = compute_radon_activity(10.0, 1.0, 1.0, 12.0, None, 1.0)
+    assert a == pytest.approx(10.0)
+    assert s == pytest.approx(1.0)
+
+
 def test_compute_total_radon():
     conc, dconc, tot, dtot = compute_total_radon(5.0, 0.5, 10.0, 20.0)
     assert conc == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- use available uncertainty when combining Po-218 and Po-214 activity
- add regression tests for single uncertainty cases

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68426e20cd58832b8bc41376266992ee