### PR TITLE
Update spectral-fit docs about emg stability

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -227,6 +227,9 @@ fit.  Important keys include:
 - `expected_peaks` – approximate ADC centroids used to locate the
   Po‑210, Po‑218 and Po‑214 peaks before fitting. The default is
   `{"Po210": 1250, "Po218": 1400, "Po214": 1800}`.
+- `emg_left` evaluations are wrapped in `np.errstate` and passed through
+  `np.nan_to_num` for stability so that NaN or infinite values never
+  reach `curve_fit`.
 
 Example snippet:
 


### PR DESCRIPTION
## Summary
- document `emg_left` stability handling in `readme.txt`

## Testing
- `scripts/setup_tests.sh`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6843bfc9d470832bafaabf1cb30de530