### PR TITLE
Validate half-life input

### DIFF
--- a/fitting.py
+++ b/fitting.py
@@ -370,6 +370,8 @@ def fit_time_series(times_dict, t_start, t_end, config, weights=None):
     for iso in iso_list:
         iso_cfg = config["isotopes"][iso]
         hl = float(iso_cfg["half_life_s"])
+        if hl <= 0:
+            raise ValueError("half_life_s must be positive")
         lam_map[iso] = np.log(2.0) / hl
         eff_map[iso] = float(iso_cfg.get("efficiency", 1.0))
         fix_b_map[iso] = not bool(config.get("fit_background", False))

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -310,3 +310,25 @@ def test_fit_time_series_covariance_checks(monkeypatch):
     monkeypatch.setattr(linalg, "eigvals", bad_eigvals)
     res_bad = fit_time_series(times_dict, 0.0, T, cfg)
     assert not res_bad["fit_valid"]
+
+
+def test_fit_time_series_half_life_zero_raises():
+    times_dict = {"Po214": np.array([0.0, 1.0])}
+    cfg = {
+        "isotopes": {"Po214": {"half_life_s": 0.0, "efficiency": 1.0}},
+        "fit_background": True,
+        "fit_initial": True,
+    }
+    with pytest.raises(ValueError):
+        fit_time_series(times_dict, 0.0, 10.0, cfg)
+
+
+def test_fit_time_series_half_life_negative_raises():
+    times_dict = {"Po214": np.array([0.0, 1.0])}
+    cfg = {
+        "isotopes": {"Po214": {"half_life_s": -1.0, "efficiency": 1.0}},
+        "fit_background": True,
+        "fit_initial": True,
+    }
+    with pytest.raises(ValueError):
+        fit_time_series(times_dict, 0.0, 10.0, cfg)


### PR DESCRIPTION
## Summary
- validate half-life in `fit_time_series`
- test that invalid half-lives raise `ValueError`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68439a095154832b97d67afe6d3127c0