### PR TITLE
Fix noise cutoff parsing

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -407,8 +407,8 @@ def main():
         try:
             thr_val = int(noise_thr)
             events = events[events["adc"] > thr_val].reset_index(drop=True)
-        except Exception:
-            pass
+        except ValueError:
+            logging.warning(f"Invalid noise_cutoff '{noise_thr}' ignored")
 
     # Optional burst filter to remove high-rate clusters
     burst_mode = (


### PR DESCRIPTION
## Summary
- handle invalid noise_cutoff more safely
- log a warning when noise_cutoff can't be parsed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849140d04f8832bb24d24de5f73e771