### PR TITLE
Add hierarchical test

### DIFF
--- a/tests/test_hierarchical.py
+++ b/tests/test_hierarchical.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from hierarchical import fit_hierarchical_runs
+
+
+def test_fit_hierarchical_runs_basic():
+    runs = [
+        {"half_life": 1.0, "dhalf_life": 0.1, "slope": 0.5, "dslope": 0.1},
+        {"half_life": 1.2, "dhalf_life": 0.1, "slope": 0.55, "dslope": 0.1},
+    ]
+
+    res = fit_hierarchical_runs(runs, draws=50, tune=50, chains=1)
+
+    assert "half_life" in res
+    assert "mean" in res["half_life"]
+    assert "slope" in res
+    assert "mean" in res["slope"]


### PR DESCRIPTION
## Summary
- add missing unit test for hierarchical Bayesian run fitting

## Testing
- `pytest -k hierarchical -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a440abdd8832bad9effd008bbafb0