### PR TITLE
Add identical centroid check to calibration

### DIFF
--- a/calibration.py
+++ b/calibration.py
@@ -37,6 +37,8 @@ def two_point_calibration(adc_centroids, energies):
     """
     x1, x2 = adc_centroids
     E1, E2 = energies
+    if x1 == x2:
+        raise ValueError("ADC centroids must be distinct for calibration")
     a = (E2 - E1) / (x2 - x1)
     c = E1 - a * x1
     return float(a), float(c)

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -20,6 +20,11 @@ def test_two_point_calibration():
     assert pytest.approx(m * 2000 + c, rel=1e-3) == 7.69
 
 
+def test_two_point_calibration_identical_centroids_error():
+    with pytest.raises(ValueError):
+        two_point_calibration([1000, 1000], [5.3, 7.7])
+
+
 def test_apply_calibration():
     slope, intercept = 0.005, 0.02
     adc_vals = np.array([0, 100, 200])


### PR DESCRIPTION
## Summary
- guard against identical ADC centroids in `two_point_calibration`
- test the error behaviour when centroids are the same

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684396d79f00832bb771c32cca5d6a72