### PR TITLE
Add plot color palettes

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -253,6 +253,10 @@ def parse_args():
         type=int,
         help="Override random seed used by analysis algorithms",
     )
+    p.add_argument(
+        "--palette",
+        help="Color palette for plots (overrides plotting.palette)",
+    )
     return p.parse_args()
 
 
@@ -354,6 +358,9 @@ def main():
 
     if args.debug:
         cfg.setdefault("pipeline", {})["log_level"] = "DEBUG"
+
+    if args.palette:
+        cfg.setdefault("plotting", {})["palette"] = args.palette
 
     # Configure logging as early as possible
     log_level = cfg.get("pipeline", {}).get("log_level", "INFO")
@@ -1336,6 +1343,7 @@ def main():
             efficiency_bar(
                 efficiency_results,
                 os.path.join(out_dir, "efficiency.png"),
+                config=cfg.get("plotting", {}),
             )
         except Exception as e:
             print(f"WARNING: Could not create efficiency plots -> {e}")

--- a/color_schemes.py
+++ b/color_schemes.py
@@ -1,0 +1,35 @@
+# Color palettes for plotting
+# Each scheme maps element names to matplotlib color names.
+
+COLOR_SCHEMES = {
+    "default": {
+        "Po214": "tab:red",
+        "Po218": "tab:blue",
+        "Po210": "tab:green",
+        "radon_activity": "tab:purple",
+        "equivalent_air": "tab:green",
+        "efficiency_bar": "tab:blue",
+        "fit": "red",
+        "hist": "gray",
+    },
+    "colorblind": {
+        "Po214": "#D55E00",  # orange-red
+        "Po218": "#0072B2",  # blue
+        "Po210": "#009E73",  # green
+        "radon_activity": "#CC79A7",
+        "equivalent_air": "#009E73",
+        "efficiency_bar": "#0072B2",
+        "fit": "#D55E00",
+        "hist": "gray",
+    },
+    "grayscale": {
+        "Po214": "black",
+        "Po218": "dimgray",
+        "Po210": "gray",
+        "radon_activity": "black",
+        "equivalent_air": "gray",
+        "efficiency_bar": "dimgray",
+        "fit": "black",
+        "hist": "lightgray",
+    },
+}

--- a/plot_utils.py
+++ b/plot_utils.py
@@ -7,6 +7,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 from datetime import datetime
+from color_schemes import COLOR_SCHEMES
 
 # Half-life constants used for the time-series overlay [seconds]
 PO214_HALF_LIFE_S = 1.64e-4  # 164 µs
