### PR TITLE
Support end time filters

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -463,9 +463,9 @@ def main():
         if noise_level is not None:
             baseline_info["noise_level"] = float(noise_level)
 
-
-        # Remove baseline events from the main dataset before any fits
-        events = events[~mask_base].reset_index(drop=True)
+        # Baseline events were already removed from ``events`` above
+        # when ``mask_base`` was first applied.  Avoid reusing the
+        # boolean mask here to prevent a misaligned index warning.
 
     # Apply optional spike/analysis end time cuts after baseline extraction
     if t_spike_end is not None:


### PR DESCRIPTION
## Summary
- filter baseline events once
- include analysis end-time handling in `analyze.py`
- document `analysis_end_time` and `spike_end_time` options

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842794a4db8832bb389662d96f1b13d