### PR TITLE
Add check for negative decay rate

### DIFF
--- a/efficiency.py
+++ b/efficiency.py
@@ -74,6 +74,8 @@ def calc_decay_efficiency(observed_rate_cps: float, expected_rate_cps: float) ->
     """
     if expected_rate_cps <= 0:
         raise ValueError("expected_rate_cps must be positive")
+    if observed_rate_cps < 0:
+        raise ValueError("observed_rate_cps cannot be negative")
     return float(observed_rate_cps) / float(expected_rate_cps)
 
 

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -27,6 +27,11 @@ def test_calc_decay_efficiency():
     assert eff == pytest.approx(0.9)
 
 
+def test_calc_decay_efficiency_negative_observed():
+    with pytest.raises(ValueError):
+        calc_decay_efficiency(-0.1, 1.0)
+
+
 def test_blue_combine_uncorrelated():
     vals = np.array([0.4, 0.5, 0.6])
     errs = np.array([0.1, 0.2, 0.1])


### PR DESCRIPTION
## Summary
- validate `calc_decay_efficiency` inputs
- test that negative observed rates raise `ValueError`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684396d8f040832b8ba56fa3f8c6cfcc