### PR TITLE
Add Po210 constants and override support

### DIFF
--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from constants import PO210, load_nuclide_overrides, load_half_life_overrides
+
+
+def test_po210_default():
+    assert PO210.half_life_s == pytest.approx(138.376 * 24 * 3600)
+
+
+def test_po210_override():
+    cfg = {"time_fit": {"hl_po210": [42.0]}}
+    consts = load_nuclide_overrides(cfg)
+    assert consts["Po210"].half_life_s == 42.0
+    hl = load_half_life_overrides(cfg)
+    assert hl["Po210"] == 42.0
+


### PR DESCRIPTION
## Summary
- define `PO210` nuclide constant in `constants.py`
- include Po‑210 in the defaults map
- allow half-life overrides from `time_fit.hl_po210`
- expose a new `load_half_life_overrides` helper
- add tests for new constant and override functionality

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a5099255c832b8dc5b7b56c8593f5