### PR TITLE
Compute and plot radon activity curves

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -951,9 +951,50 @@ def main():
 
     # Radon activity and equivalent air plots
     try:
-        times = np.linspace(t0_global, events["timestamp"].max(), 20)
-        activity_arr = np.full_like(times, radon_results["radon_activity_Bq"]["value"], dtype=float)
-        err_arr = np.full_like(times, radon_results["radon_activity_Bq"]["uncertainty"], dtype=float)
+        from radon_activity import radon_activity_curve
+
+        times = np.linspace(t0_global, events["timestamp"].max(), 100)
+        t_rel = times - t0_global
+
+        A214 = dA214 = None
+        if "Po214" in time_fit_results:
+            fit = time_fit_results["Po214"]
+            E = fit.get("E_corrected", fit.get("E_Po214"))
+            dE = fit.get("dE_Po214", 0.0)
+            N0 = fit.get("N0_Po214", 0.0)
+            dN0 = fit.get("dN0_Po214", 0.0)
+            hl = cfg.get("time_fit", {}).get("hl_Po214", [328320])[0]
+            A214, dA214 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl)
+
+        A218 = dA218 = None
+        if "Po218" in time_fit_results:
+            fit = time_fit_results["Po218"]
+            E = fit.get("E_corrected", fit.get("E_Po218"))
+            dE = fit.get("dE_Po218", 0.0)
+            N0 = fit.get("N0_Po218", 0.0)
+            dN0 = fit.get("dN0_Po218", 0.0)
+            hl = cfg.get("time_fit", {}).get("hl_Po218", [328320])[0]
+            A218, dA218 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl)
+
+        activity_arr = np.zeros_like(times, dtype=float)
+        err_arr = np.zeros_like(times, dtype=float)
+        for i in range(times.size):
+            r214 = err214_i = None
+            if A214 is not None:
+                r214 = A214[i] * eff_Po214
+                err214_i = dA214[i] * eff_Po214
+            r218 = err218_i = None
+            if A218 is not None:
+                r218 = A218[i] * eff_Po218
+                err218_i = dA218[i] * eff_Po218
+            A, s = compute_radon_activity(r218, err218_i, eff_Po218, r214, err214_i, eff_Po214)
+            activity_arr[i] = A
+            err_arr[i] = s
+
+        if np.all(activity_arr == 0):
+            activity_arr.fill(radon_results["radon_activity_Bq"]["value"])
+            err_arr.fill(radon_results["radon_activity_Bq"]["uncertainty"])
+
         plot_radon_activity(
             times,
             activity_arr,

--- a/radon_activity.py
+++ b/radon_activity.py
@@ -7,6 +7,7 @@ from typing import Optional, Tuple
 __all__ = [
     "compute_radon_activity",
     "compute_total_radon",
+    "radon_activity_curve",
 ]
 
 
@@ -102,3 +103,49 @@ def compute_total_radon(
     total_bq = conc * sample_volume
     sigma_total = sigma_conc * sample_volume
     return conc, sigma_conc, total_bq, sigma_total
+
+
+def radon_activity_curve(
+    times,
+    E: float,
+    dE: float,
+    N0: float,
+    dN0: float,
+    half_life_s: float,
+) -> Tuple["np.ndarray", "np.ndarray"]:
+    """Activity over time from fitted decay parameters.
+
+    Parameters
+    ----------
+    times : array-like
+        Relative times in seconds.
+    E : float
+        Steady-state decay rate in Bq.
+    dE : float
+        Uncertainty on ``E``.
+    N0 : float
+        Initial activity parameter.
+    dN0 : float
+        Uncertainty on ``N0``.
+    half_life_s : float
+        Half-life used for the decay model.
+
+    Returns
+    -------
+    numpy.ndarray
+        Activity at each time in Bq.
+    numpy.ndarray
+        Propagated 1-sigma uncertainty at each time.
+    """
+    import numpy as np
+
+    t = np.asarray(times, dtype=float)
+    lam = math.log(2.0) / float(half_life_s)
+    exp_term = np.exp(-lam * t)
+    activity = E * (1.0 - exp_term) + lam * N0 * exp_term
+
+    dA_dE = 1.0 - exp_term
+    dA_dN0 = lam * exp_term
+    variance = (dA_dE * dE) ** 2 + (dA_dN0 * dN0) ** 2
+    sigma = np.sqrt(variance)
+    return activity, sigma

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -3,7 +3,13 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from radon_activity import compute_radon_activity, compute_total_radon
+from radon_activity import (
+    compute_radon_activity,
+    compute_total_radon,
+    radon_activity_curve,
+)
+import math
+import numpy as np
 
 
 def test_compute_radon_activity_weighted():
@@ -34,3 +40,20 @@ def test_compute_total_radon():
     assert dconc == pytest.approx(0.05)
     assert tot == pytest.approx(10.0)
     assert dtot == pytest.approx(1.0)
+
+
+def test_radon_activity_curve():
+    times = [0.0, 1.0]
+    E = 5.0
+    dE = 0.5
+    N0 = 2.0
+    dN0 = 0.2
+    hl = 10.0
+    act, err = radon_activity_curve(times, E, dE, N0, dN0, hl)
+    lam = math.log(2.0) / hl
+    import numpy as np
+    exp_term = np.exp(-lam * np.asarray(times))
+    expected = E * (1 - exp_term) + lam * N0 * exp_term
+    var = ((1 - exp_term) * dE) ** 2 + ((lam * exp_term) * dN0) ** 2
+    assert np.allclose(act, expected)
+    assert np.allclose(err, np.sqrt(var))


### PR DESCRIPTION
## Summary
- add `radon_activity_curve` to generate decay curves with errors
- plot radon activity using decay model instead of constant lines
- test the new helper function

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842718dd80c832b95a6d383fad6357e