### PR TITLE
Add burst filter mode config option

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -110,9 +110,8 @@ def parse_args():
     )
     p.add_argument(
         "--burst-mode",
-        default="rate",
         choices=["none", "micro", "rate", "both"],
-        help="Burst filtering mode to pass to apply_burst_filter",
+        help="Burst filtering mode to pass to apply_burst_filter (overrides config)",
     )
     p.add_argument(
         "--job-id",
@@ -294,7 +293,12 @@ def main():
     events["timestamp"] = events["timestamp"].astype(float)
 
     # Optional burst filter to remove high-rate clusters
-    events, n_removed_burst = apply_burst_filter(events, cfg, mode=args.burst_mode)
+    burst_mode = (
+        args.burst_mode
+        if args.burst_mode is not None
+        else cfg.get("burst_filter", {}).get("burst_mode", "rate")
+    )
+    events, n_removed_burst = apply_burst_filter(events, cfg, mode=burst_mode)
 
     # Global t₀ reference
     t0_cfg = cfg.get("analysis", {}).get("analysis_start_time")

--- a/config.json
+++ b/config.json
@@ -13,6 +13,7 @@
         "sample_volume_l": 0.0
     },
     "burst_filter": {
+        "burst_mode": "rate",
         "burst_window_size_s": 60,
         "rolling_median_window": 5,
         "burst_multiplier": 5,

--- a/readme.txt
+++ b/readme.txt
@@ -96,12 +96,13 @@ Example snippet:
 ```
 
 `burst_filter` controls removal of short high-rate clusters.  The
-command-line option `--burst-mode` chooses the strategy:
-`none` disables the filter, `micro` applies a short sliding-window veto
-defined by `micro_window_size_s` and `micro_count_threshold`, `rate`
-uses the rolling-median threshold (`burst_window_size_s`,
-`rolling_median_window`, `burst_multiplier`) and `both` applies the
-micro filter followed by the rate veto.  The default mode is `rate`.
+`burst_mode` key selects the default strategy which can be overridden by
+the command-line option `--burst-mode`.  `none` disables the filter,
+`micro` applies a short sliding-window veto defined by
+`micro_window_size_s` and `micro_count_threshold`, `rate` uses the
+rolling-median threshold (`burst_window_size_s`, `rolling_median_window`,
+`burst_multiplier`) and `both` applies the micro filter followed by the
+rate veto.
 
 `time_bins_fallback` under the `plotting` section sets the number of
 histogram bins to use when the automatic Freedman&ndash;Diaconis rule

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -788,3 +788,51 @@ def test_ambient_file_interpolation(tmp_path, monkeypatch):
 
     assert captured.get("conc") is None
 
+
+def test_burst_mode_from_config(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+        "burst_filter": {"burst_mode": "none"},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    recorded = {}
+
+    def fake_burst(df, cfg, mode="rate"):
+        recorded["mode"] = mode
+        return df, 0
+
+    monkeypatch.setattr(analyze, "apply_burst_filter", fake_burst)
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert recorded.get("mode") == "none"
+


### PR DESCRIPTION
## Summary
- let `--burst-mode` default to `burst_filter.burst_mode`
- document the new config option
- test that the config value is used when CLI option isn't passed

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842768416e8832b92aed9ec097a268a