### PR TITLE
Introduce FitResult dataclass

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -822,7 +822,7 @@ def main():
         # Store plotting inputs (bin_edges now in energy units)
         spec_plot_data = {
             "energies": events["energy_MeV"].values,
-            "fit_vals": spec_fit_out if spectrum_results else None,
+            "fit_vals": spec_fit_out.params if spectrum_results else None,
             "bins": bins,
             "bin_edges": bin_edges,
         }
@@ -1140,8 +1140,8 @@ def main():
 
     for iso, rate in baseline_rates.items():
         fit = time_fit_results.get(iso)
-        if fit and (f"E_{iso}" in fit):
-            fit["E_corrected"] = fit[f"E_{iso}"] - rate * dilution_factor
+        if fit and (f"E_{iso}" in fit.params):
+            fit.params["E_corrected"] = fit.params[f"E_{iso}"] - rate * dilution_factor
 
     if baseline_rates:
         baseline_info["rate_Bq"] = baseline_rates
@@ -1159,14 +1159,16 @@ def main():
     rate214 = None
     err214 = None
     if "Po214" in time_fit_results:
-        rate214 = time_fit_results["Po214"].get("E_corrected", time_fit_results["Po214"].get("E_Po214"))
-        err214 = time_fit_results["Po214"].get("dE_Po214")
+        fit_dict = time_fit_results["Po214"].params
+        rate214 = fit_dict.get("E_corrected", fit_dict.get("E_Po214"))
+        err214 = fit_dict.get("dE_Po214")
 
     rate218 = None
     err218 = None
     if "Po218" in time_fit_results:
