### PR TITLE
Fix handling of mixed radon uncertainties

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -65,7 +65,7 @@ def compute_radon_activity(
         sigma = math.sqrt(1.0 / (w1 + w2))
         return A, sigma
 
-    if len(values) == 2 and any(w is not None for w in weights):
+    if len(values) == 2 and sum(w is not None for w in weights) == 1:
         idx = 0 if weights[0] is not None else 1
         return values[idx], math.sqrt(1.0 / weights[idx])
 

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -22,10 +22,22 @@ def test_compute_radon_activity_only_214_error():
     assert s == pytest.approx(2.0)
 
 
+def test_compute_radon_activity_mixed_efficiency():
+    a, s = compute_radon_activity(10.0, 1.0, 0.0, 12.0, 2.0, 1.0)
+    assert a == pytest.approx(12.0)
+    assert s == pytest.approx(2.0)
+
+
 def test_compute_radon_activity_only_218_error():
     a, s = compute_radon_activity(10.0, 1.0, 1.0, 12.0, None, 1.0)
     assert a == pytest.approx(10.0)
     assert s == pytest.approx(1.0)
+
+
+def test_compute_radon_activity_mixed_error_sign():
+    a, s = compute_radon_activity(10.0, -1.0, 1.0, 12.0, 2.0, 1.0)
+    assert a == pytest.approx(12.0)
+    assert s == pytest.approx(2.0)
 
 
 def test_compute_total_radon():


### PR DESCRIPTION
## Summary
- when only one isotope has an uncertainty use that rate
- add tests for mixed uncertainty scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842718ac77c832b9357b727390ac036