@@ -146,7 +147,13 @@ def plot_time_series(
 
     # 2) Plot each isotope s histogram + overlay the model:
     plt.figure(figsize=(8, 6))
-    colors = {"Po214": "tab:red", "Po218": "tab:blue", "Po210": "tab:green"}
+    palette_name = str(config.get("palette", "default"))
+    palette = COLOR_SCHEMES.get(palette_name, COLOR_SCHEMES["default"])
+    colors = {
+        "Po214": palette.get("Po214", "tab:red"),
+        "Po218": palette.get("Po218", "tab:blue"),
+        "Po210": palette.get("Po210", "tab:green"),
+    }
 
     for iso in iso_list:
         emin, emax = iso_params[iso]["window"]
@@ -314,7 +321,10 @@ def plot_spectrum(
         fig, ax_main = plt.subplots(figsize=(8, 6))
         ax_res = None
 
-    ax_main.bar(centers, hist, width=width, color="gray", alpha=0.7, label="Data")
+    palette_name = str(config.get("palette", "default")) if config else "default"
+    palette = COLOR_SCHEMES.get(palette_name, COLOR_SCHEMES["default"])
+    hist_color = palette.get("hist", "gray")
+    ax_main.bar(centers, hist, width=width, color=hist_color, alpha=0.7, label="Data")
 
     if fit_vals:
         x = np.linspace(edges[0], edges[-1], 1000)
@@ -327,7 +337,10 @@ def plot_spectrum(
                 mu = fit_vals[mu_key]
                 amp = fit_vals[amp_key]
                 y += amp / (sigma_E * np.sqrt(2 * np.pi)) * np.exp(-0.5 * ((x - mu) / sigma_E) ** 2)
-        ax_main.plot(x, y * width, color="red", lw=2, label="Fit")
+        palette_name = str(config.get("palette", "default")) if config else "default"
+        palette = COLOR_SCHEMES.get(palette_name, COLOR_SCHEMES["default"])
+        fit_color = palette.get("fit", "red")
+        ax_main.plot(x, y * width, color=fit_color, lw=2, label="Fit")
 
         if show_res:
             y_cent = fit_vals.get("b0", 0.0) + fit_vals.get("b1", 0.0) * centers
@@ -346,7 +359,7 @@ def plot_spectrum(
                 centers,
                 residuals,
                 width=width,
-                color="gray",
+                color=hist_color,
                 alpha=0.7,
             )
             ax_res.axhline(0.0, color="black", lw=1)
@@ -388,7 +401,10 @@ def plot_radon_activity(times, activity, errors, out_png, config=None):
     times_dt = mdates.date2num([datetime.utcfromtimestamp(t) for t in times])
 
     plt.figure(figsize=(8, 4))
-    plt.errorbar(times_dt, activity, yerr=errors, fmt="o-", color="tab:purple")
+    palette_name = str(config.get("palette", "default")) if config else "default"
+    palette = COLOR_SCHEMES.get(palette_name, COLOR_SCHEMES["default"])
+    color = palette.get("radon_activity", "tab:purple")
+    plt.errorbar(times_dt, activity, yerr=errors, fmt="o-", color=color)
     plt.xlabel("Time")
     plt.ylabel("Radon Activity (Bq)")
     plt.title("Extrapolated Radon Activity vs. Time")
@@ -432,7 +448,10 @@ def plot_equivalent_air(times, volumes, errors, conc, out_png, config=None):
     times_dt = mdates.date2num([datetime.utcfromtimestamp(t) for t in times])
 
     plt.figure(figsize=(8, 4))
-    plt.errorbar(times_dt, volumes, yerr=errors, fmt="o-", color="tab:green")
+    palette_name = str(config.get("palette", "default")) if config else "default"
+    palette = COLOR_SCHEMES.get(palette_name, COLOR_SCHEMES["default"])
+    color = palette.get("equivalent_air", "tab:green")
+    plt.errorbar(times_dt, volumes, yerr=errors, fmt="o-", color=color)
     plt.xlabel("Time")
     plt.ylabel("Equivalent Air Volume")
     if conc is None:
@@ -489,7 +508,10 @@ def plot_radon_trend(times, activity, out_png, config=None):
     times_dt = mdates.date2num([datetime.utcfromtimestamp(t) for t in times])
 
     plt.figure(figsize=(8, 4))
-    plt.plot(times_dt, activity, "o-", color="tab:purple")
+    palette_name = str(config.get("palette", "default")) if config else "default"
+    palette = COLOR_SCHEMES.get(palette_name, COLOR_SCHEMES["default"])
+    color = palette.get("radon_activity", "tab:purple")
+    plt.plot(times_dt, activity, "o-", color=color)
     plt.xlabel("Time")
     plt.ylabel("Radon Activity (Bq)")
     plt.title("Radon Activity Trend")

--- a/readme.txt
+++ b/readme.txt
@@ -307,6 +307,10 @@ Specifying `window_Po210` (and optional `eff_Po210`) adds a Po‑210
 histogram to the time-series plots. The model curve appears only when
 fit results for Po‑210 are available.
 
+`palette` under `plotting` selects the color scheme used for all plots.
+Available options are `"default"`, `"colorblind"` and `"grayscale"`.
+The command line option `--palette NAME` overrides the configuration.
+
 
 `plot_time_normalise_rate` controls how the y-axis is scaled in the
 time-series plot.  With the default `true` the histogram is normalised to

--- a/visualize.py
+++ b/visualize.py
@@ -1,6 +1,7 @@
 import os
 import numpy as np
 import matplotlib.pyplot as plt
+from color_schemes import COLOR_SCHEMES
 
 __all__ = ["cov_heatmap", "efficiency_bar"]
 
@@ -32,7 +33,7 @@ def cov_heatmap(cov_matrix, out_png, labels=None):
     return corr
 
 
-def efficiency_bar(eff_dict, out_png):
+def efficiency_bar(eff_dict, out_png, config=None):
     """Bar chart of efficiency sources annotated with BLUE weights."""
     sources = eff_dict.get("sources", {})
     names = list(sources.keys())
@@ -47,7 +48,10 @@ def efficiency_bar(eff_dict, out_png):
 
     x = np.arange(len(names))
     plt.figure(figsize=(6, 4))
-    plt.bar(x, values, yerr=errors, capsize=4, color="tab:blue", alpha=0.7)
+    palette_name = str(config.get("palette", "default")) if config else "default"
+    palette = COLOR_SCHEMES.get(palette_name, COLOR_SCHEMES["default"])
+    color = palette.get("efficiency_bar", "tab:blue")
+    plt.bar(x, values, yerr=errors, capsize=4, color=color, alpha=0.7)
     plt.xticks(x, names, rotation=45, ha="right")
     plt.ylabel("Efficiency")
     plt.title("Efficiency Estimates")


### PR DESCRIPTION
## Summary
- add color_schemes.py with default, colorblind, grayscale palettes
- allow analyze.py to set palette via CLI/config
- apply selected palette in plot utilities and visualizations
- document palette usage in `readme.txt`

## Testing
- `bash scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684921439a30832bb952ffe733672324