### PR TITLE
Add array-based plot utils tests

### DIFF
--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -217,3 +217,29 @@ def test_plot_equivalent_air_output(tmp_path):
 
     assert out_png.exists()
 
+
+def test_plot_radon_activity_array(tmp_path):
+    times = np.array([0.0, 0.5, 1.0])
+    activity = np.array([0.5, 1.0, 1.5])
+    errors = np.array([0.05, 0.1, 0.15])
+    out_png = tmp_path / "radon_arr.png"
+
+    from plot_utils import plot_radon_activity
+
+    plot_radon_activity(times, activity, errors, str(out_png))
+
+    assert out_png.exists()
+
+
+def test_plot_equivalent_air_array(tmp_path):
+    times = np.array([0.0, 0.5, 1.0])
+    volumes = np.array([0.05, 0.1, 0.15])
+    errors = np.array([0.005, 0.01, 0.015])
+    out_png = tmp_path / "air_arr.png"
+
+    from plot_utils import plot_equivalent_air
+
+    plot_equivalent_air(times, volumes, errors, 5.0, str(out_png))
+
+    assert out_png.exists()
+


### PR DESCRIPTION
## Summary
- add tests using numpy arrays for `plot_radon_activity` and `plot_equivalent_air`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842719015c8832b85db0005333d32b4