### PR TITLE
Refactor tau constant

### DIFF
--- a/calibration.py
+++ b/calibration.py
@@ -2,6 +2,7 @@ import numpy as np
 from scipy.signal import find_peaks
 from scipy.optimize import curve_fit
 from scipy.stats import exponnorm
+from constants import _TAU_MIN
 
 # Limit for stable exponentiation when evaluating the EMG tail. Values
 # beyond ~700 in magnitude overflow in IEEE-754 doubles.  Match the
@@ -149,7 +150,7 @@ def calibrate_run(adc_values, config, hist_bins=None):
         sigma0 = config["calibration"]["init_sigma_adc"]
         tau_cfg = config["calibration"].get("init_tau_adc", 0.0)
         # Avoid zero or negative starting tau which can cause numerical issues
-        tau0 = max(tau_cfg, 1e-6) if use_emg else 0.0
+        tau0 = max(tau_cfg, _TAU_MIN) if use_emg else 0.0
 
         if use_emg and iso in ("Po210", "Po218"):
             # Fit EMG: parameters [amp, mu, sigma, tau]
@@ -158,7 +159,7 @@ def calibrate_run(adc_values, config, hist_bins=None):
 
             p0 = [amp0, mu0, sigma0, tau0]
             bounds = (
-                [0, mu0 - window, 1e-3, 1e-6],  # lower bounds
+                [0, mu0 - window, 1e-3, _TAU_MIN],  # lower bounds
                 [np.inf, mu0 + window, 50.0, 200.0],  # upper bounds (tunable)
             )
             popt, pcov = curve_fit(

--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,7 @@
+# constants.py
+"""Shared constants for analysis modules."""
+
+# Minimum allowed value for the exponential tail constant used in EMG fits.
+_TAU_MIN = 1e-6
+
+__all__ = ["_TAU_MIN"]

--- a/fitting.py
+++ b/fitting.py
@@ -7,6 +7,7 @@ import numpy as np
 from iminuit import Minuit
 from scipy.optimize import curve_fit
 from calibration import emg_left, gaussian
+from constants import _TAU_MIN
 
 # Prevent overflow in exp calculations. Values beyond ~700 in magnitude
 # lead to inf/0 under IEEE-754 doubles.  Clip the exponent to a safe range
@@ -14,9 +15,8 @@ from calibration import emg_left, gaussian
 _EXP_LIMIT = 700.0
 
 # Minimum allowed value for the exponential tail constant to avoid
-# divide-by-zero overflow when evaluating the EMG component.
-_TAU_MIN = 1e-6
-
+# divide-by-zero overflow when evaluating the EMG component. The
+# value itself lives in :mod:`constants` as ``_TAU_MIN``.
 
 def _safe_exp(x):
     """Return ``exp(x)`` with the input clipped to ``[-_EXP_LIMIT, _EXP_LIMIT]``."""


### PR DESCRIPTION
## Summary
- centralize `_TAU_MIN` constant in new `constants.py`
- import `_TAU_MIN` in `fitting` and `calibration`
- use the shared constant instead of literal values

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843bfc69514832ba36ca9e0e311c5f4