### PR TITLE
Add radon activity edge-case tests

### DIFF
--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -52,6 +52,18 @@ def test_compute_radon_activity_only_218_error_eff_not_one():
     assert s == pytest.approx(1.0)
 
 
+def test_compute_radon_activity_only_214_error_zero_218_error():
+    a, s = compute_radon_activity(10.0, 0.0, 1.0, 12.0, 2.0, 1.0)
+    assert a == pytest.approx(12.0)
+    assert s == pytest.approx(2.0)
+
+
+def test_compute_radon_activity_only_218_error_zero_214_error():
+    a, s = compute_radon_activity(10.0, 1.0, 1.0, 12.0, 0.0, 1.0)
+    assert a == pytest.approx(10.0)
+    assert s == pytest.approx(1.0)
+
+
 def test_compute_radon_activity_mixed_error_sign():
     a, s = compute_radon_activity(10.0, -1.0, 1.0, 12.0, 2.0, 1.0)
     assert a == pytest.approx(12.0)


### PR DESCRIPTION
## Summary
- add new cases for compute_radon_activity when only one isotope has a valid error

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68428b616124832bb84e83e1346289c0