### PR TITLE
Add negative efficiency checks

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -29,8 +29,9 @@ def compute_radon_activity(
     err218, err214 : float or None
         Uncertainties on the rates in Bq.
     eff218, eff214 : float
-        Detection efficiencies of the two isotopes.  Non-positive values cause
-        the corresponding isotope to be ignored.
+        Detection efficiencies of the two isotopes.  Zero values cause the
+        corresponding isotope to be ignored.  Negative values raise a
+        ``ValueError``.
 
     Returns
     -------
@@ -39,6 +40,11 @@ def compute_radon_activity(
     float
         Propagated 1-sigma uncertainty.
     """
+    if eff218 < 0:
+        raise ValueError("eff218 must be non-negative")
+    if eff214 < 0:
+        raise ValueError("eff214 must be non-negative")
+
     values = []
     weights = []
 

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -114,6 +114,16 @@ def test_compute_radon_activity_uncertainty_po214_only():
     assert a == pytest.approx(5.0)
     assert s == pytest.approx(0.3)
 
+
+def test_compute_radon_activity_negative_eff218():
+    with pytest.raises(ValueError):
+        compute_radon_activity(10.0, 1.0, -0.2, 12.0, 2.0, 1.0)
+
+
+def test_compute_radon_activity_negative_eff214():
+    with pytest.raises(ValueError):
+        compute_radon_activity(10.0, 1.0, 1.0, 12.0, 2.0, -0.5)
+
 def test_compute_total_radon():
     conc, dconc, tot, dtot = compute_total_radon(5.0, 0.5, 10.0, 20.0)
     assert conc == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- check `eff218` and `eff214` for negativity
- document that negative efficiencies raise `ValueError`
- test that negative efficiency inputs raise the exception

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a2c33f5c832b873baae00ce7a7bc