### PR TITLE
Add time-dependent radon activity arrays

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1064,13 +1064,20 @@ def main():
         for i in range(times.size):
             r214 = err214_i = None
             if A214 is not None:
-                r214 = A214[i] * eff_Po214
-                err214_i = dA214[i] * eff_Po214
+                r214 = A214[i]
+                err214_i = dA214[i]
             r218 = err218_i = None
             if A218 is not None:
-                r218 = A218[i] * eff_Po218
-                err218_i = dA218[i] * eff_Po218
-            A, s = compute_radon_activity(r218, err218_i, eff_Po218, r214, err214_i, eff_Po214)
+                r218 = A218[i]
+                err218_i = dA218[i]
+            A, s = compute_radon_activity(
+                r218,
+                err218_i,
+                1.0,
+                r214,
+                err214_i,
+                1.0,
+            )
             activity_arr[i] = A
             err_arr[i] = s
 

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -334,6 +334,26 @@ def test_plot_modeled_radon_activity_variation(tmp_path, monkeypatch):
 
     assert "y" in captured
     assert not np.allclose(captured["y"], captured["y"][0])
+
+
+def test_plot_modeled_radon_activity_time_change(tmp_path, monkeypatch):
+    times = np.array([0.0, 2.0, 4.0, 6.0])
+
+    captured = {}
+
+    def fake_errorbar(x, y, *args, **kwargs):
+        captured["y"] = np.asarray(y)
+        return type("obj", (), {})()
+
+    monkeypatch.setattr("plot_utils.plt.errorbar", fake_errorbar)
+    monkeypatch.setattr("plot_utils.plt.savefig", lambda *a, **k: None)
+
+    from plot_utils import plot_modeled_radon_activity
+
+    plot_modeled_radon_activity(times, 0.5, 0.05, 1.0, 0.1, 3.0, str(tmp_path / "tc.png"))
+
+    assert "y" in captured
+    assert not np.allclose(captured["y"], captured["y"][0])
 def test_plot_radon_activity_multiple_formats(tmp_path):
     times = np.array([0.0, 1.0, 2.0])
     activity = np.array([1.0, 1.1, 1.2])


### PR DESCRIPTION
## Summary
- compute radon activity over time in `analyze.py`
- test plotting function to ensure modeled radon activity changes with time

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684283dda9a0832ba9efdd05e66cda66