### PR TITLE
Adjust radon activity inputs

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -24,11 +24,13 @@ def compute_radon_activity(
     Parameters
     ----------
     rate218, rate214 : float or None
-        Measured count rates for the two isotopes.
+        Measured activities for the two isotopes in Bq.  Rates should already be
+        corrected for the detection efficiencies.
     err218, err214 : float or None
-        Uncertainties on the rates.
+        Uncertainties on the rates in Bq.
     eff218, eff214 : float
-        Detection efficiencies used to convert counts to Bq.
+        Detection efficiencies of the two isotopes.  Non-positive values cause
+        the corresponding isotope to be ignored.
 
     Returns
     -------
@@ -40,19 +42,17 @@ def compute_radon_activity(
     values = []
     weights = []
 
-    if rate218 is not None:
-        val = rate218 / eff218 if eff218 > 0 else 0.0
-        values.append(val)
-        if err218 is not None and err218 > 0 and eff218 > 0:
-            weights.append(1.0 / (err218 / eff218) ** 2)
+    if rate218 is not None and eff218 > 0:
+        values.append(rate218)
+        if err218 is not None and err218 > 0:
+            weights.append(1.0 / err218**2)
         else:
             weights.append(None)
 
-    if rate214 is not None:
-        val = rate214 / eff214 if eff214 > 0 else 0.0
-        values.append(val)
-        if err214 is not None and err214 > 0 and eff214 > 0:
-            weights.append(1.0 / (err214 / eff214) ** 2)
+    if rate214 is not None and eff214 > 0:
+        values.append(rate214)
+        if err214 is not None and err214 > 0:
+            weights.append(1.0 / err214**2)
         else:
             weights.append(None)
 

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -28,6 +28,12 @@ def test_compute_radon_activity_only_214_error():
     assert s == pytest.approx(2.0)
 
 
+def test_compute_radon_activity_only_214_error_eff_not_one():
+    a, s = compute_radon_activity(10.0, None, 0.8, 12.0, 2.0, 0.9)
+    assert a == pytest.approx(12.0)
+    assert s == pytest.approx(2.0)
+
+
 def test_compute_radon_activity_mixed_efficiency():
     a, s = compute_radon_activity(10.0, 1.0, 0.0, 12.0, 2.0, 1.0)
     assert a == pytest.approx(12.0)
@@ -36,6 +42,12 @@ def test_compute_radon_activity_mixed_efficiency():
 
 def test_compute_radon_activity_only_218_error():
     a, s = compute_radon_activity(10.0, 1.0, 1.0, 12.0, None, 1.0)
+    assert a == pytest.approx(10.0)
+    assert s == pytest.approx(1.0)
+
+
+def test_compute_radon_activity_only_218_error_eff_not_one():
+    a, s = compute_radon_activity(10.0, 1.0, 0.7, 12.0, None, 0.6)
     assert a == pytest.approx(10.0)
     assert s == pytest.approx(1.0)
 


### PR DESCRIPTION
## Summary
- compute activity from already efficiency-corrected rates
- handle cases with single uncertainty correctly
- add regression tests for efficiencies not equal to one

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684283de664c832b9f1e76cef8d6cc8f