### PR TITLE
Propagate NaN when isotope uncertainties missing

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -57,7 +57,7 @@ def compute_radon_activity(
             weights.append(None)
 
     if not values:
-        return 0.0, 0.0
+        return 0.0, math.nan
 
     # If both have valid uncertainties use weighted average
     if len(values) == 2 and all(w is not None for w in weights):
@@ -74,7 +74,7 @@ def compute_radon_activity(
 
     # Only one valid value or missing errors
     A = values[0]
-    sigma = math.sqrt(1.0 / weights[0]) if weights[0] is not None else 0.0
+    sigma = math.sqrt(1.0 / weights[0]) if weights[0] is not None else math.nan
     return A, sigma
 
 

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -122,6 +122,13 @@ def test_compute_total_radon():
     assert dtot == pytest.approx(1.0)
 
 
+def test_compute_radon_activity_missing_uncertainty_returns_nan():
+    """Single rate without uncertainty should propagate NaN error."""
+    a, s = compute_radon_activity(5.0, None, 1.0, None, None, 1.0)
+    assert a == pytest.approx(5.0)
+    assert math.isnan(s)
+
+
 def test_radon_activity_curve():
     times = [0.0, 1.0]
     E = 5.0


### PR DESCRIPTION
## Summary
- propagate NaN for unknown isotope rate errors
- test propagation of NaN when uncertainty is missing

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a2c19d28832b9ee036ec86782357