### PR TITLE
Clarify CLI override behavior

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -151,9 +151,9 @@ def parse_args():
         nargs=2,
         metavar=("TSTART", "TEND"),
         help=(
-            "Optional baseline-run interval. "
-            "Provide two values (either ISO strings or epoch floats). "
-            "If set, those events are extracted (same energy cuts) and "
+            "Optional baseline-run interval overriding `baseline.range` in "
+            "config.json. Provide two values (either ISO strings or epoch "
+            "floats). If set, those events are extracted (same energy cuts) and "
             "listed in `baseline` of the summary."
         ),
     )
@@ -220,7 +220,10 @@ def parse_args():
     p.add_argument(
         "--noise-cutoff",
         type=int,
-        help="ADC threshold for the noise cut (overrides calibration.noise_cutoff)",
+        help=(
+            "ADC threshold for the noise cut. Overrides "
+            "`calibration.noise_cutoff` in config.json"
+        ),
     )
     p.add_argument(
         "--settle-s",
@@ -437,6 +440,11 @@ def main():
         cfg.setdefault("systematics", {})["adc_drift_rate"] = float(args.slope)
 
     if args.noise_cutoff is not None:
+        _log_override(
+            "calibration",
+            "noise_cutoff",
+            int(args.noise_cutoff),
+        )
         cfg.setdefault("calibration", {})["noise_cutoff"] = int(args.noise_cutoff)
 
     if args.debug:
@@ -675,6 +683,8 @@ def main():
     baseline_cfg = cfg.get("baseline", {})
     baseline_range = None
     if args.baseline_range:
+        if "range" in baseline_cfg:
+            _log_override("baseline", "range", args.baseline_range)
         baseline_range = args.baseline_range
     elif "range" in baseline_cfg:
         baseline_range = baseline_cfg.get("range")

--- a/readme.txt
+++ b/readme.txt
@@ -114,6 +114,9 @@ default is `400`.  Set it to `null` to skip the cut entirely.  The
 `analyze.py` pipeline applies this filter right after loading the event
 CSV.
 
+The command-line option `--noise-cutoff` overrides this value when
+provided.
+
 Example snippet:
 
 ```json
@@ -385,7 +388,9 @@ Po‑218 windows. The counts are converted directly into a decay rate in
 Bq by dividing by the baseline live time and detection efficiency.  This
 rate is scaled by the dilution factor
 `monitor_volume_l / (monitor_volume_l + sample_volume_l)` before being
-subtracted from the fitted radon decay rate of the assay.
+subtracted from the fitted radon decay rate of the assay. The command-line
+option `--baseline_range` overrides `baseline.range` from the
+configuration when provided.
 
 Example snippet:
 


### PR DESCRIPTION
## Summary
- document that CLI values override `baseline.range` and `calibration.noise_cutoff`
- show this override in the CLI help strings
- log a message when these values are replaced via command line

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c5306228c832bb4f4a0d8b7bf1903