### PR TITLE
Add half-life validation to radon activity functions

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -156,6 +156,9 @@ def radon_activity_curve(
     """
     import numpy as np
 
+    if half_life_s <= 0:
+        raise ValueError("half_life_s must be positive")
+
     t = np.asarray(times, dtype=float)
     lam = math.log(2.0) / float(half_life_s)
     exp_term = np.exp(-lam * t)
@@ -182,6 +185,9 @@ def radon_delta(
     Parameters are identical to :func:`radon_activity_curve` with ``t_start``
     and ``t_end`` specifying the relative times in seconds.
     """
+
+    if half_life_s <= 0:
+        raise ValueError("half_life_s must be positive")
 
     lam = math.log(2.0) / float(half_life_s)
     exp1 = math.exp(-lam * float(t_start))

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -188,3 +188,17 @@ def test_radon_delta():
     var = ((exp1 - exp2) * dE) ** 2 + ((lam * (exp2 - exp1)) * dN0) ** 2
     assert delta == pytest.approx(expected)
     assert sigma == pytest.approx(math.sqrt(var))
+
+
+def test_radon_activity_curve_invalid_half_life():
+    with pytest.raises(ValueError):
+        radon_activity_curve([0.0, 1.0], 1.0, 0.1, 2.0, 0.2, 0.0)
+    with pytest.raises(ValueError):
+        radon_activity_curve([0.0, 1.0], 1.0, 0.1, 2.0, 0.2, -5.0)
+
+
+def test_radon_delta_invalid_half_life():
+    with pytest.raises(ValueError):
+        radon_delta(0.0, 2.0, 1.0, 0.1, 2.0, 0.2, 0.0)
+    with pytest.raises(ValueError):
+        radon_delta(0.0, 2.0, 1.0, 0.1, 2.0, 0.2, -5.0)


### PR DESCRIPTION
## Summary
- validate `half_life_s` in `radon_activity_curve` and `radon_delta`
- add unit tests for invalid half-life values

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843975682a0832ba3a13f2bf27764d7