### PR TITLE
Fix Po210 default half life

### DIFF
--- a/plot_utils.py
+++ b/plot_utils.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 from datetime import datetime
 from color_schemes import COLOR_SCHEMES
-from constants import PO214, PO218, RN222
+from constants import PO214, PO218, PO210, RN222
 
 # Half-life constants used for the time-series overlay [seconds]
 PO214_HALF_LIFE_S = PO214.half_life_s
@@ -95,7 +95,7 @@ def plot_time_series(
                 _cfg_get(
                     config,
                     "hl_Po210",
-                    [default_const.get("Rn222", RN222).half_life_s],
+                    [default_const.get("Po210", PO210).half_life_s],
                 )[0]
             ),
         },


### PR DESCRIPTION
## Summary
- ensure Po210 constant is imported and used as default half-life in `plot_utils`
- verify the behaviour with new unit tests
- extend config-merge tests to check Po210 default

## Testing
- `pytest -q tests/test_plot_utils.py::test_plot_time_series_default_half_life_po210 tests/test_analyze_config_merge.py::test_hl_po210_default`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c53143aa8832ba94947c77b565df8