### PR TITLE
Add safety check for err_bq in radon calculations

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -96,8 +96,8 @@ def compute_total_radon(
     """Convert activity into concentration and total radon in the sample volume.
 
     Both ``monitor_volume`` and ``sample_volume`` must be non-negative.  A
-    ``ValueError`` is raised if ``monitor_volume`` is not positive or if
-    ``sample_volume`` is negative.
+    ``ValueError`` is raised if ``monitor_volume`` is not positive, if
+    ``sample_volume`` is negative, or if ``err_bq`` is negative.
 
     Returns
     -------
@@ -114,6 +114,8 @@ def compute_total_radon(
         raise ValueError("monitor_volume must be positive")
     if sample_volume < 0:
         raise ValueError("sample_volume must be non-negative")
+    if err_bq < 0:
+        raise ValueError("err_bq must be non-negative")
     conc = activity_bq / monitor_volume
     sigma_conc = err_bq / monitor_volume
 

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -153,6 +153,11 @@ def test_compute_total_radon_negative_sample_volume():
         compute_total_radon(5.0, 0.5, 10.0, -1.0)
 
 
+def test_compute_total_radon_negative_err_bq():
+    with pytest.raises(ValueError):
+        compute_total_radon(5.0, -0.1, 10.0, 1.0)
+
+
 
 def test_radon_activity_curve():
     times = [0.0, 1.0]


### PR DESCRIPTION
## Summary
- validate `err_bq` in `compute_total_radon`
- test negative uncertainty handling in `compute_total_radon`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684396d5f28c832bb224b6a546c75c2e