### PR TITLE
Use ISO timestamps in config and tests

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,17 +5,17 @@
     },
     "analysis": {
 
-        "analysis_start_time": null,
-        "analysis_end_time": null,
-        "spike_end_time": null,
-        "spike_periods": null,
-        "run_periods": null,
-        "radon_interval": null,
+        "analysis_start_time": "1970-01-01T00:00:00Z",
+        "analysis_end_time": "1970-01-01T06:00:00Z",
+        "spike_end_time": "1970-01-01T00:10:00Z",
+        "spike_periods": [["1970-01-01T01:00:00Z", "1970-01-01T02:00:00Z"]],
+        "run_periods": [["1970-01-01T02:00:00Z", "1970-01-01T05:00:00Z"]],
+        "radon_interval": ["1970-01-01T03:00:00Z", "1970-01-01T04:00:00Z"],
         "ambient_concentration": null
 
     },
     "baseline": {
-        "range": null,
+        "range": ["1970-01-01T00:00:00Z", "1970-01-01T00:05:00Z"],
         "monitor_volume_l": 605.0,
         "sample_volume_l": 0.0
     },

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,11 @@ time origin for decay fitting and time-series plots.  Provide an
 ISO‑8601 string such as `"2020-01-01T00:00:00Z"`.  When omitted the first
 event timestamp is used.
 
+All other time-related fields (`analysis_end_time`, `spike_end_time`,
+`spike_periods`, `run_periods`, `radon_interval` and
+`baseline.range`) likewise accept absolute timestamps in ISO 8601
+format.
+
 `analysis_end_time` may be specified to stop processing after the given
 timestamp while `spike_end_time` discards all events before its value.
 `spike_periods` holds a list of `[start, end]` pairs where events are

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -775,7 +775,7 @@ def test_analysis_end_time_cli(tmp_path, monkeypatch):
         "--output_dir",
         str(tmp_path),
         "--analysis-end-time",
-        "5",
+        "1970-01-01T00:00:05Z",
     ]
     monkeypatch.setattr(sys, "argv", args)
     analyze.main()
@@ -834,7 +834,7 @@ def test_spike_end_time_cli(tmp_path, monkeypatch):
         "--output_dir",
         str(tmp_path),
         "--spike-end-time",
-        "5",
+        "1970-01-01T00:00:05Z",
     ]
     monkeypatch.setattr(sys, "argv", args)
     analyze.main()
@@ -904,17 +904,20 @@ def test_spike_period_cli(tmp_path, monkeypatch):
         "--output_dir",
         str(tmp_path),
         "--spike-period",
-        "0",
-        "5",
+        "1970-01-01T00:00:00Z",
+        "1970-01-01T00:00:05Z",
         "--spike-period",
-        "10",
-        "13",
+        "1970-01-01T00:00:10Z",
+        "1970-01-01T00:00:13Z",
     ]
     monkeypatch.setattr(sys, "argv", args)
     analyze.main()
 
     assert captured["times"] == [6.0]
-    assert saved["summary"]["analysis"]["spike_periods"] == [["0", "5"], ["10", "13"]]
+    assert saved["summary"]["analysis"]["spike_periods"] == [
+        ["1970-01-01T00:00:00Z", "1970-01-01T00:00:05Z"],
+        ["1970-01-01T00:00:10Z", "1970-01-01T00:00:13Z"],
+    ]
 
 
 def test_seed_cli_sets_random_seed(tmp_path, monkeypatch):

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -12,7 +12,7 @@ import baseline_noise
 def test_time_window_filters_events(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},
-        "baseline": {"range": [0, 5], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "baseline": {"range": ["1970-01-01T00:00:00Z", "1970-01-01T00:00:05Z"], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
         "calibration": {},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
@@ -79,9 +79,9 @@ def test_time_window_filters_events(tmp_path, monkeypatch):
         "--output_dir",
         str(tmp_path),
         "--analysis-end-time",
-        "6",
+        "1970-01-01T00:00:06Z",
         "--spike-end-time",
-        "1",
+        "1970-01-01T00:00:01Z",
     ]
     monkeypatch.setattr(sys, "argv", args)
     analyze.main()
@@ -94,7 +94,7 @@ def test_time_window_filters_events(tmp_path, monkeypatch):
 def test_invalid_baseline_range_raises(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},
-        "baseline": {"range": [5, 2], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "baseline": {"range": ["1970-01-01T00:00:05Z", "1970-01-01T00:00:02Z"], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
         "calibration": {},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
@@ -143,8 +143,8 @@ def test_invalid_baseline_range_raises(tmp_path, monkeypatch):
 def test_time_window_filters_events_config(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},
-        "baseline": {"range": [0, 5], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
-        "analysis": {"analysis_end_time": 6, "spike_end_time": 1},
+        "baseline": {"range": ["1970-01-01T00:00:00Z", "1970-01-01T00:00:05Z"], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "analysis": {"analysis_end_time": "1970-01-01T00:00:06Z", "spike_end_time": "1970-01-01T00:00:01Z"},
         "calibration": {},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
@@ -222,8 +222,8 @@ def test_time_window_filters_events_config(tmp_path, monkeypatch):
 def test_run_period_filters_events(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},
-        "baseline": {"range": [0, 1], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
-        "analysis": {"run_periods": [[1, 6]]},
+        "baseline": {"range": ["1970-01-01T00:00:00Z", "1970-01-01T00:00:01Z"], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "analysis": {"run_periods": [["1970-01-01T00:00:01Z", "1970-01-01T00:00:06Z"]]},
         "calibration": {},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
@@ -309,7 +309,7 @@ def test_baseline_range_iso_strings(tmp_path, monkeypatch, start, end):
     cfg = {
         "pipeline": {"log_level": "INFO"},
         "baseline": {"range": [start, end], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
-        "analysis": {"analysis_end_time": 6, "spike_end_time": 1},
+        "analysis": {"analysis_end_time": "1970-01-01T00:00:06Z", "spike_end_time": "1970-01-01T00:00:01Z"},
         "calibration": {},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {


### PR DESCRIPTION
## Summary
- show ISO8601 defaults for time settings in `config.json`
- note that all time related options accept ISO timestamps in README
- update tests to use ISO timestamp strings

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c4158930832b8bb4585972c2a07f