### PR TITLE
Fix baseline subtraction to use radon rate

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -897,20 +897,20 @@ def main():
                 rate = count / (baseline_live_time * eff)
             else:
                 rate = 0.0
-            baseline_rates[iso] = cps_to_bq(rate, volume_liters=monitor_vol)
+            baseline_rates[iso] = rate  # Bq
 
-    scale_factor = 0.0
-    if monitor_vol > 0:
-        scale_factor = sample_vol / monitor_vol
+    dilution_factor = 0.0
+    if monitor_vol + sample_vol > 0:
+        dilution_factor = monitor_vol / (monitor_vol + sample_vol)
 
-    for iso, conc in baseline_rates.items():
+    for iso, rate in baseline_rates.items():
         fit = time_fit_results.get(iso)
         if fit and (f"E_{iso}" in fit):
-            fit["E_corrected"] = fit[f"E_{iso}"] - conc * scale_factor
+            fit["E_corrected"] = fit[f"E_{iso}"] - rate * dilution_factor
 
     if baseline_rates:
-        baseline_info["concentration_Bq_m3"] = baseline_rates
-        baseline_info["scale_factor"] = scale_factor
+        baseline_info["rate_Bq"] = baseline_rates
+        baseline_info["dilution_factor"] = dilution_factor
 
     # ────────────────────────────────────────────────────────────
     # Radon activity extrapolation

--- a/readme.txt
+++ b/readme.txt
@@ -257,10 +257,11 @@ an assay. Configuration must define three keys under `baseline`:
 - `sample_volume_l` – volume of the assay sample in liters.
 
 Events collected during the baseline period are counted in the Po‑214 and
-Po‑218 windows. The count rates are converted to Bq/m³ via
-`cps_to_bq(rate, volume_liters=monitor_volume_l)` and scaled by detection
-efficiency. This baseline activity is then subtracted from the assay result
-after applying the ratio `sample_volume_l/monitor_volume_l`.
+Po‑218 windows. The counts are converted directly into a decay rate in
+Bq by dividing by the baseline live time and detection efficiency.  This
+rate is scaled by the dilution factor
+`monitor_volume_l / (monitor_volume_l + sample_volume_l)` before being
+subtracted from the fitted radon decay rate of the assay.
 
 Example snippet:
 

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -73,11 +73,11 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
     analyze.main()
 
     summary = captured["summary"]
-    conc = summary["baseline"]["concentration_Bq_m3"]["Po214"]
-    assert conc == pytest.approx(0.330578, rel=1e-3)
+    rate = summary["baseline"]["rate_Bq"]["Po214"]
+    assert rate == pytest.approx(0.2, rel=1e-3)
     assert summary["baseline"]["n_events"] == 2
-    assert summary["baseline"]["scale_factor"] == pytest.approx(0.0)
-    assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(1.0)
+    assert summary["baseline"]["dilution_factor"] == pytest.approx(1.0)
+    assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(0.8)
     assert summary["baseline"].get("noise_level") == 5.0
     times = list(captured.get("times", []))
     assert times == [20]


### PR DESCRIPTION
## Summary
- compute baseline background as a decay rate in Bq
- subtract baseline using dilution factor `(monitor_vol/(monitor_vol + sample_vol))`
- document the new approach
- update baseline unit test

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68428b607330832b8c30d168e774f0ed