### PR TITLE
Improve burst filter handling for low event rates

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -481,6 +481,13 @@ def main():
             logging.info(f"Noise cut removed {n_removed_noise} events")
 
     # Optional burst filter to remove high-rate clusters
+    total_span = events["timestamp"].max() - events["timestamp"].min()
+    rate_cps = len(events) / total_span if total_span > 0 else 0.0
+    if args.burst_mode is None:
+        current_mode = cfg.get("burst_filter", {}).get("burst_mode", "rate")
+        if current_mode == "rate" and rate_cps < 0.1:
+            cfg.setdefault("burst_filter", {})["burst_mode"] = "none"
+
     burst_mode = (
         args.burst_mode
         if args.burst_mode is not None

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -1378,6 +1378,72 @@ def test_burst_mode_cli_overrides(tmp_path, monkeypatch):
     assert recorded.get("mode") == "micro"
 
 
+def test_burst_filter_auto_disabled(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+        "burst_filter": {"burst_mode": "rate"},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame(
+        {
+            "fUniqueID": [1, 2],
+            "fBits": [0, 0],
+            "timestamp": [0, 2000],
+            "adc": [1, 1],
+            "fchannel": [1, 1],
+        }
+    )
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    recorded = {}
+
+    def fake_burst(df, cfg, mode="rate"):
+        recorded["mode"] = mode
+        return df, 0
+
+    monkeypatch.setattr(analyze, "apply_burst_filter", fake_burst)
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants",
+        lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)},
+    )
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants_auto",
+        lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)},
+    )
+    monkeypatch.setattr(
+        analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0, 0)), 0)
+    )
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert recorded.get("mode") == "none"
+
+
 def test_ambient_concentration_default_none(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},


### PR DESCRIPTION
## Summary
- auto-disable burst filter when the event rate falls below 0.1 cps
- add regression test covering the automatic behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c512f2a18832b8e3a0929294952a5