### PR TITLE
Add color scheme test

### DIFF
--- a/tests/test_color_schemes.py
+++ b/tests/test_color_schemes.py
@@ -1,0 +1,4 @@
+import color_schemes as cs
+
+def test_po214_color_defined():
+    assert hasattr(cs, "COLOR_SCHEMES") and "Po214" in cs.COLOR_SCHEMES["default"]


### PR DESCRIPTION
## Summary
- test that Po214 exists in default color scheme

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a5096bdd8832ba6d9e9daefd27187