### PR TITLE
Apply CLI half-life overrides early

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -238,6 +238,11 @@ def parse_args():
         help="Half-life to use for Po-218 in seconds",
     )
     p.add_argument(
+        "--hl-po210",
+        type=float,
+        help="Half-life to use for Po-210 in seconds",
+    )
+    p.add_argument(
         "--debug",
         action="store_true",
         help="Enable debug logging",
@@ -377,6 +382,14 @@ def main():
         if isinstance(current, list) and len(current) > 1:
             sig = current[1]
         tf["hl_Po218"] = [float(args.hl_po218), sig]
+
+    if args.hl_po210 is not None:
+        tf = cfg.setdefault("time_fit", {})
+        sig = 0.0
+        current = tf.get("hl_Po210")
+        if isinstance(current, list) and len(current) > 1:
+            sig = current[1]
+        tf["hl_Po210"] = [float(args.hl_po210), sig]
 
 
     if args.time_bin_mode:

--- a/readme.txt
+++ b/readme.txt
@@ -33,7 +33,7 @@ python analyze.py --config config.json --input merged_data.csv \
     [--analysis-end-time ISO --spike-end-time ISO] \
     [--spike-period START END] [--run-period START END] \
     [--radon-interval START END] \
-    [--hl-po214 SEC] [--hl-po218 SEC] \
+    [--hl-po214 SEC] [--hl-po218 SEC] [--hl-po210 SEC] \
     [--settle-s SEC] [--debug] [--seed SEED] \
     [--ambient-file amb.txt (time conc)] [--ambient-concentration 0.1] \
     [--burst-mode rate] \
@@ -239,7 +239,7 @@ initial settling period in the decay fit, `--seed` to set the random
 seed used by the analysis, `--hierarchical-summary PATH` to produce a
 Bayesian combination across runs and `--debug` to increase log verbosity.
 The half-lives used in the decay fit can also be changed with
-`--hl-po214` and `--hl-po218`.
+`--hl-po214`, `--hl-po218` and `--hl-po210`.
 
 When the spectrum is binned in raw ADC channels (`"spectral_binning_mode": "adc"`),
 the bin edges are internally converted to energy using the calibration
@@ -369,7 +369,7 @@ Example snippet:
 ```
 
 These half-life values may also be set on the command line with
-`--hl-po214` and `--hl-po218`.
+`--hl-po214`, `--hl-po218` and `--hl-po210`.
 
 ### Baseline Runs
 

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -1605,3 +1605,69 @@ def test_hl_po214_cli_overrides(tmp_path, monkeypatch):
     assert values["Po214"] == 5.0
 
 
+def test_hl_po210_cli_overrides(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": True,
+            "window_Po214": [0.0, 20.0],
+            "window_Po210": [5.0, 6.0],
+            "hl_Po214": [1.0, 0.0],
+            "hl_Po210": [2.0, 0.0],
+            "eff_Po214": [1.0, 0.0],
+            "eff_Po210": [1.0, 0.0],
+            "flags": {},
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0.0], "adc": [8.0], "fchannel": [1]})
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+
+    calls = []
+    received = {}
+
+    def fake_fit(ts_dict, t_start, t_end, config):
+        iso = list(ts_dict.keys())[0]
+        calls.append((iso, config))
+        return FitResult({}, np.zeros((0, 0)), 0)
+
+    def fake_plot_ts(*args, **kwargs):
+        received.update(kwargs)
+        Path(kwargs["out_png"]).touch()
+        return None
+
+    monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
+    monkeypatch.setattr(analyze, "plot_time_series", fake_plot_ts)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+        "--hl-po210",
+        "7",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+
+    analyze.main()
+
+    assert received["config"]["hl_Po210"][0] == 7.0
+
+


### PR DESCRIPTION
## Summary
- allow overriding Po-210 half-life via `--hl-po210`
- merge `--hl-po210` into configuration early
- document new option in README
- test Po-210 CLI override

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a50969698832b85fb32327928f630