### PR TITLE
Improve covariance handling in time-series fit

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -86,6 +86,12 @@ When using ``compute_radon_activity`` you should pass the fitted rates
 directly. They already represent activities in Bq and no additional
 division by the detection efficiency is required.
 
+The time-series fit checks whether the covariance matrix returned by
+Minuit is positive definite.  If not, a tiny diagonal jitter is added
+before repeating the check.  When even the jittered matrix fails this
+test the result still contains the fitted values but ``fit_valid`` is set
+to ``False``.
+
 ## Configuration
 
 `nominal_adc` under the `calibration` section sets the expected raw ADC

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -319,8 +319,6 @@ def test_fit_time_series_covariance_checks(monkeypatch):
 
     import numpy.linalg as linalg
 
-    orig_eig = linalg.eigvals
-
     def good_eigvals(x):
         return np.ones(x.shape[0])
 
@@ -333,7 +331,11 @@ def test_fit_time_series_covariance_checks(monkeypatch):
         vals[0] = -1.0
         return vals
 
+    def cholesky_fail(x):
+        raise linalg.LinAlgError("not PD")
+
     monkeypatch.setattr(linalg, "eigvals", bad_eigvals)
+    monkeypatch.setattr(linalg, "cholesky", cholesky_fail)
     res_bad = fit_time_series(times_dict, 0.0, T, cfg)
     assert not res_bad["fit_valid"]
 


### PR DESCRIPTION
## Summary
- improve covariance checks and jitter logic in `fit_time_series`
- document `fit_valid` behaviour when covariance is not positive definite
- update test to match new jitter behaviour

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c193d644832b89fdc9aa62587480