-        rate218 = time_fit_results["Po218"].get("E_corrected", time_fit_results["Po218"].get("E_Po218"))
-        err218 = time_fit_results["Po218"].get("dE_Po218")
+        fit_dict = time_fit_results["Po218"].params
+        rate218 = fit_dict.get("E_corrected", fit_dict.get("E_Po218"))
+        err218 = fit_dict.get("dE_Po218")
 
     A_radon, dA_radon = compute_radon_activity(
         rate218, err218, eff_Po218, rate214, err214, eff_Po214
@@ -1199,7 +1201,7 @@ def main():
 
         delta214 = err_delta214 = None
         if "Po214" in time_fit_results:
-            fit = time_fit_results["Po214"]
+            fit = time_fit_results["Po214"].params
             E = fit.get("E_corrected", fit.get("E_Po214"))
             dE = fit.get("dE_Po214", 0.0)
             N0 = fit.get("N0_Po214", 0.0)
@@ -1217,7 +1219,7 @@ def main():
 
         delta218 = err_delta218 = None
         if "Po218" in time_fit_results:
-            fit = time_fit_results["Po218"]
+            fit = time_fit_results["Po218"].params
             E = fit.get("E_corrected", fit.get("E_Po218"))
             dE = fit.get("dE_Po218", 0.0)
             N0 = fit.get("N0_Po218", 0.0)
@@ -1246,12 +1248,25 @@ def main():
     # ────────────────────────────────────────────────────────────
     # 8. Assemble and write out the summary JSON
     # ────────────────────────────────────────────────────────────
+    spec_dict = {}
+    if spectrum_results:
+        spec_dict = dict(spectrum_results.params)
+        spec_dict["cov"] = spectrum_results.cov.tolist()
+        spec_dict["ndf"] = spectrum_results.ndf
+
+    time_fit_serializable = {}
+    for iso, fit in time_fit_results.items():
+        d = dict(fit.params)
+        d["cov"] = fit.cov.tolist()
+        d["ndf"] = fit.ndf
+        time_fit_serializable[iso] = d
+
     summary = {
         "timestamp": now_str,
         "config_used": os.path.basename(args.config),
         "calibration": cal_params,
-        "spectral_fit": spectrum_results,
-        "time_fit": time_fit_results,
+        "spectral_fit": spec_dict,
+        "time_fit": time_fit_serializable,
         "systematics": systematics_results,
         "baseline": baseline_info,
         "radon_results": radon_results,
@@ -1303,13 +1318,16 @@ def main():
                         plot_cfg[f"window_{other_iso}"] = None
                 ts_times = pdata["events_times"]
                 ts_energy = pdata["events_energy"]
-                fit_dict = time_fit_results.get(iso, {})
+                fit_obj = time_fit_results.get(iso)
+                fit_dict = fit_obj.params if fit_obj else {}
             else:
                 ts_times = events["timestamp"].values
                 ts_energy = events["energy_MeV"].values
                 fit_dict = {}
                 for k in ("Po214", "Po218", "Po210"):
-                    fit_dict.update(time_fit_results.get(k, {}))
+                    obj = time_fit_results.get(k)
+                    if obj:
+                        fit_dict.update(obj.params)
             _ = plot_time_series(
                 all_timestamps=ts_times,
                 all_energies=ts_energy,
@@ -1349,7 +1367,7 @@ def main():
 
         A214 = dA214 = None
         if "Po214" in time_fit_results:
-            fit = time_fit_results["Po214"]
+            fit = time_fit_results["Po214"].params
             E = fit.get("E_corrected", fit.get("E_Po214"))
             dE = fit.get("dE_Po214", 0.0)
             N0 = fit.get("N0_Po214", 0.0)
@@ -1366,7 +1384,7 @@ def main():
 
         A218 = dA218 = None
         if "Po218" in time_fit_results:
-            fit = time_fit_results["Po218"]
+            fit = time_fit_results["Po218"].params
             E = fit.get("E_corrected", fit.get("E_Po218"))
             dE = fit.get("dE_Po218", 0.0)
             N0 = fit.get("N0_Po218", 0.0)
@@ -1413,7 +1431,7 @@ def main():
             rel_trend = times_trend - t0_global
             A214_tr = None
             if "Po214" in time_fit_results:
-                fit = time_fit_results["Po214"]
+                fit = time_fit_results["Po214"].params
                 E214 = fit.get("E_corrected", fit.get("E_Po214"))
                 dE214 = fit.get("dE_Po214", 0.0)
                 N0214 = fit.get("N0_Po214", 0.0)
@@ -1422,7 +1440,7 @@ def main():
                 A214_tr, _ = radon_activity_curve(rel_trend, E214, dE214, N0214, dN0214, hl214)
             A218_tr = None
             if "Po218" in time_fit_results:
-                fit = time_fit_results["Po218"]
+                fit = time_fit_results["Po218"].params
                 E218 = fit.get("E_corrected", fit.get("E_Po218"))
                 dE218 = fit.get("dE_Po218", 0.0)
                 N0218 = fit.get("N0_Po218", 0.0)

--- a/tests/test_adc_drift.py
+++ b/tests/test_adc_drift.py
@@ -6,6 +6,8 @@ import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+import numpy as np
+from fitting import FitResult
 
 
 def _write_basic(tmp_path, drift_rate):
@@ -49,7 +51,7 @@ def test_adc_drift_applied(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "apply_linear_adc_shift", fake_shift)
     monkeypatch.setattr(analyze, "derive_calibration_constants", fake_cal)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", fake_cal)
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
 
@@ -95,7 +97,7 @@ def test_adc_drift_zero_noop(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "apply_linear_adc_shift", fake_shift)
     monkeypatch.setattr(analyze, "derive_calibration_constants", fake_cal)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", fake_cal)
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
 

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -7,6 +7,7 @@ import logging
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from fitting import FitResult
 
 
 def test_plot_time_series_receives_merged_config(tmp_path, monkeypatch):
@@ -51,7 +52,7 @@ def test_plot_time_series_receives_merged_config(tmp_path, monkeypatch):
     # Patch heavy functions with no-op versions
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
 
     received = {}
@@ -123,7 +124,7 @@ def test_analysis_start_time_applied(tmp_path, monkeypatch):
 
     def fake_fit_time_series(times_dict, t_start, t_end, config):
         captured["t_start"] = t_start
-        return {}
+        return FitResult({}, np.zeros((0, 0)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit_time_series)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -182,7 +183,7 @@ def test_job_id_overrides_results_folder(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "apply_burst_filter", lambda df, cfg, mode="rate": (df, 0))
@@ -246,7 +247,7 @@ def test_efficiency_json_cli(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
 
@@ -303,7 +304,7 @@ def test_systematics_json_cli(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
 
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {"E":0.0})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({"E":0.0}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -358,7 +359,7 @@ def test_time_bin_cli(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
 
     captured = {}
@@ -422,7 +423,7 @@ def test_po210_time_series_plot_generated(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
 
     outputs = []
@@ -471,7 +472,7 @@ def test_spike_count_cli(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
 
@@ -541,7 +542,7 @@ def test_assay_efficiency_list(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -622,7 +623,7 @@ def test_spike_efficiency_list(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -697,7 +698,7 @@ def test_debug_flag_sets_log_level(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
 
@@ -762,7 +763,7 @@ def test_settle_s_cli(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, config):
         captured["times"] = ts_dict["Po214"].tolist()
-        return {}
+        return FitResult({}, np.zeros((0, 0)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
@@ -821,7 +822,7 @@ def test_analysis_end_time_cli(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, config):
         captured["times"] = ts_dict["Po214"].tolist()
-        return {}
+        return FitResult({}, np.zeros((0, 0)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
@@ -880,7 +881,7 @@ def test_spike_end_time_cli(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, config):
         captured["times"] = ts_dict["Po214"].tolist()
-        return {}
+        return FitResult({}, np.zeros((0, 0)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
@@ -939,7 +940,7 @@ def test_spike_period_cli(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, config):
         captured["times"] = ts_dict["Po214"].tolist()
-        return {}
+        return FitResult({}, np.zeros((0, 0)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
@@ -998,7 +999,7 @@ def test_seed_cli_sets_random_seed(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -1051,7 +1052,7 @@ def test_ambient_concentration_recorded(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -1111,7 +1112,7 @@ def test_ambient_concentration_from_config(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -1177,7 +1178,7 @@ def test_ambient_file_interpolation(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -1258,7 +1259,7 @@ def test_burst_mode_from_config(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "apply_burst_filter", fake_burst)
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -1306,7 +1307,7 @@ def test_burst_mode_micro_config(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "apply_burst_filter", fake_burst)
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -1354,7 +1355,7 @@ def test_burst_mode_cli_overrides(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "apply_burst_filter", fake_burst)
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -1396,7 +1397,7 @@ def test_ambient_concentration_default_none(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -1448,7 +1449,7 @@ def test_ambient_concentration_written_to_summary_file(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -1513,7 +1514,7 @@ def test_spike_periods_null_config(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
 
@@ -1581,7 +1582,7 @@ def test_hl_po214_cli_overrides(tmp_path, monkeypatch):
     def fake_fit(ts_dict, t_start, t_end, config):
         iso = list(ts_dict.keys())[0]
         calls.append((iso, config))
-        return {}
+        return FitResult({}, np.zeros((0, 0)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 

--- a/tests/test_analyze_noise_cutoff.py
+++ b/tests/test_analyze_noise_cutoff.py
@@ -5,6 +5,8 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+import numpy as np
+from fitting import FitResult
 
 
 def test_analyze_noise_cutoff(tmp_path, monkeypatch):
@@ -55,7 +57,7 @@ def test_analyze_noise_cutoff(tmp_path, monkeypatch):
 
     def fake_fit_time_series(times_dict, t_start, t_end, cfg, weights=None):
         captured["fit_times"] = list(times_dict.get("Po214", []))
-        return {"E_Po214": 1.0}
+        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit_time_series)
 

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -2,10 +2,12 @@ import sys, json
 from pathlib import Path
 import pandas as pd
 import pytest
+import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
+from fitting import FitResult
 
 
 def test_simple_baseline_subtraction(tmp_path, monkeypatch):
@@ -45,7 +47,7 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
 
     def fake_fit_time_series(times_dict, t_start, t_end, cfg):
         captured["times"] = times_dict.get("Po214")
-        return {"E_Po214": 1.0}
+        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit_time_series)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -119,7 +121,7 @@ def test_baseline_scaling_factor(tmp_path, monkeypatch):
     cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {"E_Po214": 1.0})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({"E_Po214": 1.0}, np.zeros((1,1)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -193,7 +195,7 @@ def test_n0_prior_from_baseline(tmp_path, monkeypatch):
     captured = {}
 
     def fake_fit_time_series(times_dict, t_start, t_end, cfg):
-        return {"E_Po214": 1.0}
+        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit_time_series)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_cli_metadata.py
+++ b/tests/test_cli_metadata.py
@@ -5,6 +5,8 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+import numpy as np
+from fitting import FitResult
 
 
 def test_summary_includes_git_and_cli(tmp_path, monkeypatch):
@@ -32,7 +34,7 @@ def test_summary_includes_git_and_cli(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -31,7 +31,7 @@ def test_fit_time_series_po214_only():
     }
 
     res = fit_time_series(times_dict, 0.0, T, cfg)
-    E_fit = res["E_Po214"]
+    E_fit = res.params["E_Po214"]
     # Basic sanity: E_fit should be within factor of 2 of E_true (low stats)
     assert E_fit > 0
     assert abs(E_fit - E_true) / E_true < 1.0
@@ -82,7 +82,7 @@ def test_fit_time_series_time_window_config():
     count_narrow = mask2.sum()
 
     assert count_narrow < count_full
-    assert res_narrow["E_Po214"] < res_full["E_Po214"]
+    assert res_narrow.params["E_Po214"] < res_full.params["E_Po214"]
 
 
 def test_fit_spectrum_use_emg_flag():
@@ -115,9 +115,9 @@ def test_fit_spectrum_use_emg_flag():
     out_emg = fit_spectrum(energies, priors_emg)
 
     # The EMG fit should return a tau parameter and modify the peak shape
-    assert "tau_Po218" in out_emg
-    assert out_emg["tau_Po218"] != 0
-    assert abs(out_emg["S_Po218"] - out_no_emg["S_Po218"]) > 1e-3
+    assert "tau_Po218" in out_emg.params
+    assert out_emg.params["tau_Po218"] != 0
+    assert abs(out_emg.params["S_Po218"] - out_no_emg.params["S_Po218"]) > 1e-3
 
 
 def test_fit_spectrum_fixed_parameter_bounds():
@@ -142,7 +142,7 @@ def test_fit_spectrum_fixed_parameter_bounds():
     }
 
     out = fit_spectrum(energies, priors, flags={"fix_mu_Po210": True})
-    assert "mu_Po210" in out
+    assert "mu_Po210" in out.params
 
 
 def test_fit_spectrum_custom_bins_and_edges():
@@ -168,12 +168,12 @@ def test_fit_spectrum_custom_bins_and_edges():
 
     # Using integer number of bins
     out_bins = fit_spectrum(energies, priors, bins=30)
-    assert "sigma_E" in out_bins
+    assert "sigma_E" in out_bins.params
 
     # Using explicit bin edges
     edges = np.linspace(5.0, 8.0, 25)
     out_edges = fit_spectrum(energies, priors, bin_edges=edges)
-    assert "sigma_E" in out_edges
+    assert "sigma_E" in out_edges.params
 
 
 def test_fit_spectrum_custom_bounds():
@@ -199,7 +199,7 @@ def test_fit_spectrum_custom_bounds():
 
     bounds = {"mu_Po218": (5.9, 6.1)}
     out = fit_spectrum(energies, priors, bounds=bounds)
-    assert 5.9 <= out["mu_Po218"] <= 6.1
+    assert 5.9 <= out.params["mu_Po218"] <= 6.1
 
 
 def test_fit_spectrum_bounds_clip():
@@ -229,7 +229,7 @@ def test_fit_spectrum_bounds_clip():
     priors["mu_Po218"] = (mu_clipped, priors["mu_Po218"][1])
 
     out = fit_spectrum(energies, priors, bounds=bounds)
-    assert lo <= out["mu_Po218"] <= hi
+    assert lo <= out.params["mu_Po218"] <= hi
 
 
 def test_fit_spectrum_tau_lower_bound():
@@ -255,7 +255,7 @@ def test_fit_spectrum_tau_lower_bound():
     }
 
     result = fit_spectrum(energies, priors)
-    assert result["tau_Po218"] >= _TAU_MIN
+    assert result.params["tau_Po218"] >= _TAU_MIN
 
 
 def test_fit_spectrum_covariance_checks(monkeypatch):
@@ -289,7 +289,7 @@ def test_fit_spectrum_covariance_checks(monkeypatch):
 
     monkeypatch.setattr(fitting_mod, "curve_fit", good_curve_fit)
     out = fit_spectrum(energies, priors)
-    assert out["fit_valid"]
+    assert out.params["fit_valid"]
 
     def bad_curve_fit(*args, **kwargs):
         popt, pcov = orig_curve_fit(*args, **kwargs)
@@ -299,7 +299,7 @@ def test_fit_spectrum_covariance_checks(monkeypatch):
 
     monkeypatch.setattr(fitting_mod, "curve_fit", bad_curve_fit)
     out_bad = fit_spectrum(energies, priors)
-    assert not out_bad["fit_valid"]
+    assert not out_bad.params["fit_valid"]
 
 
 def test_fit_time_series_covariance_checks(monkeypatch):
@@ -324,7 +324,7 @@ def test_fit_time_series_covariance_checks(monkeypatch):
 
     monkeypatch.setattr(linalg, "eigvals", good_eigvals)
     res = fit_time_series(times_dict, 0.0, T, cfg)
-    assert res["fit_valid"]
+    assert res.params["fit_valid"]
 
     def bad_eigvals(x):
         vals = np.ones(x.shape[0])
@@ -337,7 +337,7 @@ def test_fit_time_series_covariance_checks(monkeypatch):
     monkeypatch.setattr(linalg, "eigvals", bad_eigvals)
     monkeypatch.setattr(linalg, "cholesky", cholesky_fail)
     res_bad = fit_time_series(times_dict, 0.0, T, cfg)
-    assert not res_bad["fit_valid"]
+    assert not res_bad.params["fit_valid"]
 
 
 def test_fit_time_series_half_life_zero_raises():

--- a/tests/test_linear_background.py
+++ b/tests/test_linear_background.py
@@ -10,6 +10,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from background import estimate_linear_background
 import analyze
+import numpy as np
+from fitting import FitResult
 
 
 def generate_spectrum():
@@ -79,7 +81,7 @@ def test_auto_background_priors(monkeypatch, tmp_path):
 
     def fake_fit_spectrum(energies, priors, **kw):
         captured.update(priors)
-        return {}
+        return FitResult({}, np.zeros((0, 0)), 0)
 
     monkeypatch.setattr(analyze, "fit_spectrum", fake_fit_spectrum)
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (0.001, 0.0), "c": (0.0, 0.0), "sigma_E": (0.05, 0.01)})
@@ -90,7 +92,7 @@ def test_auto_background_priors(monkeypatch, tmp_path):
     monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "write_summary", lambda *a, **k: str(tmp_path))
     monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
 
     args = [
         "analyze.py",

--- a/tests/test_noise_cutoff.py
+++ b/tests/test_noise_cutoff.py
@@ -6,6 +6,8 @@ import logging
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+import numpy as np
+from fitting import FitResult
 
 
 def test_noise_cutoff_filters_events(tmp_path, monkeypatch):
@@ -50,7 +52,7 @@ def test_noise_cutoff_filters_events(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, cfg, weights=None):
         captured["times"] = ts_dict.get("Po214", []).tolist()
-        return {"E_Po214": 1.0}
+        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
@@ -118,7 +120,7 @@ def test_invalid_noise_cutoff_skips_cut(tmp_path, monkeypatch, caplog):
 
     def fake_fit(ts_dict, t_start, t_end, cfg, weights=None):
         captured["times"] = ts_dict.get("Po214", []).tolist()
-        return {"E_Po214": 1.0}
+        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 

--- a/tests/test_sample_radon.py
+++ b/tests/test_sample_radon.py
@@ -7,6 +7,8 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import radon_activity
+import numpy as np
+from fitting import FitResult
 
 
 def test_total_radon_uses_sample_volume(tmp_path, monkeypatch):
@@ -37,7 +39,7 @@ def test_total_radon_uses_sample_volume(tmp_path, monkeypatch):
     cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: {})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -3,6 +3,8 @@ import json
 from pathlib import Path
 import pandas as pd
 import pytest
+import numpy as np
+from fitting import FitResult
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
@@ -57,7 +59,7 @@ def test_time_window_filters_events(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, config):
         captured["times"] = ts_dict.get("Po214", []).tolist()
-        return {"E_Po214": 1.0}
+        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
@@ -189,7 +191,7 @@ def test_time_window_filters_events_config(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, config):
         captured["times"] = ts_dict.get("Po214", []).tolist()
-        return {"E_Po214": 1.0}
+        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
@@ -268,7 +270,7 @@ def test_run_period_filters_events(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, config):
         captured["times"] = ts_dict.get("Po214", []).tolist()
-        return {"E_Po214": 1.0}
+        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
@@ -354,7 +356,7 @@ def test_baseline_range_iso_strings(tmp_path, monkeypatch, start, end):
 
     def fake_fit(ts_dict, t_start, t_end, config):
         captured["times"] = ts_dict.get("Po214", []).tolist()
-        return {"E_Po214": 1.0}
+        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 

--- a/utils.py
+++ b/utils.py
@@ -3,6 +3,7 @@
 import numpy as np
 from scipy.signal import find_peaks
 import math
+from dataclasses import is_dataclass, asdict
 
 __all__ = ["to_native", "find_adc_peaks", "cps_to_cpd", "cps_to_bq"]
 
@@ -21,6 +22,8 @@ def to_native(obj):
         return {to_native(k): to_native(v) for k, v in obj.items()}
     elif isinstance(obj, list):
         return [to_native(x) for x in obj]
+    if is_dataclass(obj):
+        return to_native(asdict(obj))
     if pd is not None:
         # Handle pandas scalar types
         if obj is pd.NA:


### PR DESCRIPTION
## Summary
- add `FitResult` dataclass to hold fit outputs
- return `FitResult` from spectrum and decay fitting routines
- adapt analysis pipeline and utilities for new dataclass
- update unit tests for new return type

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684921458ebc832bb8f35f71cf18ad56