### PR TITLE
Correct baseline N0 units and tests

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -728,11 +728,18 @@ def main():
             )
             n0_count = float(np.sum(probs_base))
             baseline_counts[iso] = n0_count
+
+            eff = cfg["time_fit"].get(f"eff_{iso}", [1.0])[0]
+            if baseline_live_time > 0 and eff > 0:
+                n0_activity = n0_count / (baseline_live_time * eff)
+                n0_sigma = np.sqrt(n0_count) / (baseline_live_time * eff)
+            else:
+                n0_activity = 0.0
+                n0_sigma = 1.0
+
             priors_time["N0"] = (
-                n0_count,
-                cfg["time_fit"].get(
-                    f"sig_N0_{iso}", np.sqrt(n0_count) if n0_count > 0 else 1.0
-                ),
+                n0_activity,
+                cfg["time_fit"].get(f"sig_N0_{iso}", n0_sigma),
             )
         else:
             priors_time["N0"] = (

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -154,3 +154,86 @@ def test_baseline_scaling_factor(tmp_path, monkeypatch):
     assert dilution == pytest.approx(0.5)
     assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(0.9)
 
+
+def test_n0_prior_from_baseline(tmp_path, monkeypatch):
+    """Baseline counts convert to an N0 prior in activity units."""
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "baseline": {"range": [0, 10], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": True,
+            "window_Po214": [7, 9],
+            "hl_Po214": [1.0, 0.0],
+            "eff_Po214": [1.0, 0.0],
+            "flags": {},
+        },
+        "systematics": {"enable": True, "sigma_shifts": {}, "scan_keys": []},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1, 2, 3],
+        "fBits": [0, 0, 0],
+        "timestamp": [1, 2, 20],
+        "adc": [8, 8, 8],
+        "fchannel": [1, 1, 1],
+    })
+    data_path = tmp_path / "data.csv"
+    df.to_csv(data_path, index=False)
+
+    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
+
+    captured = {}
+
+    def fake_fit_time_series(times_dict, t_start, t_end, cfg):
+        return {"E_Po214": 1.0}
+
+    monkeypatch.setattr(analyze, "fit_time_series", fake_fit_time_series)
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(baseline_noise, "estimate_baseline_noise", lambda *a, **k: (None, {}))
+
+    def fake_scan_systematics(fit_func, priors, sigma_dict, keys):
+        captured["priors"] = priors
+        try:
+            fit_func(priors)
+        except Exception:
+            pass
+        return {}, 0.0
+
+    monkeypatch.setattr(analyze, "scan_systematics", fake_scan_systematics)
+
+    def fake_write(out_dir, summary, timestamp=None):
+        captured["summary"] = summary
+        d = Path(out_dir) / (timestamp or "x")
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+
+    analyze.main()
+
+    n0_prior = captured.get("priors", {}).get("N0", (None,))[0]
+    assert n0_prior == pytest.approx(0.2, rel=1e-3)
+


### PR DESCRIPTION
## Summary
- scale baseline counts into N0 activity for `fit_time_series`
- provide prior in new units in `analyze.py`
- test N0 prior scaling from baseline counts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842a62e0bf8832ba7702ff0d335a3f4