### PR TITLE
Add Po-210 time series support and axis windowing

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -10,6 +10,34 @@ from constants import load_nuclide_overrides
 import numpy as np
 from utils import to_native
 
+
+def extract_time_series_events(events, cfg):
+    """Slice events for time-series fits based on isotope windows.
+
+    Parameters
+    ----------
+    events : pandas.DataFrame
+        Event data with ``timestamp`` and ``energy_MeV`` columns.
+    cfg : dict
+        Configuration containing ``time_fit`` settings.
+
+    Returns
+    -------
+    dict
+        Mapping of isotope name to ``numpy.ndarray`` of timestamps.
+    """
+
+    ts_cfg = cfg.get("time_fit", {})
+    out = {}
+    for iso in ("Po214", "Po218", "Po210"):
+        win = ts_cfg.get(f"window_{iso}")
+        if win is None:
+            continue
+        lo, hi = win
+        mask = (events["energy_MeV"] >= lo) & (events["energy_MeV"] <= hi)
+        out[iso] = events.loc[mask, "timestamp"].values.astype(float)
+    return out
+
 logger = logging.getLogger(__name__)
 
 

--- a/plot_utils.py
+++ b/plot_utils.py
@@ -337,6 +337,14 @@ def plot_spectrum(
     hist_color = palette.get("hist", "gray")
     ax_main.bar(centers, hist, width=width, color=hist_color, alpha=0.7, label="Data")
 
+    # If an explicit Po-210 window is provided, focus the x-axis on that region
+    win_p210 = None
+    if config is not None:
+        win_p210 = config.get("window_Po210")
+    if win_p210 is not None:
+        lo, hi = win_p210
+        ax_main.set_xlim(lo, hi)
+
     if fit_vals:
         x = np.linspace(edges[0], edges[-1], 1000)
         sigma_E = fit_vals.get("sigma_E", 1.0)
@@ -401,6 +409,8 @@ def plot_spectrum(
     for fmt in save_fmts:
         fig.savefig(base + f".{fmt}", dpi=300)
     plt.close(fig)
+
+    return ax_main
 
 
 def plot_radon_activity(times, activity, errors, out_png, config=None):

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -90,6 +90,13 @@ def test_plot_spectrum_save_formats(tmp_path):
     assert out_png.with_suffix('.pdf').exists()
 
 
+def test_plot_spectrum_po210_xlim(tmp_path):
+    energies = np.linspace(0, 10, 100)
+    cfg = {"window_Po210": [5.0, 5.5]}
+    ax = plot_spectrum(energies, config=cfg, out_png=str(tmp_path / "spec2.png"))
+    assert ax.get_xlim() == (5.0, 5.5)
+
+
 def test_plot_time_series_custom_half_life(tmp_path, monkeypatch):
     times = np.array([1000.1, 1000.2, 1001.1, 1001.8])
     energies = np.array([7.6, 7.7, 7.8, 7.7])


### PR DESCRIPTION
## Summary
- extract Po-210 time series events in `io_utils`
- focus spectrum plot on configured Po-210 window
- return axis from `plot_spectrum`
- test Po-210 x-axis limits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a509694ec832b99bb975b4eb7f26f