### PR TITLE
Remove baseline events from dataset prior to fits

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -387,6 +387,7 @@ def main():
             events["timestamp"] < t_end_base
         )
         base_events = events[mask_base].copy()
+        events = events[~mask_base].reset_index(drop=True)
         baseline_live_time = float(t_end_base - t_start_base)
         baseline_info = {
             "start": t_start_base,
@@ -415,9 +416,6 @@ def main():
 
         if noise_level is not None:
             baseline_info["noise_level"] = float(noise_level)
-
-        # Remove baseline events from the main dataset before any fits
-        events = events[~mask_base].reset_index(drop=True)
     baseline_counts = {}
     # ────────────────────────────────────────────────────────────
     # 5. Spectral fit (optional)

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -75,6 +75,7 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
     summary = captured["summary"]
     conc = summary["baseline"]["concentration_Bq_m3"]["Po214"]
     assert conc == pytest.approx(0.330578, rel=1e-3)
+    assert summary["baseline"]["n_events"] == 2
     assert summary["baseline"]["scale_factor"] == pytest.approx(0.0)
     assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(1.0)
     assert summary["baseline"].get("noise_level") == 5.0


### PR DESCRIPTION
## Summary
- drop baseline events from the main dataframe immediately after extraction
- check recorded baseline event count in baseline tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842768a46fc832bb24ef68d12eed7b1