### PR TITLE
Document burst-mode CLI override

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,7 @@ python analyze.py --config config.json --input merged_data.csv \
     [--analysis-end-time ISO --spike-end-time ISO] \
     [--settle-s SEC] [--debug] [--seed SEED] \
     [--ambient-file amb.txt] [--ambient-concentration 0.1] \
+    [--burst-mode rate] \
     [--time-bin-mode fixed --time-bin-width 3600] [--dump-ts-json]
 ```
 

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -1015,6 +1015,56 @@ def test_burst_mode_micro_config(tmp_path, monkeypatch):
     assert recorded.get("mode") == "micro"
 
 
+def test_burst_mode_cli_overrides(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+        "burst_filter": {"burst_mode": "none"},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    recorded = {}
+
+    def fake_burst(df, cfg, mode="rate"):
+        recorded["mode"] = mode
+        return df, 0
+
+    monkeypatch.setattr(analyze, "apply_burst_filter", fake_burst)
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+        "--burst-mode",
+        "micro",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert recorded.get("mode") == "micro"
+
+
 def test_ambient_concentration_default_none(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},


### PR DESCRIPTION
## Summary
- document `--burst-mode` in README
- test that the CLI option overrides the configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68428b640ea8832bb38184fe9343fa63