### PR TITLE
Validate baseline time window

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -455,6 +455,10 @@ def main():
 
         t_start_base = to_epoch(baseline_range[0])
         t_end_base = to_epoch(baseline_range[1])
+        if t_end_base <= t_start_base:
+            raise ValueError(
+                "baseline_range end time must be greater than start time"
+            )
         mask_base = (events["timestamp"] >= t_start_base) & (
             events["timestamp"] < t_end_base
         )

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -91,6 +91,55 @@ def test_time_window_filters_events(tmp_path, monkeypatch):
     assert captured.get("times") == [6.0]
 
 
+def test_invalid_baseline_range_raises(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "baseline": {"range": [5, 2], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": False,
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1],
+        "fBits": [0],
+        "timestamp": [0.0],
+        "adc": [8.0],
+        "fchannel": [1],
+    })
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(baseline_noise, "estimate_baseline_noise", lambda *a, **k: (None, {}))
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+
+    with pytest.raises(ValueError):
+        analyze.main()
+
+
 def test_time_window_filters_events_config(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},


### PR DESCRIPTION
## Summary
- enforce `baseline_range` end time exceeds start time
- test that invalid baseline range raises `ValueError`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f510fba0832b8ec796660f182359