### PR TITLE
Add plot output tests and fix baseline masking

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -464,8 +464,11 @@ def main():
             baseline_info["noise_level"] = float(noise_level)
 
 
-        # Remove baseline events from the main dataset before any fits
-        events = events[~mask_base].reset_index(drop=True)
+
+        # Baseline events were already removed above. Avoid reapplying the mask
+        # here since it may be misaligned after ``events`` has been
+        # reindexed, which can inadvertently drop all remaining rows on
+        # newer pandas versions.
 
     # Apply optional spike/analysis end time cuts after baseline extraction
     if t_spike_end is not None:

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -304,3 +304,31 @@ def test_plot_equivalent_air_small_array(tmp_path):
 
     assert out_png.exists()
 
+
+def test_plot_radon_activity_multiple_formats(tmp_path):
+    times = np.array([0.0, 1.0, 2.0])
+    activity = np.array([1.0, 1.1, 1.2])
+    errors = np.array([0.1, 0.1, 0.1])
+    out_png = tmp_path / "radon_multi.png"
+
+    from plot_utils import plot_radon_activity
+
+    plot_radon_activity(times, activity, errors, str(out_png), config={"plot_save_formats": ["png", "pdf"]})
+
+    assert out_png.exists()
+    assert out_png.with_suffix('.pdf').exists()
+
+
+def test_plot_equivalent_air_multiple_formats(tmp_path):
+    times = np.array([0.0, 0.5, 1.0])
+    volumes = np.array([0.1, 0.2, 0.3])
+    errors = np.array([0.01, 0.01, 0.02])
+    out_png = tmp_path / "air_multi.png"
+
+    from plot_utils import plot_equivalent_air
+
+    plot_equivalent_air(times, volumes, errors, 1.0, str(out_png), config={"plot_save_formats": ["png", "pdf"]})
+
+    assert out_png.exists()
+    assert out_png.with_suffix('.pdf').exists()
+


### PR DESCRIPTION
## Summary
- add tests verifying PNG/PDF output from `plot_radon_activity` and `plot_equivalent_air`
- avoid double baseline mask application which dropped all events on newer pandas versions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684279513a70832bbc0485d911a3af76