### PR TITLE
Add analysis_end_time and spike_end_time options

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,6 +5,8 @@
     },
     "analysis": {
         "analysis_start_time": null,
+        "analysis_end_time": null,
+        "spike_end_time": null,
         "ambient_concentration": null
     },
     "baseline": {

--- a/readme.txt
+++ b/readme.txt
@@ -29,6 +29,7 @@ python analyze.py --config config.json --input merged_data.csv \
     [--output_dir results] [--job-id MYRUN] \
     [--efficiency-json eff.json] [--systematics-json syst.json] \
     [--spike-count N --spike-count-err S] [--slope RATE] \
+    [--analysis-end-time ISO --spike-end-time ISO] \
     [--settle-s SEC] [--debug] [--seed SEED] \
     [--ambient-file amb.txt] [--ambient-concentration 0.1] \
     [--time-bin-mode fixed --time-bin-width 3600] [--dump-ts-json]
@@ -82,6 +83,11 @@ time origin for decay fitting and time-series plots.  Provide an
 ISO‑8601 string such as `"2020-01-01T00:00:00Z"`.  When omitted the first
 event timestamp is used.
 
+`analysis_end_time` may be specified to stop processing after the given
+timestamp while `spike_end_time` discards all events before its value.
+Both accept ISO‑8601 strings and can also be set with the corresponding
+CLI options.
+
 `ambient_concentration` may also be specified here to record the ambient
 radon concentration in Bq/m³ used for the equivalent air plot.  The
 command-line option `--ambient-concentration` overrides this value.
@@ -91,6 +97,8 @@ Example snippet:
 ```json
 "analysis": {
     "analysis_start_time": "2020-01-01T00:00:00Z",
+    "analysis_end_time": "2020-01-02T00:00:00Z",
+    "spike_end_time": "2020-01-01T01:00:00Z",
     "ambient_concentration": 0.02
 }
 ```
@@ -114,7 +122,8 @@ histogram counts to a `*_ts.json` file alongside the plot.
 
 Additional convenience flags include `--spike-count` (with optional
 `--spike-count-err`) to override spike efficiency inputs, `--slope` to
-apply a linear ADC drift correction, `--settle-s` to skip the initial
+apply a linear ADC drift correction, `--analysis-end-time` and
+`--spike-end-time` to clip the dataset, `--settle-s` to skip the initial
 settling period in the decay fit, `--seed` to set the random seed used
 by the analysis and `--debug` to increase log verbosity.
 

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -563,6 +563,124 @@ def test_settle_s_cli(tmp_path, monkeypatch):
     assert captured["times"] == [10.0]
 
 
+def test_analysis_end_time_cli(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": True,
+            "window_Po214": [0.0, 20.0],
+            "hl_Po214": [1.0, 0.0],
+            "eff_Po214": [1.0, 0.0],
+            "flags": {},
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1, 2],
+        "fBits": [0, 0],
+        "timestamp": [0.0, 10.0],
+        "adc": [8.0, 8.0],
+        "fchannel": [1, 1],
+    })
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+
+    captured = {}
+
+    def fake_fit(ts_dict, t_start, t_end, config):
+        captured["times"] = ts_dict["Po214"].tolist()
+        return {}
+
+    monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+        "--analysis-end-time",
+        "5",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert captured["times"] == [0.0]
+
+
+def test_spike_end_time_cli(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": True,
+            "window_Po214": [0.0, 20.0],
+            "hl_Po214": [1.0, 0.0],
+            "eff_Po214": [1.0, 0.0],
+            "flags": {},
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1, 2],
+        "fBits": [0, 0],
+        "timestamp": [0.0, 10.0],
+        "adc": [8.0, 8.0],
+        "fchannel": [1, 1],
+    })
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+
+    captured = {}
+
+    def fake_fit(ts_dict, t_start, t_end, config):
+        captured["times"] = ts_dict["Po214"].tolist()
+        return {}
+
+    monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+        "--spike-end-time",
+        "5",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert captured["times"] == [10.0]
+
+
 def test_seed_cli_sets_random_seed(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},


### PR DESCRIPTION
## Summary
- allow specifying `analysis_end_time` and `spike_end_time` via config or CLI
- trim events based on these limits before fitting
- update plots and summary to respect end times
- document new options and show examples
- test new CLI flags

## Testing
- `./scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427684c660832b899c2373598cb87b