### PR TITLE
Refactor half-life constants with config overrides

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -72,7 +72,7 @@ from calibration import derive_calibration_constants, derive_calibration_constan
 
 from fitting import fit_spectrum, fit_time_series, FitResult
 
-from constants import DEFAULT_NOISE_CUTOFF
+from constants import DEFAULT_NOISE_CUTOFF, RN222
 
 from plot_utils import (
     plot_spectrum,
@@ -1250,7 +1250,8 @@ def main():
             dE = fit.get("dE_Po214", 0.0)
             N0 = fit.get("N0_Po214", 0.0)
             dN0 = fit.get("dN0_Po214", 0.0)
-            hl = cfg.get("time_fit", {}).get("hl_Po214", [328320])[0]
+            default_rn = cfg.get("nuclide_constants", {}).get("Rn222", RN222).half_life_s
+            hl = cfg.get("time_fit", {}).get("hl_Po214", [default_rn])[0]
             delta214, err_delta214 = radon_delta(
                 t_start_rel,
                 t_end_rel,
@@ -1268,7 +1269,8 @@ def main():
             dE = fit.get("dE_Po218", 0.0)
             N0 = fit.get("N0_Po218", 0.0)
             dN0 = fit.get("dN0_Po218", 0.0)
-            hl = cfg.get("time_fit", {}).get("hl_Po218", [328320])[0]
+            default_rn = cfg.get("nuclide_constants", {}).get("Rn222", RN222).half_life_s
+            hl = cfg.get("time_fit", {}).get("hl_Po218", [default_rn])[0]
             delta218, err_delta218 = radon_delta(
                 t_start_rel,
                 t_end_rel,
@@ -1424,7 +1426,8 @@ def main():
             dE = fit.get("dE_Po214", 0.0)
             N0 = fit.get("N0_Po214", 0.0)
             dN0 = fit.get("dN0_Po214", 0.0)
-            hl = cfg.get("time_fit", {}).get("hl_Po214", [328320])[0]
+            default_rn = cfg.get("nuclide_constants", {}).get("Rn222", RN222).half_life_s
+            hl = cfg.get("time_fit", {}).get("hl_Po214", [default_rn])[0]
             A214, dA214 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl)
             plot_radon_activity(
                 times,
@@ -1441,7 +1444,8 @@ def main():
             dE = fit.get("dE_Po218", 0.0)
             N0 = fit.get("N0_Po218", 0.0)
             dN0 = fit.get("dN0_Po218", 0.0)
-            hl = cfg.get("time_fit", {}).get("hl_Po218", [328320])[0]
+            default_rn = cfg.get("nuclide_constants", {}).get("Rn222", RN222).half_life_s
+            hl = cfg.get("time_fit", {}).get("hl_Po218", [default_rn])[0]
             A218, dA218 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl)
 
         activity_arr = np.zeros_like(times, dtype=float)
@@ -1488,7 +1492,8 @@ def main():
                 dE214 = fit.get("dE_Po214", 0.0)
                 N0214 = fit.get("N0_Po214", 0.0)
                 dN0214 = fit.get("dN0_Po214", 0.0)
-                hl214 = cfg.get("time_fit", {}).get("hl_Po214", [328320])[0]
+                default_rn = cfg.get("nuclide_constants", {}).get("Rn222", RN222).half_life_s
+                hl214 = cfg.get("time_fit", {}).get("hl_Po214", [default_rn])[0]
                 A214_tr, _ = radon_activity_curve(rel_trend, E214, dE214, N0214, dN0214, hl214)
             A218_tr = None
             if "Po218" in time_fit_results:
@@ -1497,7 +1502,8 @@ def main():
                 dE218 = fit.get("dE_Po218", 0.0)
                 N0218 = fit.get("N0_Po218", 0.0)
                 dN0218 = fit.get("dN0_Po218", 0.0)
-                hl218 = cfg.get("time_fit", {}).get("hl_Po218", [328320])[0]
+                default_rn = cfg.get("nuclide_constants", {}).get("Rn222", RN222).half_life_s
+                hl218 = cfg.get("time_fit", {}).get("hl_Po218", [default_rn])[0]
                 A218_tr, _ = radon_activity_curve(rel_trend, E218, dE218, N0218, dN0218, hl218)
             trend = np.zeros_like(times_trend)
             for i in range(times_trend.size):

--- a/constants.py
+++ b/constants.py
@@ -12,9 +12,59 @@ DEFAULT_NOISE_CUTOFF = 400
 # Iteration cap for ``scipy.optimize.curve_fit``
 CURVE_FIT_MAX_EVALS = 10000
 
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class NuclideConst:
+    """Basic constants for a radioactive nuclide."""
+
+    half_life_s: float
+    Q_value_MeV: float | None = None
+
+
+PO214 = NuclideConst(half_life_s=1.64e-4)
+PO218 = NuclideConst(half_life_s=183.0)
+RN222 = NuclideConst(half_life_s=3.8 * 86400.0)
+
+
+_NUCLIDE_DEFAULTS = {
+    "Po214": PO214,
+    "Po218": PO218,
+    "Rn222": RN222,
+}
+
+
+def load_nuclide_overrides(cfg: dict | None) -> dict[str, NuclideConst]:
+    """Return nuclide constants with optional overrides from ``cfg``.
+
+    The configuration may define a ``"nuclides"`` section mapping isotope
+    names to ``{"half_life_s": <float>}`` dictionaries. Missing values fall
+    back to :mod:`constants` defaults.
+    """
+
+    if cfg is None:
+        return _NUCLIDE_DEFAULTS.copy()
+
+    section = cfg.get("nuclides", {}) if isinstance(cfg, dict) else {}
+
+    result: dict[str, NuclideConst] = {}
+    for name, const in _NUCLIDE_DEFAULTS.items():
+        override = section.get(name, {}) if isinstance(section, dict) else {}
+        hl = override.get("half_life_s", const.half_life_s)
+        qv = override.get("Q_value_MeV", const.Q_value_MeV)
+        result[name] = NuclideConst(half_life_s=float(hl), Q_value_MeV=qv)
+
+    return result
+
 __all__ = [
     "_TAU_MIN",
     "EXP_OVERFLOW_DOUBLE",
     "DEFAULT_NOISE_CUTOFF",
     "CURVE_FIT_MAX_EVALS",
+    "NuclideConst",
+    "PO214",
+    "PO218",
+    "RN222",
+    "load_nuclide_overrides",
 ]

--- a/io_utils.py
+++ b/io_utils.py
@@ -5,6 +5,7 @@ import json
 import logging
 from datetime import datetime
 import pandas as pd
+from constants import load_nuclide_overrides
 
 import numpy as np
 from utils import to_native
@@ -31,6 +32,8 @@ def load_config(config_path):
 
     with open(path, "r", encoding="utf-8") as f:
         cfg = json.load(f)
+
+    cfg["nuclide_constants"] = load_nuclide_overrides(cfg)
 
     # Basic validation: check for required keys within each section
     required_structure = {

--- a/plot_utils.py
+++ b/plot_utils.py
@@ -8,10 +8,11 @@ import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 from datetime import datetime
 from color_schemes import COLOR_SCHEMES
+from constants import PO214, PO218, RN222
 
 # Half-life constants used for the time-series overlay [seconds]
-PO214_HALF_LIFE_S = 1.64e-4  # 164 µs
-PO218_HALF_LIFE_S = 183.0    # ~3.05 minutes
+PO214_HALF_LIFE_S = PO214.half_life_s
+PO218_HALF_LIFE_S = PO218.half_life_s
 
 __all__ = [
     "plot_time_series",
@@ -56,15 +57,19 @@ def plot_time_series(
             return cfg[key]
         return default
 
+    default_const = config.get("nuclide_constants", {})
+    default214 = default_const.get("Po214", PO214).half_life_s
+    default218 = default_const.get("Po218", PO218).half_life_s
+
     po214_hl = (
         float(hl_Po214)
         if hl_Po214 is not None
-        else float(config.get("hl_Po214", [PO214_HALF_LIFE_S])[0])
+        else float(config.get("hl_Po214", [default214])[0])
     )
     po218_hl = (
         float(hl_Po218)
         if hl_Po218 is not None
-        else float(config.get("hl_Po218", [PO218_HALF_LIFE_S])[0])
+        else float(config.get("hl_Po218", [default218])[0])
     )
 
     if po214_hl <= 0:
@@ -86,7 +91,13 @@ def plot_time_series(
         "Po210": {
             "window": _cfg_get(config, "window_Po210"),
             "eff": float(_cfg_get(config, "eff_Po210", [1.0])[0]),
-            "half_life": float(_cfg_get(config, "hl_Po210", [328320])[0]),
+            "half_life": float(
+                _cfg_get(
+                    config,
+                    "hl_Po210",
+                    [default_const.get("Rn222", RN222).half_life_s],
+                )[0]
+            ),
         },
     }
     iso_list = [iso for iso, p in iso_params.items() if p["window"] is not None]


### PR DESCRIPTION
## Summary
- define `NuclideConst` dataclass and default nuclide constants in `constants`
- expose `load_nuclide_overrides` to read optional `nuclides` config section
- use the new constants and overrides in plotting utilities and analysis
- store `nuclide_constants` in the loaded configuration

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a324bcab4832bbd4b80fd6d9da596