### PR TITLE
Rename peak finding helper

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -84,7 +84,7 @@ from plot_utils import (
 )
 from systematics import scan_systematics, apply_linear_adc_shift
 from visualize import cov_heatmap, efficiency_bar
-from utils import find_adc_peaks, cps_to_bq
+from utils import find_adc_bin_peaks, cps_to_bq
 
 
 def _fit_params(obj):
@@ -813,8 +813,8 @@ def main():
 
         expected_peaks = cfg["spectral_fit"]["expected_peaks"]
 
-        # `find_adc_peaks` will return a dict: e.g. { "Po210": adc_centroid, … }
-        adc_peaks = find_adc_peaks(
+        # `find_adc_bin_peaks` will return a dict: e.g. { "Po210": adc_centroid, … }
+        adc_peaks = find_adc_bin_peaks(
             events["adc"].values,
             expected=expected_peaks,
             window=cfg["spectral_fit"].get("peak_search_width_adc", 50),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from utils import cps_to_cpd, cps_to_bq
+from utils import cps_to_cpd, cps_to_bq, find_adc_bin_peaks
 
 
 def test_cps_to_cpd():
@@ -28,3 +28,11 @@ def test_cps_to_bq_zero_volume():
 def test_cps_to_bq_negative_volume():
     with pytest.raises(ValueError):
         cps_to_bq(1.0, volume_liters=-1.0)
+
+
+def test_find_adc_bin_peaks_basic():
+    adc = [10, 10, 20, 20, 20, 30]
+    expected = {"p1": 10, "p2": 20}
+    result = find_adc_bin_peaks(adc, expected, window=2)
+    assert result["p1"] == pytest.approx(10.5)
+    assert result["p2"] == pytest.approx(20.5)

--- a/utils.py
+++ b/utils.py
@@ -5,7 +5,7 @@ from scipy.signal import find_peaks
 import math
 from dataclasses import is_dataclass, asdict
 
-__all__ = ["to_native", "find_adc_peaks", "cps_to_cpd", "cps_to_bq"]
+__all__ = ["to_native", "find_adc_bin_peaks", "cps_to_cpd", "cps_to_bq"]
 
 try:
     import pandas as pd
@@ -46,7 +46,7 @@ def to_native(obj):
     return obj
 
 
-def find_adc_peaks(adc_values, expected, window=50, prominence=0.0, width=None):
+def find_adc_bin_peaks(adc_values, expected, window=50, prominence=0.0, width=None):
     """Locate peak centroids in an ADC array.
 
     Parameters


### PR DESCRIPTION
## Summary
- rename `find_adc_peaks` helper to `find_adc_bin_peaks`
- update analysis import/call
- expose new name in `utils.__all__`
- add unit test for renamed helper

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c53071350832ba1de61dc90b50a74