### PR TITLE
Add Po214 radon activity plots

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1294,6 +1294,13 @@ def main():
             dN0 = fit.get("dN0_Po214", 0.0)
             hl = cfg.get("time_fit", {}).get("hl_Po214", [328320])[0]
             A214, dA214 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl)
+            plot_radon_activity(
+                times,
+                A214,
+                dA214,
+                os.path.join(out_dir, "radon_activity_po214.png"),
+                config=cfg.get("plotting", {}),
+            )
 
         A218 = dA218 = None
         if "Po218" in time_fit_results:
@@ -1393,6 +1400,15 @@ def main():
                 os.path.join(out_dir, "equivalent_air.png"),
                 config=cfg.get("plotting", {}),
             )
+            if A214 is not None:
+                plot_equivalent_air(
+                    times,
+                    A214 / ambient_interp,
+                    dA214 / ambient_interp,
+                    None,
+                    os.path.join(out_dir, "equivalent_air_po214.png"),
+                    config=cfg.get("plotting", {}),
+                )
         elif ambient:
             vol_arr = activity_arr / float(ambient)
             vol_err = err_arr / float(ambient)
@@ -1404,6 +1420,15 @@ def main():
                 os.path.join(out_dir, "equivalent_air.png"),
                 config=cfg.get("plotting", {}),
             )
+            if A214 is not None:
+                plot_equivalent_air(
+                    times,
+                    A214 / float(ambient),
+                    dA214 / float(ambient),
+                    float(ambient),
+                    os.path.join(out_dir, "equivalent_air_po214.png"),
+                    config=cfg.get("plotting", {}),
+                )
     except Exception as e:
         print(f"WARNING: Could not create radon activity plots -> {e}")
 

--- a/readme.txt
+++ b/readme.txt
@@ -370,6 +370,9 @@ activity versus time.  When either `--ambient-file` or
 `--ambient-concentration` is supplied an additional plot
 `equivalent_air.png` shows the volume of ambient air containing the same
 activity.
+The Po‑214 activity alone is plotted in `radon_activity_po214.png`. When
+ambient concentration data are available, `equivalent_air_po214.png`
+shows the equivalent air volume derived from this Po‑214 activity.
 
 ## Efficiency Calculations
 

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -505,3 +505,29 @@ def test_plot_radon_trend_output(tmp_path):
 
     assert out_png.exists()
 
+
+def test_plot_radon_activity_po214(tmp_path):
+    times = [0.0, 1.0, 2.0]
+    activity = [1.0, 2.0, 3.0]
+    errors = [0.1, 0.2, 0.3]
+    out_png = tmp_path / "radon_activity_po214.png"
+
+    from plot_utils import plot_radon_activity
+
+    plot_radon_activity(times, activity, errors, str(out_png))
+
+    assert out_png.exists()
+
+
+def test_plot_equivalent_air_po214(tmp_path):
+    times = [0.0, 1.0, 2.0]
+    volumes = [0.1, 0.2, 0.3]
+    errors = [0.01, 0.02, 0.03]
+    out_png = tmp_path / "equivalent_air_po214.png"
+
+    from plot_utils import plot_equivalent_air
+
+    plot_equivalent_air(times, volumes, errors, 5.0, str(out_png))
+
+    assert out_png.exists()
+


### PR DESCRIPTION
## Summary
- plot Po-214 activity curve in `radon_activity_po214.png`
- when ambient data exist, plot Po-214 equivalent air volume
- document new plots in the README
- test that the new output filenames are produced

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c416aab0832b8181b111bf05cc30