### PR TITLE
Add fractional systematics scanning

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1073,8 +1073,11 @@ def main():
     # ────────────────────────────────────────────────────────────
     systematics_results = {}
     if cfg.get("systematics", {}).get("enable", False):
-        sigma_dict = cfg["systematics"].get("sigma_shifts", {})
-        keys = cfg["systematics"].get("scan_keys", [])
+        sys_cfg = cfg.get("systematics", {})
+        sigma_dict = {}
+        for name in ("sigma_E_frac", "tail_fraction", "energy_shift_keV"):
+            if name in sys_cfg:
+                sigma_dict[name] = sys_cfg[name]
 
         for iso, fit_out in time_fit_results.items():
             if not fit_out:
@@ -1134,7 +1137,7 @@ def main():
 
             try:
                 deltas, total_unc = scan_systematics(
-                    fit_wrapper, priors_time_all.get(iso, {}), sigma_dict, keys
+                    fit_wrapper, priors_time_all.get(iso, {}), sigma_dict
                 )
                 systematics_results[iso] = {"deltas": deltas, "total_unc": total_unc}
             except Exception as e:

--- a/config.json
+++ b/config.json
@@ -108,6 +108,9 @@
             "efficiency_Po214_shift_pct": 0.10,
             "efficiency_Po218_shift_pct": 0.10
         },
+        "sigma_E_frac": 0.10,
+        "tail_fraction": 0.05,
+        "energy_shift_keV": 1.0,
         "scan_keys": [],
         "adc_drift_rate": 0.0
     },

--- a/readme.txt
+++ b/readme.txt
@@ -300,6 +300,12 @@ is non-zero `analyze.py` applies the shift using
 `apply_linear_adc_shift` and stores the value in `summary.json` under
 `adc_drift_rate`.
 
+`sigma_E_frac`, `tail_fraction` and `energy_shift_keV` provide the
+magnitude of systematic shifts applied during the scan.  The first two
+are interpreted fractionally relative to the current parameter values,
+while `energy_shift_keV` is an absolute shift.  Each entry is optional
+and only affects the scan when present.
+
 `plot_time_style` chooses how the histogram is drawn in the time-series
 plot.  Use `"steps"` (default) for a stepped histogram or `"lines"` to
 connect bin centers with straight lines.  The line style is useful when

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -204,7 +204,7 @@ def test_n0_prior_from_baseline(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
     monkeypatch.setattr(baseline_noise, "estimate_baseline_noise", lambda *a, **k: (None, {}))
 
-    def fake_scan_systematics(fit_func, priors, sigma_dict, keys):
+    def fake_scan_systematics(fit_func, priors, sigma_dict):
         captured["priors"] = priors
         try:
             fit_func(priors)

--- a/tests/test_systematics.py
+++ b/tests/test_systematics.py
@@ -4,6 +4,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import numpy as np
 import pytest
+import math
 from systematics import scan_systematics, apply_linear_adc_shift
 
 
@@ -15,13 +16,12 @@ def test_scan_systematics_with_dict_result():
     }
 
     sigma_dict = {"p1": 0.5, "p2": 0.25}
-    keys = ["p1", "p2"]
 
     def dummy_fit(p):
         # Simple deterministic function returning parameter means plus 1
         return {k: v[0] + 1 for k, v in p.items()}
 
-    deltas, total_unc = scan_systematics(dummy_fit, priors, sigma_dict, keys)
+    deltas, total_unc = scan_systematics(dummy_fit, priors, sigma_dict)
     assert deltas["p1"] == pytest.approx(0.5)
     assert deltas["p2"] == pytest.approx(0.25)
     # Total uncertainty should be sqrt(0.5^2 + 0.25^2)
@@ -56,6 +56,20 @@ def test_scan_systematics_with_adc_drift():
 
     priors = {"drift": (0.0, 0.0)}
     sig = {"drift": 1.0}
-    deltas, tot = scan_systematics(fit_func, priors, sig, ["drift"])
+    deltas, tot = scan_systematics(fit_func, priors, sig)
     assert deltas["drift"] == pytest.approx(1.0)
     assert tot == pytest.approx(1.0)
+
+
+def test_scan_systematics_fractional_and_absolute():
+    priors = {"sigma_E": (2.0, 0.1), "mu": (5.0, 0.1)}
+
+    def fit_func(p):
+        return {k: v[0] for k, v in p.items()}
+
+    shifts = {"sigma_E_frac": 0.1, "mu_keV": 2.0}
+    deltas, tot = scan_systematics(fit_func, priors, shifts)
+    assert deltas["sigma_E"] == pytest.approx(0.2)
+    assert deltas["mu"] == pytest.approx(2.0)
+    expected = math.sqrt(0.2 ** 2 + 2.0 ** 2)
+    assert tot == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- extend configuration with `sigma_E_frac`, `tail_fraction` and `energy_shift_keV`
- interpret `_frac` and `_keV` suffixes in `scan_systematics`
- build the new sigma dict in `analyze.py`
- update docs and tests for new behaviour

## Testing
- `pytest -q` *(fails: Package 'numpy' is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_684c5309e8f4832bb77b5d9c1bd7b1d1