### PR TITLE
Support spike periods and multiple spike efficiencies

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -30,6 +30,7 @@ python analyze.py --config config.json --input merged_data.csv \
     [--efficiency-json eff.json] [--systematics-json syst.json] \
     [--spike-count N --spike-count-err S] [--slope RATE] \
     [--analysis-end-time ISO --spike-end-time ISO] \
+    [--spike-period START END] \
     [--settle-s SEC] [--debug] [--seed SEED] \
     [--ambient-file amb.txt (time conc)] [--ambient-concentration 0.1] \
     [--burst-mode rate] \
@@ -103,9 +104,11 @@ event timestamp is used.
 
 `analysis_end_time` may be specified to stop processing after the given
 timestamp while `spike_end_time` discards all events before its value.
-Events outside this window are ignored when computing baselines and
-running the decay fits. Both accept ISO‑8601 strings and can also be set
-with the corresponding CLI options.
+`spike_periods` can list one or more `[start, end]` pairs of timestamps
+whose events should also be removed.  Events outside the final window
+are ignored when computing baselines and running the decay fits. All
+three options accept ISO‑8601 strings and can also be set with the
+corresponding CLI flags.
 
 `ambient_concentration` may also be specified here to record the ambient
 radon concentration in Bq/m³ used for the equivalent air plot.  The
@@ -124,6 +127,7 @@ Example snippet:
     "analysis_start_time": "2020-01-01T00:00:00Z",
     "analysis_end_time": "2020-01-02T00:00:00Z",
     "spike_end_time": "2020-01-01T01:00:00Z",
+    "spike_periods": [["2020-01-01T03:00:00Z", "2020-01-01T04:00:00Z"]],
     "ambient_concentration": 0.02
 }
 ```
@@ -134,6 +138,7 @@ When present the value is also written to `summary.json` under the
 ```json
 "analysis": {
     "analysis_start_time": "2020-01-01T00:00:00Z",
+    "spike_periods": [["2020-01-01T03:00:00Z", "2020-01-01T04:00:00Z"]],
 "ambient_concentration": 0.02
 }
 ```
@@ -354,7 +359,10 @@ with entries such as:
 
 ```json
 "efficiency": {
-    "spike": {"counts": 1000, "activity_bq": 50, "live_time_s": 3600},
+    "spike": [
+        {"counts": 1000, "activity_bq": 50, "live_time_s": 3600},
+        {"counts": 800, "activity_bq": 50, "live_time_s": 3600}
+    ],
     "assay": {"rate_cps": 0.8, "reference_bq": 2.0}
 }
 ```

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -457,6 +457,75 @@ def test_spike_count_cli(tmp_path, monkeypatch):
     assert saved["summary"]["efficiency"]["sources"]["spike"]["error"] == 2.0
 
 
+def test_spike_efficiency_multiple_entries(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "efficiency": {
+            "spike": [
+                {"counts": 10, "activity_bq": 5, "live_time_s": 100},
+                {"counts": 20, "activity_bq": 5, "live_time_s": 100},
+            ]
+        },
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+
+    import efficiency
+
+    calls = []
+
+    def fake_spike(cnt, act, live):
+        calls.append(cnt)
+        return 0.1
+
+    monkeypatch.setattr(efficiency, "calc_spike_efficiency", fake_spike)
+    monkeypatch.setattr(efficiency, "calc_assay_efficiency", lambda *a, **k: 0.1)
+    monkeypatch.setattr(efficiency, "calc_decay_efficiency", lambda *a, **k: 0.1)
+
+    saved = {}
+
+    def fake_write(out_dir, summary, timestamp=None):
+        saved["summary"] = summary
+        d = Path(out_dir) / "x"
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert calls == [10, 20]
+    spike_source = saved["summary"]["efficiency"]["sources"]["spike"]
+    assert isinstance(spike_source, list) and len(spike_source) == 2
+
+
 
 def test_debug_flag_sets_log_level(tmp_path, monkeypatch):
     cfg = {

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -304,3 +304,87 @@ def test_baseline_range_iso_strings(tmp_path, monkeypatch, start, end):
     assert summary["baseline"]["n_events"] == 1
     assert captured.get("times") == [6.0]
 
+
+def test_multiple_spike_periods_cli(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "baseline": {"range": [0, 5], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": True,
+            "window_Po214": [7, 9],
+            "hl_Po214": [1.0, 0.0],
+            "eff_Po214": [1.0, 0.0],
+            "flags": {},
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1, 2, 3, 4, 5],
+        "fBits": [0, 0, 0, 0, 0],
+        "timestamp": [0.0, 2.0, 4.0, 6.0, 8.0],
+        "adc": [8.0] * 5,
+        "fchannel": [1] * 5,
+    })
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    cal_mock = {
+        "a": (1.0, 0.0),
+        "c": (0.0, 0.0),
+        "sigma_E": (1.0, 0.0),
+        "peaks": {"Po210": {"centroid_adc": 10}},
+    }
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(baseline_noise, "estimate_baseline_noise", lambda *a, **k: (5.0, {}))
+
+    captured = {}
+
+    def fake_fit(ts_dict, t_start, t_end, config):
+        captured["times"] = ts_dict.get("Po214", []).tolist()
+        return {"E_Po214": 1.0}
+
+    monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
+
+    def fake_write(out_dir, summary, timestamp=None):
+        captured["summary"] = summary
+        d = Path(out_dir) / (timestamp or "x")
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+        "--spike-period",
+        "1",
+        "3",
+        "--spike-period",
+        "5",
+        "7",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    summary = captured.get("summary", {})
+    assert summary["baseline"]["n_events"] == 2
+    assert captured.get("times") == [8.0]
+


### PR DESCRIPTION
## Summary
- add `--spike-period` CLI option and related config handling
- remove events inside any `spike_periods`
- allow multiple spike efficiency entries
- document new options in `readme.txt`
- test spike periods and multiple spike efficiencies

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68432d5cd4d8832bab46db5363752287