### PR TITLE
Ensure pandas timestamp parsing uses UTC

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -367,7 +367,9 @@ def main():
     # Ensure “timestamp” column is float‐seconds since epoch
     # If user provided ISO‐strings, convert to epoch:
     if events["timestamp"].dtype == object:
-        events["timestamp"] = pd.to_datetime(events["timestamp"]).astype(np.int64) / 1e9
+        events["timestamp"] = (
+            pd.to_datetime(events["timestamp"], utc=True).astype(np.int64) / 1e9
+        )
 
     events["timestamp"] = events["timestamp"].astype(float)
 


### PR DESCRIPTION
## Summary
- fix `pd.to_datetime` call in `analyze.py` so ISO timestamps are read as UTC

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684390b7f908832b9487e81bda37e64b