### PR TITLE
Document input format with example

### DIFF
--- a/example_input.csv
+++ b/example_input.csv
@@ -1,0 +1,4 @@
+fUniqueID,fBits,timestamp,adc,fchannel
+1,0,1000,1200,1
+2,0,1005,1300,1
+3,0,1010,1250,1

--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,19 @@ python analyze.py --config config.json --input merged_data.csv \
     [--time-bin-mode fixed --time-bin-width 3600] [--dump-ts-json]
 ```
 
+## Input CSV Format
+
+The input file must be a comma-separated table with these columns:
+
+- `fUniqueID` – unique event number
+- `fBits` – status bits or flags
+- `timestamp` – event timestamp in seconds
+- `adc` – raw ADC value
+- `fchannel` – acquisition channel
+
+Columns beyond these are ignored. See `example_input.csv` for a
+sample layout.
+
 ## Output
 
 The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--job-id` is given the folder `<output_dir>/<job-id>/` is used instead. The directory includes:


### PR DESCRIPTION
## Summary
- add a small `example_input.csv`
- document required columns in a new "Input CSV Format" section

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a036ad54832b8f840f7aea343cf2