### PR TITLE
Add sample volume check

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -86,6 +86,10 @@ def compute_total_radon(
 ) -> Tuple[float, float, float, float]:
     """Convert activity into concentration and total radon in the sample volume.
 
+    Both ``monitor_volume`` and ``sample_volume`` must be non-negative.  A
+    ``ValueError`` is raised if ``monitor_volume`` is not positive or if
+    ``sample_volume`` is negative.
+
     Returns
     -------
     concentration : float
@@ -99,6 +103,8 @@ def compute_total_radon(
     """
     if monitor_volume <= 0:
         raise ValueError("monitor_volume must be positive")
+    if sample_volume < 0:
+        raise ValueError("sample_volume must be non-negative")
     conc = activity_bq / monitor_volume
     sigma_conc = err_bq / monitor_volume
 

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -122,6 +122,11 @@ def test_compute_total_radon():
     assert dtot == pytest.approx(1.0)
 
 
+def test_compute_total_radon_negative_sample_volume():
+    with pytest.raises(ValueError):
+        compute_total_radon(5.0, 0.5, 10.0, -1.0)
+
+
 def test_radon_activity_curve():
     times = [0.0, 1.0]
     E = 5.0


### PR DESCRIPTION
## Summary
- enforce non-negative `sample_volume` in `compute_total_radon`
- document that both volume arguments must be non-negative
- test ValueError is raised for negative `sample_volume`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a2cc4590832b8c196a979978c390