### PR TITLE
Add hl-po210 CLI parameter

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -238,6 +238,11 @@ def parse_args():
         help="Half-life to use for Po-218 in seconds",
     )
     p.add_argument(
+        "--hl-po210",
+        type=float,
+        help="Half-life to use for Po-210 in seconds",
+    )
+    p.add_argument(
         "--debug",
         action="store_true",
         help="Enable debug logging",
@@ -377,6 +382,14 @@ def main():
         if isinstance(current, list) and len(current) > 1:
             sig = current[1]
         tf["hl_Po218"] = [float(args.hl_po218), sig]
+
+    if args.hl_po210 is not None:
+        tf = cfg.setdefault("time_fit", {})
+        sig = 0.0
+        current = tf.get("hl_Po210")
+        if isinstance(current, list) and len(current) > 1:
+            sig = current[1]
+        tf["hl_Po210"] = [float(args.hl_po210), sig]
 
 
     if args.time_bin_mode:

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -1605,3 +1605,68 @@ def test_hl_po214_cli_overrides(tmp_path, monkeypatch):
     assert values["Po214"] == 5.0
 
 
+def test_hl_po210_cli_overrides(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": True,
+            "window_Po214": [0.0, 20.0],
+            "window_Po218": [0.0, 20.0],
+            "window_Po210": [5.2, 5.4],
+            "hl_Po214": [1.0, 0.0],
+            "hl_Po210": [2.0, 0.0],
+            "eff_Po214": [1.0, 0.0],
+            "eff_Po210": [1.0, 0.0],
+            "flags": {},
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0.0], "adc": [8.0], "fchannel": [1]})
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0, 0)), 0))
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+
+    captured = {}
+
+    def fake_plot_time_series(*args, **kwargs):
+        key = Path(kwargs["out_png"]).name
+        captured[key] = kwargs["config"]
+        Path(kwargs["out_png"]).touch()
+        return None
+
+    monkeypatch.setattr(analyze, "plot_time_series", fake_plot_time_series)
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+        "--hl-po210",
+        "7",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+
+    analyze.main()
+
+    cfg_used = captured.get("time_series_Po210.png")
+    assert cfg_used is not None
+    assert cfg_used["hl_Po210"][0] == 7.0
+
+


### PR DESCRIPTION
## Summary
- add `--hl-po210` argument in `parse_args`
- merge the new CLI flag into `cfg['time_fit']['hl_Po210']`
- test CLI override for Po‑210 half-life

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a5098efdc832ba0d78274321ca590