### PR TITLE
Fix Po210 half-life defaults

### DIFF
--- a/plot_utils.py
+++ b/plot_utils.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 from datetime import datetime
 from color_schemes import COLOR_SCHEMES
-from constants import PO214, PO218, RN222
+from constants import PO214, PO218, PO210, RN222
 
 # Half-life constants used for the time-series overlay [seconds]
 PO214_HALF_LIFE_S = PO214.half_life_s
@@ -95,7 +95,7 @@ def plot_time_series(
                 _cfg_get(
                     config,
                     "hl_Po210",
-                    [default_const.get("Rn222", RN222).half_life_s],
+                    [default_const.get("Po210", PO210).half_life_s],
                 )[0]
             ),
         },

--- a/readme.txt
+++ b/readme.txt
@@ -331,7 +331,7 @@ Example snippet:
 ```
 
 `plot_time_series` takes its half-life values from the `time_fit` section.
-When these keys are omitted, `hl_Po214` and `hl_Po218` default to the radon half-life (~3.8 days or about `3.28e5` s). Specify them to use other values. These custom half-lives control the decay model drawn over the time-series histogram.
+When these keys are omitted, `hl_Po214` and `hl_Po218` default to the radon half-life (~3.8 days or about `3.28e5` s). `hl_Po210` falls back to the Po‑210 half-life (≈138 days). Specify them to use other values. These custom half-lives control the decay model drawn over the time-series histogram.
 The same values are used in the `time_fit` routine itself, so changing
 `hl_Po214` or `hl_Po218` affects both the unbinned fit and the overlay in
 `plot_time_series`. For monitoring that spans multiple days you may set

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -1674,4 +1674,58 @@ def test_hl_po210_cli_overrides(tmp_path, monkeypatch):
     assert cfg_used["hl_Po210"][0] == 7.0
 
 
+def test_hl_po210_default_used(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": False,
+            "window_Po210": [5.2, 5.4],
+            "flags": {},
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0.0], "adc": [8.0], "fchannel": [1]})
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+
+    received = {}
+
+    def fake_plot_time_series(*args, **kwargs):
+        received.update(kwargs)
+        Path(kwargs["out_png"]).touch()
+        return None
+
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0, 0)), 0))
+    monkeypatch.setattr(analyze, "plot_time_series", fake_plot_time_series)
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+
+    analyze.main()
+
+    assert "hl_Po210" not in received["config"]
+
+
 

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from constants import PO210
 from plot_utils import plot_time_series, plot_spectrum
 
 
@@ -259,6 +260,39 @@ def test_plot_time_series_po210_no_model(tmp_path, monkeypatch):
     )
 
     assert "Model Po210" not in labels
+
+
+def test_plot_time_series_po210_default_half_life(tmp_path, monkeypatch):
+    times = np.array([1000.1, 1001.1, 1001.9])
+    energies = np.array([5.3, 5.3, 5.3])
+    cfg = basic_config()
+    cfg.update({"window_Po210": [5.2, 5.4], "eff_Po210": [1.0]})
+
+    captured = {}
+
+    def fake_plot(x, y, *args, **kwargs):
+        if kwargs.get("label") == "Model Po210":
+            captured["y"] = np.array(y)
+        return type("obj", (), {})()
+
+    monkeypatch.setattr("plot_utils.plt.plot", fake_plot)
+    monkeypatch.setattr("plot_utils.plt.savefig", lambda *a, **k: None)
+
+    plot_time_series(
+        times,
+        energies,
+        {"E": 0.1, "B": 0.0, "N0": 0.0},
+        1000.0,
+        1002.0,
+        cfg,
+        str(tmp_path / "ts_p210_def.png"),
+    )
+
+    lam = np.log(2.0) / PO210.half_life_s
+    centers = np.array([0.5, 1.5])
+    expected = 0.1 * (1.0 - np.exp(-lam * centers))
+    assert "y" in captured
+    assert np.allclose(captured["y"], expected, rtol=1e-4)
 
 
 def test_plot_time_series_rate_normalisation(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- use Po210 constant when hl_Po210 not provided
- document Po210 default in readme
- test Po210 default behaviour

## Testing
- `pytest -q tests/test_plot_utils.py`
- `pytest -q tests/test_analyze_config_merge.py::test_hl_po210_default_used`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c523b5d68832bac1c25fbb996e64f