### PR TITLE
Add half-life validation to plot_time_series

### DIFF
--- a/plot_utils.py
+++ b/plot_utils.py
@@ -66,6 +66,11 @@ def plot_time_series(
         else float(config.get("hl_Po218", [PO218_HALF_LIFE_S])[0])
     )
 
+    if po214_hl <= 0:
+        raise ValueError("hl_Po214 must be positive")
+    if po218_hl <= 0:
+        raise ValueError("hl_Po218 must be positive")
+
     iso_params = {
         "Po214": {
             "window": _cfg_get(config, "window_Po214"),

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -1,6 +1,7 @@
 import numpy as np
 import sys
 from pathlib import Path
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from plot_utils import plot_time_series, plot_spectrum
@@ -157,6 +158,36 @@ def test_plot_time_series_custom_half_life_po218(tmp_path, monkeypatch):
     centers = np.array([0.5, 1.5, 2.5])
     expected = 0.1 * (1.0 - np.exp(-lam * centers))
     assert np.allclose(captured.get("y"), expected, rtol=1e-4)
+
+
+def test_plot_time_series_invalid_half_life_po214(tmp_path):
+    cfg = basic_config()
+    cfg["hl_Po214"] = [0.0]
+    with pytest.raises(ValueError):
+        plot_time_series(
+            np.array([1000.1]),
+            np.array([7.7]),
+            None,
+            1000.0,
+            1001.0,
+            cfg,
+            str(tmp_path / "ts_bad214.png"),
+        )
+
+
+def test_plot_time_series_invalid_half_life_po218(tmp_path):
+    cfg = basic_config()
+    cfg.update({"window_Po218": [5.8, 6.3], "eff_Po218": [1.0], "hl_Po218": [-2.0]})
+    with pytest.raises(ValueError):
+        plot_time_series(
+            np.array([1000.1]),
+            np.array([6.0]),
+            None,
+            1000.0,
+            1001.0,
+            cfg,
+            str(tmp_path / "ts_bad218.png"),
+        )
 
 
 def test_plot_time_series_line_style(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- validate Po-214 and Po-218 half-lives in `plot_time_series`
- raise `ValueError` when a half-life is non-positive
- add tests for invalid half-life values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68439a0b0df0832bbbfa6b5a52df2a79