### PR TITLE
Support variable ambient concentration in equivalent air plot

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -167,6 +167,10 @@ def parse_args():
         help="Write *_ts.json files containing binned time-series data",
     )
     p.add_argument(
+        "--ambient-file",
+        help="Path to two-column file with time and ambient concentration",
+    )
+    p.add_argument(
         "--ambient-concentration",
         type=float,
         help="Ambient radon concentration in Bq per liter for equivalent air plot",
@@ -963,7 +967,26 @@ def main():
         )
 
         ambient = cfg.get("analysis", {}).get("ambient_concentration")
-        if ambient:
+        ambient_interp = None
+        if args.ambient_file:
+            try:
+                dat = np.loadtxt(args.ambient_file, usecols=(0, 1))
+                ambient_interp = np.interp(times, dat[:, 0], dat[:, 1])
+            except Exception as e:
+                print(f"WARNING: Could not read ambient file '{args.ambient_file}': {e}")
+
+        if ambient_interp is not None:
+            vol_arr = activity_arr / ambient_interp
+            vol_err = err_arr / ambient_interp
+            plot_equivalent_air(
+                times,
+                vol_arr,
+                vol_err,
+                None,
+                os.path.join(out_dir, "equivalent_air.png"),
+                config=cfg.get("plotting", {}),
+            )
+        elif ambient:
             vol_arr = activity_arr / float(ambient)
             vol_err = err_arr / float(ambient)
             plot_equivalent_air(

--- a/plot_utils.py
+++ b/plot_utils.py
@@ -360,7 +360,14 @@ def plot_radon_activity(times, activity, errors, out_png, config=None):
 
 
 def plot_equivalent_air(times, volumes, errors, conc, out_png, config=None):
-    """Plot equivalent air volume versus time."""
+    """Plot equivalent air volume versus time.
+
+    Parameters
+    ----------
+    conc : float or str or None
+        Ambient concentration label to include in the plot title. When ``None``
+        the concentration is omitted from the title.
+    """
     times = np.asarray(times, dtype=float)
     volumes = np.asarray(volumes, dtype=float)
     errors = np.asarray(errors, dtype=float)
@@ -369,7 +376,11 @@ def plot_equivalent_air(times, volumes, errors, conc, out_png, config=None):
     plt.errorbar(times, volumes, yerr=errors, fmt="o-", color="tab:green")
     plt.xlabel("Time (s)")
     plt.ylabel("Equivalent Air Volume")
-    plt.title(f"Equivalent Air Volume vs. Time (ambient {conc} Bq/L)")
+    if conc is None:
+        title = "Equivalent Air Volume vs. Time"
+    else:
+        title = f"Equivalent Air Volume vs. Time (ambient {conc} Bq/L)"
+    plt.title(title)
     plt.tight_layout()
     os.makedirs(os.path.dirname(out_png), exist_ok=True)
 

--- a/readme.txt
+++ b/readme.txt
@@ -30,7 +30,7 @@ python analyze.py --config config.json --input merged_data.csv \
     [--efficiency-json eff.json] [--systematics-json syst.json] \
     [--spike-count N --spike-count-err S] [--slope RATE] \
     [--settle-s SEC] [--debug] [--seed SEED] \
-    [--ambient-concentration 0.1] \
+    [--ambient-file amb.txt] [--ambient-concentration 0.1] \
     [--time-bin-mode fixed --time-bin-width 3600] [--dump-ts-json]
 ```
 
@@ -46,7 +46,8 @@ The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--j
 - `efficiency.png` – bar chart of individual efficiencies and the BLUE result.
 - `eff_cov.png` – heatmap of the efficiency covariance matrix.
 - `radon_activity.png` – extrapolated radon activity over time.
-- `equivalent_air.png` – equivalent air volume plot when `--ambient-concentration` is given.
+ - `equivalent_air.png` – equivalent air volume plot when `--ambient-file` or
+   `--ambient-concentration` is provided.
 
 The `time_fit` routine currently fits only Po‑214 and Po‑218.  Supporting
 Po‑210 would require adding its half‑life and detection efficiency to the
@@ -259,9 +260,10 @@ converted to an instantaneous radon activity.  The result is written to
 `summary.json` under `radon_results` together with the corresponding
 concentration (per liter) and the total amount of radon in the combined
 monitor + sample volume.  The file `radon_activity.png` visualises this
-activity versus time.  When the option `--ambient-concentration` is
-supplied an additional plot `equivalent_air.png` shows the volume of
-ambient air containing the same activity.
+activity versus time.  When either `--ambient-file` or
+`--ambient-concentration` is supplied an additional plot
+`equivalent_air.png` shows the volume of ambient air containing the same
+activity.
 
 ## Efficiency Calculations
 

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -720,3 +720,71 @@ def test_ambient_concentration_from_config(tmp_path, monkeypatch):
 
     assert captured["summary"]["analysis"]["ambient_concentration"] == 0.7
 
+
+def test_ambient_file_interpolation(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1, 2],
+        "fBits": [0, 0],
+        "timestamp": [0, 2],
+        "adc": [1, 1],
+        "fchannel": [1, 1],
+    })
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    amb = tmp_path / "amb.txt"
+    np.savetxt(amb, [[0.0, 1.0], [2.0, 2.0]])
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+
+    captured = {}
+
+    def fake_plot_equivalent_air(t, v, e, conc, out_png, config=None):
+        captured["conc"] = conc
+        captured["times"] = list(t)
+        Path(out_png).touch()
+
+    monkeypatch.setattr(analyze, "plot_equivalent_air", fake_plot_equivalent_air)
+
+    def fake_write(out_dir, summary, timestamp=None):
+        d = Path(out_dir) / "x"
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+        "--ambient-file",
+        str(amb),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert captured.get("conc") is None
+

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -217,3 +217,16 @@ def test_plot_equivalent_air_output(tmp_path):
 
     assert out_png.exists()
 
+
+def test_plot_equivalent_air_no_conc(tmp_path):
+    times = [0.0, 1.0, 2.0]
+    volumes = [1.0, 2.0, 3.0]
+    errors = [0.1, 0.2, 0.3]
+    out_png = tmp_path / "air_none.png"
+
+    from plot_utils import plot_equivalent_air
+
+    plot_equivalent_air(times, volumes, errors, None, str(out_png))
+
+    assert out_png.exists()
+


### PR DESCRIPTION
## Summary
- allow providing an ambient concentration file via `--ambient-file`
- interpolate ambient concentration for equivalent air plot
- accept optional ambient label in plotting utility
- document new option in `readme.txt`
- test equivalent air plotting with no concentration
- test use of `--ambient-file`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842718ebab8832b957ce40a26a109c5