### PR TITLE
Add plot utils tests for radon activity and air volume

### DIFF
--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -255,3 +255,29 @@ def test_plot_equivalent_air_no_conc(tmp_path):
 
     assert out_png.exists()
 
+
+def test_plot_radon_activity_small_array(tmp_path):
+    times = np.array([0.0, 0.2, 0.4])
+    activity = np.array([1.0, 1.1, 1.2])
+    errors = np.array([0.1, 0.1, 0.1])
+    out_png = tmp_path / "radon_small.png"
+
+    from plot_utils import plot_radon_activity
+
+    plot_radon_activity(times, activity, errors, str(out_png))
+
+    assert out_png.exists()
+
+
+def test_plot_equivalent_air_small_array(tmp_path):
+    times = np.array([0.0, 0.5, 1.0])
+    volumes = np.array([0.1, 0.15, 0.2])
+    errors = np.array([0.01, 0.01, 0.02])
+    out_png = tmp_path / "air_small.png"
+
+    from plot_utils import plot_equivalent_air
+
+    plot_equivalent_air(times, volumes, errors, 2.5, str(out_png))
+
+    assert out_png.exists()
+


### PR DESCRIPTION
## Summary
- add coverage for `plot_radon_activity` and `plot_equivalent_air` with small arrays

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684276865c58832b9d583fd9c9546a28