### PR TITLE
Fix total radon computation

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -986,11 +986,13 @@ def main():
         rate218, err218, eff_Po218, rate214, err214, eff_Po214
     )
 
+    # Convert activity to a concentration per liter of monitor volume and the
+    # total amount of radon present in just the assay sample.
     conc, dconc, total_bq, dtotal_bq = compute_total_radon(
         A_radon,
         dA_radon,
         monitor_vol,
-        monitor_vol + sample_vol,
+        sample_vol,
     )
 
     radon_results["radon_activity_Bq"] = {"value": A_radon, "uncertainty": dA_radon}

--- a/readme.txt
+++ b/readme.txt
@@ -338,8 +338,8 @@ python utils.py 0.5 --to bq --volume_liters 10
 After the decay fits a weighted average of the Po‑218 and Po‑214 rates is
 converted to an instantaneous radon activity.  The result is written to
 `summary.json` under `radon_results` together with the corresponding
-concentration (per liter) and the total amount of radon in the combined
-monitor + sample volume.  The file `radon_activity.png` visualises this
+concentration (per liter) and the total amount of radon contained in the
+sample volume.  The file `radon_activity.png` visualises this
 activity versus time.  When either `--ambient-file` or
 `--ambient-concentration` is supplied an additional plot
 `equivalent_air.png` shows the volume of ambient air containing the same

--- a/tests/test_sample_radon.py
+++ b/tests/test_sample_radon.py
@@ -1,0 +1,71 @@
+import sys
+from pathlib import Path
+import json
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+import radon_activity
+
+
+def test_total_radon_uses_sample_volume(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "baseline": {"monitor_volume_l": 10.0, "sample_volume_l": 5.0},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": True, "window_Po214": [7, 9], "hl_Po214": [1.0, 0.0], "eff_Po214": [1.0, 0.0], "flags": {}},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1],
+        "fBits": [0],
+        "timestamp": [0],
+        "adc": [8],
+        "fchannel": [1],
+    })
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+
+    monkeypatch.setattr(radon_activity, "compute_radon_activity", lambda *a, **k: (5.0, 0.5))
+
+    captured = {}
+
+    def fake_write(out_dir, summary, timestamp=None):
+        captured["summary"] = summary
+        d = Path(out_dir) / (timestamp or "x")
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config", str(cfg_path),
+        "--input", str(data_path),
+        "--output_dir", str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+
+    analyze.main()
+
+    summary = captured.get("summary", {})
+    expected = radon_activity.compute_total_radon(5.0, 0.5, 10.0, 5.0)[2]
+    assert summary["radon_results"]["total_radon_in_sample_Bq"]["value"] == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- use sample volume directly when computing total radon
- clarify the radon activity docs
- test that analyze.py uses the sample volume

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a6340bf0832b81e4e11a4e90ed95