### PR TITLE
Support multiple spike periods and efficiency lists

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,6 +8,7 @@
         "analysis_start_time": null,
         "analysis_end_time": null,
         "spike_end_time": null,
+        "spike_periods": null,
         "ambient_concentration": null
 
     },

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -538,6 +538,87 @@ def test_assay_efficiency_list(tmp_path, monkeypatch):
     assert "assay_1" in sources and "assay_2" in sources
 
 
+def test_spike_efficiency_list(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "efficiency": {
+            "spike": [
+                {"counts": 10, "activity_bq": 5, "live_time_s": 100, "error": 0.1},
+                {"counts": 20, "activity_bq": 5, "live_time_s": 100, "error": 0.2},
+            ]
+        },
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+
+    import efficiency
+
+    calls = []
+
+    def fake_spike(cnt, act, live):
+        calls.append((cnt, act, live))
+        return 0.05
+
+    recorded = {}
+
+    def fake_blue(vals, errs):
+        recorded["vals"] = list(vals)
+        recorded["errs"] = list(errs)
+        return 0.1, 0.01, np.array([0.5, 0.5])
+
+    monkeypatch.setattr(efficiency, "calc_spike_efficiency", fake_spike)
+    monkeypatch.setattr(efficiency, "calc_assay_efficiency", lambda *a, **k: 0.1)
+    monkeypatch.setattr(efficiency, "calc_decay_efficiency", lambda *a, **k: 0.1)
+    monkeypatch.setattr(efficiency, "blue_combine", fake_blue)
+
+    saved = {}
+
+    def fake_write(out_dir, summary, timestamp=None):
+        saved["summary"] = summary
+        d = Path(out_dir) / "x"
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert len(calls) == 2
+    assert recorded["vals"] == [0.05, 0.05]
+    assert recorded["errs"] == [0.1, 0.2]
+    sources = saved["summary"]["efficiency"]["sources"]
+    assert "spike_1" in sources and "spike_2" in sources
+
+
 def test_debug_flag_sets_log_level(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},
@@ -759,6 +840,81 @@ def test_spike_end_time_cli(tmp_path, monkeypatch):
     analyze.main()
 
     assert captured["times"] == [10.0]
+
+
+def test_spike_period_cli(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": True,
+            "window_Po214": [0.0, 20.0],
+            "hl_Po214": [1.0, 0.0],
+            "eff_Po214": [1.0, 0.0],
+            "flags": {},
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1, 2, 3],
+        "fBits": [0, 0, 0],
+        "timestamp": [0.0, 6.0, 12.0],
+        "adc": [8.0, 8.0, 8.0],
+        "fchannel": [1, 1, 1],
+    })
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+
+    captured = {}
+
+    def fake_fit(ts_dict, t_start, t_end, config):
+        captured["times"] = ts_dict["Po214"].tolist()
+        return {}
+
+    monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
+
+    saved = {}
+
+    def fake_write(out_dir, summary, timestamp=None):
+        saved["summary"] = summary
+        d = Path(out_dir) / "x"
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+        "--spike-period",
+        "0",
+        "5",
+        "--spike-period",
+        "10",
+        "13",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert captured["times"] == [6.0]
+    assert saved["summary"]["analysis"]["spike_periods"] == [["0", "5"], ["10", "13"]]
 
 
 def test_seed_cli_sets_random_seed(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add `--spike-period` CLI option
- allow multiple spike windows and record them in `summary.json`
- support list entries for `efficiency.spike`
- document new features in `readme.txt`
- update default `config.json`
- test spike-period filtering and spike efficiency lists

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f9d8aa9c832b974e77f349563b63