### PR TITLE
Add config schema validation with duplicate detection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest>=6.0
 pandas>=1.2
 iminuit>=2.0
 pymc
+jsonschema>=4.0


### PR DESCRIPTION
## Summary
- validate configuration using a JSON schema
- detect duplicate keys when loading JSON
- raise KeyError on missing required config sections
- add tests for duplicate key errors and invalid ranges
- depend on `jsonschema`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c523e7324832ba230813d64539f68