### PR TITLE
Handle NaN values when writing summaries

### DIFF
--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -158,6 +158,20 @@ def test_write_summary_with_nullable_integers(tmp_path):
     assert loaded["list"] == [1, None]
 
 
+def test_write_summary_with_nan_values(tmp_path):
+    summary = {"nan": float("nan"), "inf": float("inf"), "list": [float("nan"), 1.0]}
+    outdir = tmp_path / "out_nan"
+    ts = "19700101T000002Z"
+    results = write_summary(str(outdir), summary, ts)
+    summary_path = Path(results) / "summary.json"
+    assert summary_path.exists()
+    with open(summary_path, "r", encoding="utf-8") as f:
+        loaded = json.load(f)
+    assert loaded["nan"] is None
+    assert loaded["inf"] is None
+    assert loaded["list"] == [None, 1.0]
+
+
 def test_apply_burst_filter_no_removal():
     df = pd.DataFrame(
         {

--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 from scipy.signal import find_peaks
+import math
 
 __all__ = ["to_native", "find_adc_peaks", "cps_to_cpd", "cps_to_bq"]
 
@@ -28,13 +29,18 @@ def to_native(obj):
             return obj.isoformat()
         elif isinstance(obj, (pd.Series, pd.Index)):
             return [to_native(x) for x in obj.tolist()]
-    if isinstance(obj, np.generic):
-        return obj.item()
-    elif isinstance(obj, np.ndarray):
+    if isinstance(obj, np.ndarray):
         # Convert array into list of native types
         return [to_native(x) for x in obj.tolist()]
-    else:
-        return obj
+
+    if isinstance(obj, np.generic):
+        obj = obj.item()
+
+    if isinstance(obj, float):
+        if math.isnan(obj) or not math.isfinite(obj):
+            return None
+
+    return obj
 
 
 def find_adc_peaks(adc_values, expected, window=50, prominence=0.0, width=None):


### PR DESCRIPTION
## Summary
- convert NaN or infinite values to `None` in `to_native`
- test that `write_summary` outputs JSON null for NaN inputs

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f5105924832b8d742a771653eb26