### PR TITLE
Remove baseline events before fits

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -411,6 +411,9 @@ def main():
 
         if noise_level is not None:
             baseline_info["noise_level"] = float(noise_level)
+
+        # Remove baseline events from the main dataset before any fits
+        events = events[~mask_base].reset_index(drop=True)
     baseline_counts = {}
     # ────────────────────────────────────────────────────────────
     # 5. Spectral fit (optional)


### PR DESCRIPTION
## Summary
- drop baseline events from main dataset after they are copied
- record fit times during baseline tests
- assert baseline interval doesn't influence time series fit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842718bf094832b963cda1339e52a85