### PR TITLE
Add ambient concentration default docs and summary test

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -464,8 +464,7 @@ def main():
             baseline_info["noise_level"] = float(noise_level)
 
 
-        # Remove baseline events from the main dataset before any fits
-        events = events[~mask_base].reset_index(drop=True)
+        # Baseline events are already removed above
 
     # Apply optional spike/analysis end time cuts after baseline extraction
     if t_spike_end is not None:

--- a/readme.txt
+++ b/readme.txt
@@ -90,7 +90,8 @@ CLI options.
 
 `ambient_concentration` may also be specified here to record the ambient
 radon concentration in Bq/m³ used for the equivalent air plot.  The
-command-line option `--ambient-concentration` overrides this value.
+command-line option `--ambient-concentration` overrides this value.  The
+default configuration sets this key to `null`.
 
 Example snippet:
 

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -966,3 +966,54 @@ def test_burst_mode_from_config(tmp_path, monkeypatch):
 
     assert recorded.get("mode") == "none"
 
+
+def test_ambient_concentration_default_none(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+
+    captured = {}
+
+    def fake_write(out_dir, summary, timestamp=None):
+        captured["summary"] = summary
+        d = Path(out_dir) / "x"
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert captured["summary"]["analysis"]["ambient_concentration"] is None
+


### PR DESCRIPTION
## Summary
- clarify that ambient_concentration defaults to null in README
- add regression test for default ambient concentration recording
- remove duplicate baseline event removal

## Testing
- `./scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684279494f44832bb624bee8f2ec54b2