### PR TITLE
Propagate E–N0 covariance in radon activity

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -131,6 +131,7 @@ def radon_activity_curve(
     N0: float,
     dN0: float,
     half_life_s: float,
+    cov_en0: float = 0.0,
 ) -> Tuple["np.ndarray", "np.ndarray"]:
     """Activity over time from fitted decay parameters.
 
@@ -148,6 +149,9 @@ def radon_activity_curve(
         Uncertainty on ``N0``.
     half_life_s : float
         Half-life used for the decay model.
+    cov_en0 : float, optional
+        Covariance between ``E`` and ``N0``.  If omitted the covariance is
+        assumed to be zero.
 
     Returns
     -------
@@ -168,7 +172,11 @@ def radon_activity_curve(
 
     dA_dE = 1.0 - exp_term
     dA_dN0 = lam * exp_term
-    variance = (dA_dE * dE) ** 2 + (dA_dN0 * dN0) ** 2
+    variance = (
+        (dA_dE * dE) ** 2
+        + (dA_dN0 * dN0) ** 2
+        + 2.0 * dA_dE * dA_dN0 * cov_en0
+    )
     sigma = np.sqrt(variance)
     return activity, sigma
 
@@ -181,11 +189,13 @@ def radon_delta(
     N0: float,
     dN0: float,
     half_life_s: float,
+    cov_en0: float = 0.0,
 ) -> Tuple[float, float]:
     """Change in activity between two times.
 
     Parameters are identical to :func:`radon_activity_curve` with ``t_start``
-    and ``t_end`` specifying the relative times in seconds.
+    and ``t_end`` specifying the relative times in seconds. ``cov_en0``
+    represents the covariance between ``E`` and ``N0`` and defaults to zero.
     """
 
     if half_life_s <= 0:
@@ -199,6 +209,10 @@ def radon_delta(
 
     d_delta_dE = exp1 - exp2
     d_delta_dN0 = lam * (exp2 - exp1)
-    variance = (d_delta_dE * dE) ** 2 + (d_delta_dN0 * dN0) ** 2
+    variance = (
+        (d_delta_dE * dE) ** 2
+        + (d_delta_dN0 * dN0) ** 2
+        + 2.0 * d_delta_dE * d_delta_dN0 * cov_en0
+    )
     sigma = math.sqrt(variance)
     return delta, sigma

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -176,6 +176,26 @@ def test_radon_activity_curve():
     assert np.allclose(err, np.sqrt(var))
 
 
+def test_radon_activity_curve_with_covariance():
+    times = [0.0, 1.0]
+    E = 5.0
+    dE = 0.5
+    N0 = 2.0
+    dN0 = 0.2
+    cov = -0.01
+    hl = 10.0
+    act, err = radon_activity_curve(times, E, dE, N0, dN0, hl, cov)
+    lam = math.log(2.0) / hl
+    import numpy as np
+    exp_term = np.exp(-lam * np.asarray(times))
+    var = (
+        ((1 - exp_term) * dE) ** 2
+        + ((lam * exp_term) * dN0) ** 2
+        + 2 * (1 - exp_term) * (lam * exp_term) * cov
+    )
+    assert np.allclose(err, np.sqrt(var))
+
+
 def test_radon_delta():
     start = 0.0
     end = 2.0
@@ -191,6 +211,30 @@ def test_radon_delta():
     exp2 = math.exp(-lam * end)
     expected = E * (exp1 - exp2) + lam * N0 * (exp2 - exp1)
     var = ((exp1 - exp2) * dE) ** 2 + ((lam * (exp2 - exp1)) * dN0) ** 2
+    assert delta == pytest.approx(expected)
+    assert sigma == pytest.approx(math.sqrt(var))
+
+
+def test_radon_delta_with_covariance():
+    start = 0.0
+    end = 2.0
+    E = 5.0
+    dE = 0.5
+    N0 = 2.0
+    dN0 = 0.2
+    cov = 0.01
+    hl = 10.0
+    delta, sigma = radon_delta(start, end, E, dE, N0, dN0, hl, cov)
+
+    lam = math.log(2.0) / hl
+    exp1 = math.exp(-lam * start)
+    exp2 = math.exp(-lam * end)
+    expected = E * (exp1 - exp2) + lam * N0 * (exp2 - exp1)
+    var = (
+        ((exp1 - exp2) * dE) ** 2
+        + ((lam * (exp2 - exp1)) * dN0) ** 2
+        + 2 * (exp1 - exp2) * (lam * (exp2 - exp1)) * cov
+    )
     assert delta == pytest.approx(expected)
     assert sigma == pytest.approx(math.sqrt(var))
 


### PR DESCRIPTION
## Summary
- allow `radon_activity_curve` and `radon_delta` to take a covariance parameter
- compute the cross variance term when covariance is provided
- expose helper `_cov_entry` in `analyze.py` to read covariance matrices
- pass covariance terms to activity curves and deltas
- test uncertainty propagation with non‑zero covariance

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c52381f34832bae537a931d0787d7