### PR TITLE
Add burst_mode config support

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -123,6 +123,19 @@ rolling-median threshold (`burst_window_size_s`, `rolling_median_window`,
 `burst_multiplier`) and `both` applies the micro filter followed by the
 rate veto.
 
+Example snippet:
+
+```json
+"burst_filter": {
+    "burst_mode": "rate",
+    "burst_window_size_s": 60,
+    "rolling_median_window": 5,
+    "burst_multiplier": 5,
+    "micro_window_size_s": 1,
+    "micro_count_threshold": 3
+}
+```
+
 `time_bins_fallback` under the `plotting` section sets the number of
 histogram bins to use when the automatic Freedman&ndash;Diaconis rule
 fails, typically due to zero IQR.  The default is `1`.

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -967,6 +967,54 @@ def test_burst_mode_from_config(tmp_path, monkeypatch):
     assert recorded.get("mode") == "none"
 
 
+def test_burst_mode_micro_config(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+        "burst_filter": {"burst_mode": "micro"},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    recorded = {}
+
+    def fake_burst(df, cfg, mode="rate"):
+        recorded["mode"] = mode
+        return df, 0
+
+    monkeypatch.setattr(analyze, "apply_burst_filter", fake_burst)
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert recorded.get("mode") == "micro"
+
+
 def test_ambient_concentration_default_none(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},


### PR DESCRIPTION
## Summary
- document `burst_mode` configuration in README
- verify burst mode from config with new test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684283e0d724832b834811a7ea012b4f