### PR TITLE
Handle mixed radon uncertainties

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -433,7 +433,6 @@ def main():
             events["timestamp"] < t_end_base
         )
         base_events = events[mask_base].copy()
-        events = events[~mask_base].reset_index(drop=True)
         baseline_live_time = float(t_end_base - t_start_base)
         baseline_info = {
             "start": t_start_base,

--- a/radon_activity.py
+++ b/radon_activity.py
@@ -68,8 +68,9 @@ def compute_radon_activity(
 
     if len(values) == 2 and sum(w is not None for w in weights) == 1:
         # Identify the isotope with a valid uncertainty
-        valid_idx = 0 if weights[0] is not None else 1
-        return values[valid_idx], math.sqrt(1.0 / weights[valid_idx])
+        for idx, w in enumerate(weights):
+            if w is not None:
+                return values[idx], math.sqrt(1.0 / w)
 
     # Only one valid value or missing errors
     A = values[0]

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -58,6 +58,18 @@ def test_compute_radon_activity_mixed_efficiency_214():
     assert s == pytest.approx(1.0)
 
 
+def test_compute_radon_activity_single_214():
+    a, s = compute_radon_activity(None, None, 1.0, 12.0, 2.0, 1.0)
+    assert a == pytest.approx(12.0)
+    assert s == pytest.approx(2.0)
+
+
+def test_compute_radon_activity_single_218():
+    a, s = compute_radon_activity(10.0, 1.0, 1.0, None, None, 1.0)
+    assert a == pytest.approx(10.0)
+    assert s == pytest.approx(1.0)
+
+
 def test_compute_total_radon():
     conc, dconc, tot, dtot = compute_total_radon(5.0, 0.5, 10.0, 20.0)
     assert conc == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- improve compute_radon_activity when only one uncertainty is provided
- avoid removing baseline events twice
- test compute_radon_activity for single-isotope cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427945a820832bb8061ac35f4d1437