### PR TITLE
Add noise cutoff CLI override

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -203,6 +203,11 @@ def parse_args():
         help="Apply a linear ADC drift correction with the given slope",
     )
     p.add_argument(
+        "--noise-cutoff",
+        type=int,
+        help="ADC threshold for the noise cut (overrides calibration.noise_cutoff)",
+    )
+    p.add_argument(
         "--settle-s",
         type=float,
         help="Discard events occurring this many seconds after the start",
@@ -351,6 +356,9 @@ def main():
 
     if args.slope is not None:
         cfg.setdefault("systematics", {})["adc_drift_rate"] = float(args.slope)
+
+    if args.noise_cutoff is not None:
+        cfg.setdefault("calibration", {})["noise_cutoff"] = int(args.noise_cutoff)
 
     if args.debug:
         cfg.setdefault("pipeline", {})["log_level"] = "DEBUG"

--- a/readme.txt
+++ b/readme.txt
@@ -29,6 +29,7 @@ python analyze.py --config config.json --input merged_data.csv \
     [--output_dir results] [--job-id MYRUN] \
     [--efficiency-json eff.json] [--systematics-json syst.json] \
     [--spike-count N --spike-count-err S] [--slope RATE] \
+    [--noise-cutoff N] \
     [--analysis-end-time ISO --spike-end-time ISO] \
     [--spike-period START END] [--run-period START END] \
     [--radon-interval START END] \

--- a/tests/test_noise_cut.py
+++ b/tests/test_noise_cut.py
@@ -1,0 +1,77 @@
+import json
+import sys
+from pathlib import Path
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+
+
+def test_noise_cutoff_cli_overrides(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {"noise_cutoff": 100},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": True,
+            "window_Po214": [0, 20],
+            "hl_Po214": [1.0, 0.0],
+            "eff_Po214": [1.0, 0.0],
+            "flags": {},
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1, 2],
+        "fBits": [0, 0],
+        "timestamp": [1.0, 2.0],
+        "adc": [3, 9],
+        "fchannel": [1, 1],
+    })
+    data_path = tmp_path / "data.csv"
+    df.to_csv(data_path, index=False)
+
+    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {}}
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "apply_burst_filter", lambda df, cfg, mode="rate": (df, 0))
+
+    captured = {}
+
+    def fake_fit(ts_dict, t_start, t_end, cfg, weights=None):
+        captured["times"] = ts_dict.get("Po214", []).tolist()
+        return {"E_Po214": 1.0}
+
+    monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
+
+    def fake_write(out_dir, summary, timestamp=None):
+        captured["summary"] = summary
+        d = Path(out_dir) / (timestamp or "x")
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config", str(cfg_path),
+        "--input", str(data_path),
+        "--output_dir", str(tmp_path),
+        "--noise-cutoff", "5",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert captured.get("times") == [2.0]
+    assert captured["summary"]["noise_cut"]["removed_events"] == 1
+


### PR DESCRIPTION
## Summary
- expose `--noise-cutoff` CLI argument in `analyze.py`
- allow CLI to override `calibration.noise_cutoff` in configuration
- update README usage to document the new option
- add unit test verifying CLI override

## Testing
- `pytest -q` *(fails: Package 'numpy' is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_684921989e14832bbba822abeb32225d