### PR TITLE
Add ambient concentration summary test

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -91,7 +91,12 @@ CLI options.
 `ambient_concentration` may also be specified here to record the ambient
 radon concentration in Bq/m³ used for the equivalent air plot.  The
 command-line option `--ambient-concentration` overrides this value.  The
-default configuration sets this key to `null`.
+default configuration sets this key to `null`.  The template
+`config.json` therefore includes
+```json
+"ambient_concentration": null
+```
+under the `analysis` section.
 
 Example snippet:
 

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -1017,3 +1017,61 @@ def test_ambient_concentration_default_none(tmp_path, monkeypatch):
 
     assert captured["summary"]["analysis"]["ambient_concentration"] is None
 
+
+def test_ambient_concentration_written_to_summary_file(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "analysis": {"ambient_concentration": 1.3},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "plot_equivalent_air", lambda *a, **k: Path(a[4]).touch())
+
+    from io_utils import write_summary as real_write_summary
+
+    results = {}
+
+    def capture_write(out_dir, summary, timestamp=None):
+        p = real_write_summary(out_dir, summary, timestamp)
+        results["path"] = p
+        return p
+
+    monkeypatch.setattr(analyze, "write_summary", capture_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    summary_path = Path(results["path"]) / "summary.json"
+    with open(summary_path, "r", encoding="utf-8") as f:
+        summary = json.load(f)
+
+    assert summary["analysis"]["ambient_concentration"] == 1.3
+


### PR DESCRIPTION
## Summary
- document the `ambient_concentration` option in the README
- add a unit test that verifies the value is written to `summary.json`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684283dfe9c8832b93dbf2828f80004f