### PR TITLE
Add ambient concentration docs and tests

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,8 +4,8 @@
         "random_seed": null
     },
     "analysis": {
-        "analysis_start_time": null,
-        "ambient_concentration": null
+        "ambient_concentration": null,
+        "analysis_start_time": null
     },
     "baseline": {
         "range": null,

--- a/readme.txt
+++ b/readme.txt
@@ -95,6 +95,16 @@ Example snippet:
 }
 ```
 
+When present the value is also written to `summary.json` under the
+`analysis` section:
+
+```json
+"analysis": {
+    "analysis_start_time": "2020-01-01T00:00:00Z",
+    "ambient_concentration": 0.02
+}
+```
+
 `burst_filter` controls removal of short high-rate clusters.  The
 command-line option `--burst-mode` chooses the strategy:
 `none` disables the filter, `micro` applies a short sliding-window veto

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -642,6 +642,11 @@ def test_ambient_concentration_recorded(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
 
     captured = {}
+    def fake_plot_equivalent_air(t, v, e, conc, out_png, config=None):
+        captured["conc"] = conc
+        Path(out_png).touch()
+
+    monkeypatch.setattr(analyze, "plot_equivalent_air", fake_plot_equivalent_air)
 
     def fake_write(out_dir, summary, timestamp=None):
         captured["summary"] = summary
@@ -667,6 +672,7 @@ def test_ambient_concentration_recorded(tmp_path, monkeypatch):
     analyze.main()
 
     assert captured["summary"]["analysis"]["ambient_concentration"] == 1.2
+    assert captured["conc"] == 1.2
 
 
 def test_ambient_concentration_from_config(tmp_path, monkeypatch):
@@ -696,6 +702,11 @@ def test_ambient_concentration_from_config(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
 
     captured = {}
+    def fake_plot_equivalent_air(t, v, e, conc, out_png, config=None):
+        captured["conc"] = conc
+        Path(out_png).touch()
+
+    monkeypatch.setattr(analyze, "plot_equivalent_air", fake_plot_equivalent_air)
 
     def fake_write(out_dir, summary, timestamp=None):
         captured["summary"] = summary
@@ -719,6 +730,7 @@ def test_ambient_concentration_from_config(tmp_path, monkeypatch):
     analyze.main()
 
     assert captured["summary"]["analysis"]["ambient_concentration"] == 0.7
+    assert captured["conc"] == 0.7
 
 
 def test_ambient_file_interpolation(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- document ambient concentration handling in README
- verify CLI/config ambient concentration is passed to equivalent air plot
- reorder the analysis section of `config.json` to explicitly include ambient key

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842768703e0832bb00fc621128d0771