### PR TITLE
Verify dilution factor in baseline subtraction

### DIFF
--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -84,3 +84,73 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
     # Ensure baseline events were not passed to the time fit
     assert all(t >= cfg["baseline"]["range"][1] for t in times)
 
+
+def test_baseline_scaling_factor(tmp_path, monkeypatch):
+    """Baseline subtraction scales by the monitor dilution factor."""
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "baseline": {"range": [0, 10], "monitor_volume_l": 605.0, "sample_volume_l": 605.0},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": True,
+            "window_Po214": [7, 9],
+            "hl_Po214": [1.0, 0.0],
+            "eff_Po214": [1.0, 0.0],
+            "flags": {},
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1, 2, 3],
+        "fBits": [0, 0, 0],
+        "timestamp": [1, 2, 20],
+        "adc": [8, 8, 8],
+        "fchannel": [1, 1, 1],
+    })
+    data_path = tmp_path / "data.csv"
+    df.to_csv(data_path, index=False)
+
+    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {"E_Po214": 1.0})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(baseline_noise, "estimate_baseline_noise", lambda *a, **k: (None, {}))
+
+    captured = {}
+
+    def fake_write(out_dir, summary, timestamp=None):
+        captured["summary"] = summary
+        d = Path(out_dir) / (timestamp or "x")
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config", str(cfg_path),
+        "--input", str(data_path),
+        "--output_dir", str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+
+    analyze.main()
+
+    summary = captured["summary"]
+    rate = summary["baseline"]["rate_Bq"]["Po214"]
+    dilution = summary["baseline"]["dilution_factor"]
+    assert rate == pytest.approx(0.2, rel=1e-3)
+    assert dilution == pytest.approx(0.5)
+    assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(0.9)
+


### PR DESCRIPTION
## Summary
- expand baseline tests to cover monitor dilution factor

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842986ec0dc832bb59f1bd6b9d90873