### PR TITLE
Return numpy array from adc shift

### DIFF
--- a/systematics.py
+++ b/systematics.py
@@ -1,4 +1,5 @@
 import math
+import numpy as np
 from typing import Callable, Dict, Tuple, List
 
 
@@ -31,7 +32,10 @@ def apply_linear_adc_shift(adc_values, timestamps, rate, t_ref=None):
     if t_ref is None:
         t_ref = float(time_arr[0]) if len(time_arr) else 0.0
 
-    return [a + rate * (t - t_ref) for a, t in zip(adc_arr, time_arr)]
+    return np.array(
+        [a + rate * (t - t_ref) for a, t in zip(adc_arr, time_arr)],
+        dtype=float,
+    )
 
 
 def scan_systematics(

--- a/tests/test_adc_drift.py
+++ b/tests/test_adc_drift.py
@@ -75,6 +75,7 @@ def test_adc_drift_applied(tmp_path, monkeypatch):
     analyze.main()
 
     assert captured.get("shift_called") is True
+    assert isinstance(captured.get("cal_adc"), np.ndarray)
     assert np.allclose(captured.get("cal_adc"), np.array([15, 15, 15]))
     assert captured["summary"].get("adc_drift_rate") == 1.0
 
@@ -120,5 +121,6 @@ def test_adc_drift_zero_noop(tmp_path, monkeypatch):
     analyze.main()
 
     assert captured.get("called") is None
+    assert isinstance(captured.get("cal_adc"), np.ndarray)
     assert np.allclose(captured.get("cal_adc"), np.array([10, 10, 10]))
     assert captured["summary"].get("adc_drift_rate") == 0.0

--- a/tests/test_systematics.py
+++ b/tests/test_systematics.py
@@ -33,6 +33,7 @@ def test_apply_linear_adc_shift_noop():
     adc = np.array([100, 101, 102])
     t = np.array([0.0, 1.0, 2.0])
     out = apply_linear_adc_shift(adc, t, 0.0)
+    assert isinstance(out, np.ndarray)
     assert np.allclose(out, adc)
 
 
@@ -40,6 +41,7 @@ def test_apply_linear_adc_shift_rate():
     adc = np.zeros(3)
     t = np.array([0.0, 1.0, 2.0])
     out = apply_linear_adc_shift(adc, t, 1.0)
+    assert isinstance(out, np.ndarray)
     assert np.allclose(out, [0.0, 1.0, 2.0])
 
 


### PR DESCRIPTION
## Summary
- ensure systematics module returns numpy array from `apply_linear_adc_shift`
- validate output type in adc drift/systematics tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684390b731a0832bbc0fb8274afc3154