### PR TITLE
Add hierarchical summary option

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -60,6 +60,8 @@ import numpy as np
 import pandas as pd
 from scipy.stats import norm
 
+from hierarchical import fit_hierarchical_runs
+
 # ‣ Import our supporting modules (all must live in the same folder).
 from io_utils import (
     load_config,
@@ -275,6 +277,14 @@ def parse_args():
         "--palette",
         help="Color palette for plots (overrides plotting.palette)",
     )
+    p.add_argument(
+        "--hierarchical-summary",
+        metavar="OUTFILE",
+        help=(
+            "Combine half-life and calibration results from previous runs and "
+            "write a hierarchical fit summary to OUTFILE"
+        ),
+    )
     return p.parse_args()
 
 
@@ -300,6 +310,8 @@ def main():
         args.systematics_json = Path(args.systematics_json)
     if args.ambient_file:
         args.ambient_file = Path(args.ambient_file)
+    if args.hierarchical_summary:
+        args.hierarchical_summary = Path(args.hierarchical_summary)
 
     # ────────────────────────────────────────────────────────────
     # 1. Load configuration
@@ -1563,6 +1575,39 @@ def main():
                 )
     except Exception as e:
         print(f"WARNING: Could not create radon activity plots -> {e}")
+
+    if args.hierarchical_summary:
+        try:
+            run_results = []
+            for p in args.output_dir.glob("*/summary.json"):
+                try:
+                    with open(p, "r", encoding="utf-8") as f:
+                        dat = json.load(f)
+                except Exception as e:
+                    print(f"WARNING: Skipping {p} -> {e}")
+                    continue
+                hl = dat.get("half_life")
+                dhl = dat.get("dhalf_life")
+                cal = dat.get("calibration", {})
+                slope, dslope = cal.get("a", (None, None))
+                intercept, dintercept = cal.get("c", (None, None))
+                if hl is not None:
+                    run_results.append(
+                        {
+                            "half_life": hl,
+                            "dhalf_life": dhl,
+                            "slope": slope,
+                            "dslope": dslope,
+                            "intercept": intercept,
+                            "dintercept": dintercept,
+                        }
+                    )
+            if run_results:
+                hier_out = fit_hierarchical_runs(run_results)
+                with open(args.hierarchical_summary, "w", encoding="utf-8") as f:
+                    json.dump(hier_out, f, indent=4)
+        except Exception as e:
+            print(f"WARNING: hierarchical fit failed -> {e}")
 
     print(f"Analysis complete. Results written to -> {out_dir}")
 

--- a/readme.txt
+++ b/readme.txt
@@ -37,7 +37,8 @@ python analyze.py --config config.json --input merged_data.csv \
     [--settle-s SEC] [--debug] [--seed SEED] \
     [--ambient-file amb.txt (time conc)] [--ambient-concentration 0.1] \
     [--burst-mode rate] \
-    [--time-bin-mode fixed --time-bin-width 3600] [--dump-ts-json]
+    [--time-bin-mode fixed --time-bin-width 3600] [--dump-ts-json] \
+    [--hierarchical-summary OUT.json]
 ```
 
 ## Input CSV Format
@@ -235,7 +236,8 @@ apply a linear ADC drift correction, `--analysis-end-time` and
 `--spike-end-time` to clip the dataset, one or more `--spike-period`
 options to exclude specific time windows, `--settle-s` to skip the
 initial settling period in the decay fit, `--seed` to set the random
-seed used by the analysis and `--debug` to increase log verbosity.
+seed used by the analysis, `--hierarchical-summary PATH` to produce a
+Bayesian combination across runs and `--debug` to increase log verbosity.
 The half-lives used in the decay fit can also be changed with
 `--hl-po214` and `--hl-po218`.
 
@@ -480,4 +482,4 @@ pytest -v
 
 ## Hierarchical Analysis
 
-Use `hierarchical.py` to perform Bayesian hierarchical inference across multiple runs. The function `fit_hierarchical_runs` pools measurements of the half-life and calibration constants. It returns posterior means, standard deviations and 95% credible intervals for the global parameters.
+Use `hierarchical.py` to perform Bayesian hierarchical inference across multiple runs. The function `fit_hierarchical_runs` pools measurements of the half-life and calibration constants. It returns posterior means, standard deviations and 95% credible intervals for the global parameters. Running `analyze.py` with `--hierarchical-summary result.json` collects the half-life and calibration outputs from all `summary.json` files under the chosen output directory and writes the combined fit to `result.json`.

--- a/tests/test_hierarchical_summary.py
+++ b/tests/test_hierarchical_summary.py
@@ -1,0 +1,92 @@
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+from fitting import FitResult
+
+
+def test_hierarchical_summary(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1],
+        "fBits": [0],
+        "timestamp": [0],
+        "adc": [1000],
+        "fchannel": [1],
+    })
+    data_path = tmp_path / "data.csv"
+    df.to_csv(data_path, index=False)
+
+    # Existing run summaries
+    for i in range(2):
+        d = tmp_path / f"old{i}"
+        d.mkdir()
+        with open(d / "summary.json", "w") as f:
+            json.dump({
+                "half_life": 10.0 + i,
+                "dhalf_life": 1.0,
+                "calibration": {"a": [1.0, 0.1], "c": [0.0, 0.1]},
+            }, f)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, None, 0))
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+
+    captured = {}
+
+    def fake_fit(runs, draws=2000, tune=1000, chains=2, random_seed=42):
+        captured["runs"] = runs
+        return {"half_life": {"mean": 11.0}}
+
+    monkeypatch.setattr(analyze, "fit_hierarchical_runs", fake_fit)
+
+    def fake_write(out_dir, summary, timestamp=None):
+        d = Path(out_dir) / "new"
+        d.mkdir(parents=True, exist_ok=True)
+        with open(d / "summary.json", "w") as f:
+            json.dump({
+                "half_life": 12.0,
+                "dhalf_life": 1.0,
+                "calibration": {"a": [1.2, 0.1], "c": [0.2, 0.1]},
+            }, f)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    out_json = tmp_path / "hier.json"
+    args = [
+        "analyze.py",
+        "--config", str(cfg_path),
+        "--input", str(data_path),
+        "--output_dir", str(tmp_path),
+        "--hierarchical-summary", str(out_json),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+
+    analyze.main()
+
+    assert len(captured.get("runs", [])) == 3
+    assert out_json.exists()
+    with open(out_json) as f:
+        res = json.load(f)
+    assert res["half_life"]["mean"] == 11.0


### PR DESCRIPTION
## Summary
- add CLI flag `--hierarchical-summary` and path handling
- write hierarchical combination using `fit_hierarchical_runs`
- document the new flag in readme
- test hierarchical summary output

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a4409b044832bab4a7aded8f4964c