### PR TITLE
Fix radon activity doc and tests

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -67,6 +67,10 @@ from utils import cps_to_bq
 activity_bq_m3 = cps_to_bq(fit_result["E_Po214"], volume_liters=10.0)
 ```
 
+When using ``compute_radon_activity`` you should pass the fitted rates
+directly. They already represent activities in Bq and no additional
+division by the detection efficiency is required.
+
 ## Configuration
 
 `nominal_adc` under the `calibration` section sets the expected raw ADC

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -94,6 +94,20 @@ def test_compute_radon_activity_single_218():
     assert s == pytest.approx(1.0)
 
 
+def test_compute_radon_activity_single_214_eff_not_one():
+    """Efficiency values should not scale single-isotope rates."""
+    a, s = compute_radon_activity(None, None, 0.5, 12.0, 2.0, 0.7)
+    assert a == pytest.approx(12.0)
+    assert s == pytest.approx(2.0)
+
+
+def test_compute_radon_activity_single_218_eff_not_one():
+    """Efficiency values should not scale single-isotope rates."""
+    a, s = compute_radon_activity(10.0, 1.0, 0.3, None, None, 0.8)
+    assert a == pytest.approx(10.0)
+    assert s == pytest.approx(1.0)
+
+
 def test_compute_total_radon():
     conc, dconc, tot, dtot = compute_total_radon(5.0, 0.5, 10.0, 20.0)
     assert conc == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- clarify that compute_radon_activity expects efficiency-corrected rates
- test that efficiencies do not scale single-isotope radon rates

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842986f6e50832b8eed14b36ea46a20