### PR TITLE
Clarify radon activity efficiency handling

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -24,14 +24,16 @@ def compute_radon_activity(
     Parameters
     ----------
     rate218, rate214 : float or None
-        Measured activities for the two isotopes in Bq.  Rates should already be
-        corrected for the detection efficiencies.
+        Measured activities for the two isotopes in Bq.  The values should
+        already include the detection efficiencies; this function will not
+        scale them further.
     err218, err214 : float or None
         Uncertainties on the rates in Bq.
     eff218, eff214 : float
-        Detection efficiencies of the two isotopes.  Zero values cause the
-        corresponding isotope to be ignored.  Negative values raise a
-        ``ValueError``.
+        Detection efficiencies for the two isotopes.  They are only used to
+        determine whether an isotope contributes to the average: a value of zero
+        disables that isotope and negative values raise a ``ValueError``.  The
+        efficiencies are not applied as multiplicative weights.
 
     Returns
     -------

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -22,6 +22,14 @@ def test_compute_radon_activity_weighted():
     assert s == pytest.approx(err)
 
 
+def test_compute_radon_activity_efficiencies_not_weighted():
+    """Non-zero efficiencies should not scale the rates."""
+    a_ref, s_ref = compute_radon_activity(10.0, 1.0, 1.0, 12.0, 2.0, 1.0)
+    a, s = compute_radon_activity(10.0, 1.0, 0.6, 12.0, 2.0, 0.7)
+    assert a == pytest.approx(a_ref)
+    assert s == pytest.approx(s_ref)
+
+
 def test_compute_radon_activity_only_214_error():
     a, s = compute_radon_activity(10.0, None, 1.0, 12.0, 2.0, 1.0)
     assert a == pytest.approx(12.0)


### PR DESCRIPTION
## Summary
- clarify how efficiencies are used in `compute_radon_activity`
- add test showing efficiencies do not scale the rates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a6315f10832b80288d70df10d878