### PR TITLE
Support multiple assay efficiencies

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -930,16 +930,22 @@ def main():
 
         if "assay" in eff_cfg:
             acfg = eff_cfg["assay"]
-            try:
-                val = calc_assay_efficiency(
-                    acfg["rate_cps"], acfg["reference_bq"]
-                )
-                err = float(acfg.get("error", 0.0))
-                sources["assay"] = {"value": val, "error": err}
-                vals.append(val)
-                errs.append(err)
-            except Exception as e:
-                print(f"WARNING: Assay efficiency -> {e}")
+            if isinstance(acfg, dict):
+                acfg_list = [acfg]
+            else:
+                acfg_list = list(acfg)
+            for idx, cfg_item in enumerate(acfg_list, start=1):
+                try:
+                    val = calc_assay_efficiency(
+                        cfg_item["rate_cps"], cfg_item["reference_bq"]
+                    )
+                    err = float(cfg_item.get("error", 0.0))
+                    key = "assay" if isinstance(acfg, dict) else f"assay_{idx}"
+                    sources[key] = {"value": val, "error": err}
+                    vals.append(val)
+                    errs.append(err)
+                except Exception as e:
+                    print(f"WARNING: Assay efficiency -> {e}")
 
         if "decay" in eff_cfg:
             dcfg = eff_cfg["decay"]

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -457,6 +457,86 @@ def test_spike_count_cli(tmp_path, monkeypatch):
     assert saved["summary"]["efficiency"]["sources"]["spike"]["error"] == 2.0
 
 
+def test_assay_efficiency_list(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "efficiency": {
+            "assay": [
+                {"rate_cps": 1.0, "reference_bq": 10.0, "error": 0.1},
+                {"rate_cps": 2.0, "reference_bq": 20.0, "error": 0.2},
+            ]
+        },
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+
+    import efficiency
+
+    calls = []
+
+    def fake_assay(rate, ref):
+        calls.append((rate, ref))
+        return 0.05
+
+    recorded = {}
+
+    def fake_blue(vals, errs):
+        recorded["vals"] = list(vals)
+        recorded["errs"] = list(errs)
+        return 0.1, 0.01, np.array([0.5, 0.5])
+
+    monkeypatch.setattr(efficiency, "calc_spike_efficiency", lambda *a, **k: 0.1)
+    monkeypatch.setattr(efficiency, "calc_assay_efficiency", fake_assay)
+    monkeypatch.setattr(efficiency, "calc_decay_efficiency", lambda *a, **k: 0.1)
+    monkeypatch.setattr(efficiency, "blue_combine", fake_blue)
+
+    saved = {}
+
+    def fake_write(out_dir, summary, timestamp=None):
+        saved["summary"] = summary
+        d = Path(out_dir) / "x"
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert len(calls) == 2
+    assert recorded["vals"] == [0.05, 0.05]
+    assert recorded["errs"] == [0.1, 0.2]
+    sources = saved["summary"]["efficiency"]["sources"]
+    assert "assay_1" in sources and "assay_2" in sources
+
 
 def test_debug_flag_sets_log_level(tmp_path, monkeypatch):
     cfg = {


### PR DESCRIPTION
## Summary
- handle `efficiency.assay` as a list in `analyze.main`
- store each run under unique keys and combine with BLUE
- add unit test covering list behavior

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68432d5c7780832b8f0f48bd7c0a3ca3