### PR TITLE
Support covariance in radon activity calculations

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -96,6 +96,23 @@ def _fit_params(obj):
     return {}
 
 
+def _cov_entry(fit: FitResult | dict, p1: str, p2: str) -> float:
+    """Return covariance between two parameters from a FitResult."""
+    if isinstance(fit, FitResult) and fit.cov is not None:
+        ordered = [
+            k for k in fit.params.keys() if k != "fit_valid" and not k.startswith("d")
+        ]
+        try:
+            i1 = ordered.index(p1)
+            i2 = ordered.index(p2)
+        except ValueError:
+            return 0.0
+        cov = np.asarray(fit.cov, dtype=float)
+        if cov.ndim >= 2 and i1 < cov.shape[0] and i2 < cov.shape[1]:
+            return float(cov[i1, i2])
+    return 0.0
+
+
 def window_prob(E, sigma, lo, hi):
     """Return probability that each ``E`` lies in [lo, hi].
 
@@ -114,9 +131,9 @@ def window_prob(E, sigma, lo, hi):
     zero_mask = sigma == 0
 
     if np.any(zero_mask):
-        prob[zero_mask] = (
-            (E[zero_mask] >= lo_val) & (E[zero_mask] <= hi_val)
-        ).astype(float)
+        prob[zero_mask] = ((E[zero_mask] >= lo_val) & (E[zero_mask] <= hi_val)).astype(
+            float
+        )
 
     if np.any(~zero_mask):
         nz = ~zero_mask
@@ -278,9 +295,7 @@ def parse_args():
     )
     p.add_argument(
         "--ambient-file",
-        help=(
-            "Two-column text file of timestamp and ambient concentration in Bq/L"
-        ),
+        help=("Two-column text file of timestamp and ambient concentration in Bq/L"),
     )
     p.add_argument(
         "--ambient-concentration",
@@ -311,10 +326,9 @@ def main():
     cli_args = sys.argv[:]
     cli_sha256 = hashlib.sha256(" ".join(cli_args).encode("utf-8")).hexdigest()
     try:
-        commit = (
-            subprocess.check_output(["git", "rev-parse", "HEAD"], encoding="utf-8")
-            .strip()
-        )
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], encoding="utf-8"
+        ).strip()
     except Exception:
         commit = "unknown"
 
@@ -347,7 +361,9 @@ def main():
             with open(args.efficiency_json, "r", encoding="utf-8") as f:
                 cfg["efficiency"] = json.load(f)
         except Exception as e:
-            print(f"ERROR: Could not load efficiency JSON '{args.efficiency_json}': {e}")
+            print(
+                f"ERROR: Could not load efficiency JSON '{args.efficiency_json}': {e}"
+            )
             sys.exit(1)
 
     if args.systematics_json:
@@ -355,7 +371,9 @@ def main():
             with open(args.systematics_json, "r", encoding="utf-8") as f:
                 cfg["systematics"] = json.load(f)
         except Exception as e:
-            print(f"ERROR: Could not load systematics JSON '{args.systematics_json}': {e}")
+            print(
+                f"ERROR: Could not load systematics JSON '{args.systematics_json}': {e}"
+            )
             sys.exit(1)
 
     if args.seed is not None:
@@ -405,7 +423,6 @@ def main():
             sig = current[1]
         tf["hl_Po210"] = [float(args.hl_po210), sig]
 
-
     def _log_override(section, key, new_val):
         prev = cfg.get(section, {}).get(key)
         if prev is not None and prev != new_val:
@@ -422,7 +439,9 @@ def main():
             "plot_time_bin_width_s",
             float(args.time_bin_width),
         )
-        cfg.setdefault("plotting", {})["plot_time_bin_width_s"] = float(args.time_bin_width)
+        cfg.setdefault("plotting", {})["plot_time_bin_width_s"] = float(
+            args.time_bin_width
+        )
     if args.dump_ts_json:
         cfg.setdefault("plotting", {})["dump_time_series_json"] = True
 
@@ -498,9 +517,7 @@ def main():
         try:
             thr_val = int(noise_thr)
         except (ValueError, TypeError):
-            logging.warning(
-                f"Invalid noise_cutoff '{noise_thr}' - skipping noise cut"
-            )
+            logging.warning(f"Invalid noise_cutoff '{noise_thr}' - skipping noise cut")
         else:
             before = len(events)
             events = events[events["adc"] > thr_val].reset_index(drop=True)
@@ -551,9 +568,7 @@ def main():
         try:
             t_spike_end = _to_epoch(spike_end_cfg)
         except Exception:
-            logging.warning(
-                f"Invalid spike_end_time '{spike_end_cfg}' - ignoring"
-            )
+            logging.warning(f"Invalid spike_end_time '{spike_end_cfg}' - ignoring")
             t_spike_end = None
 
     spike_periods_cfg = cfg.get("analysis", {}).get("spike_periods", [])
@@ -610,7 +625,9 @@ def main():
     if run_periods:
         keep_mask = np.zeros(len(events), dtype=bool)
         for start_ts, end_ts in run_periods:
-            keep_mask |= (events["timestamp"] >= start_ts) & (events["timestamp"] < end_ts)
+            keep_mask |= (events["timestamp"] >= start_ts) & (
+                events["timestamp"] < end_ts
+            )
         events = events[keep_mask].reset_index(drop=True)
         if t_end_cfg is None and len(events) > 0:
             t_end_global = events["timestamp"].max()
@@ -621,8 +638,10 @@ def main():
 
     # Optional ADC drift correction before calibration
     # Applied once using either the CLI value or the config default.
-    drift_rate = float(args.slope) if args.slope is not None else float(
-        cfg.get("systematics", {}).get("adc_drift_rate", 0.0)
+    drift_rate = (
+        float(args.slope)
+        if args.slope is not None
+        else float(cfg.get("systematics", {}).get("adc_drift_rate", 0.0))
     )
 
     if drift_rate != 0.0:
@@ -636,7 +655,6 @@ def main():
         except Exception as e:
             print(f"WARNING: Could not apply ADC drift correction -> {e}")
 
-
     # ────────────────────────────────────────────────────────────
     # 3. Energy calibration
     # ────────────────────────────────────────────────────────────
@@ -647,7 +665,9 @@ def main():
             # Auto‐cal using Freedman‐Diaconis histogram + peak detection
             cal_params = derive_calibration_constants_auto(
                 adc_vals,
-                noise_cutoff=cfg["calibration"].get("noise_cutoff", DEFAULT_NOISE_CUTOFF),
+                noise_cutoff=cfg["calibration"].get(
+                    "noise_cutoff", DEFAULT_NOISE_CUTOFF
+                ),
                 hist_bins=cfg["calibration"].get("hist_bins", 2000),
                 peak_search_radius=cfg["calibration"].get("peak_search_radius", 200),
                 nominal_adc=cfg["calibration"].get("nominal_adc"),
@@ -666,7 +686,7 @@ def main():
 
     # Apply linear calibration -> new column “energy_MeV” and its uncertainty
     events["energy_MeV"] = events["adc"] * a + c
-    events["denergy_MeV"] = np.sqrt((events["adc"] * a_sig) ** 2 + c_sig ** 2)
+    events["denergy_MeV"] = np.sqrt((events["adc"] * a_sig) ** 2 + c_sig**2)
 
     # ────────────────────────────────────────────────────────────
     # 4. Baseline run (optional)
@@ -696,9 +716,7 @@ def main():
         t_start_base = to_epoch(baseline_range[0])
         t_end_base = to_epoch(baseline_range[1])
         if t_end_base <= t_start_base:
-            raise ValueError(
-                "baseline_range end time must be greater than start time"
-            )
+            raise ValueError("baseline_range end time must be greater than start time")
         mask_base = (events["timestamp"] >= t_start_base) & (
             events["timestamp"] < t_end_base
         )
@@ -716,11 +734,7 @@ def main():
         try:
             from baseline_noise import estimate_baseline_noise
 
-            peak_adc = (
-                cal_params.get("peaks", {})
-                .get("Po210", {})
-                .get("centroid_adc")
-            )
+            peak_adc = cal_params.get("peaks", {}).get("Po210", {}).get("centroid_adc")
             if peak_adc is not None:
                 noise_level, _ = estimate_baseline_noise(
                     base_events["adc"].values,
@@ -732,12 +746,9 @@ def main():
         if noise_level is not None:
             baseline_info["noise_level"] = float(noise_level)
 
-
-
         # Remove baseline events from the main dataset before any fits.
         # This is done once here to avoid accidentally discarding data twice
         # which previously left an empty DataFrame for the time fits.
-
 
     # After creating ``base_events``, drop them from the dataset
     if baseline_range:
@@ -747,16 +758,10 @@ def main():
         if t_end_cfg is None:
             t_end_global = events["timestamp"].max()
 
-
-
-
         # Baseline events were already removed above. Avoid reapplying the mask
         # here since it may be misaligned after ``events`` has been
         # reindexed, which can inadvertently drop all remaining rows on
         # newer pandas versions.
-
-
-
 
     baseline_counts = {}
     # ────────────────────────────────────────────────────────────
@@ -809,7 +814,9 @@ def main():
         # Find approximate ADC centroids for Po‐210, Po‐218, Po‐214
 
         if "expected_peaks" not in cfg.get("spectral_fit", {}):
-            raise KeyError("'spectral_fit.expected_peaks' must be provided in the configuration")
+            raise KeyError(
+                "'spectral_fit.expected_peaks' must be provided in the configuration"
+            )
 
         expected_peaks = cfg["spectral_fit"]["expected_peaks"]
 
@@ -941,7 +948,9 @@ def main():
                 continue
 
             lo, hi = win_range
-            probs = window_prob(events["energy_MeV"].values, events["denergy_MeV"].values, lo, hi)
+            probs = window_prob(
+                events["energy_MeV"].values, events["denergy_MeV"].values, lo, hi
+            )
             iso_mask = probs > 0
             iso_events = events[iso_mask].copy()
             iso_events["weight"] = probs[iso_mask]
@@ -1297,13 +1306,17 @@ def main():
 
         delta214 = err_delta214 = None
         if "Po214" in time_fit_results:
-            fit = _fit_params(time_fit_results["Po214"])
+            fit_result = time_fit_results["Po214"]
+            fit = _fit_params(fit_result)
             E = fit.get("E_corrected", fit.get("E_Po214"))
             dE = fit.get("dE_Po214", 0.0)
             N0 = fit.get("N0_Po214", 0.0)
             dN0 = fit.get("dN0_Po214", 0.0)
-            default_rn = cfg.get("nuclide_constants", {}).get("Rn222", RN222).half_life_s
+            default_rn = (
+                cfg.get("nuclide_constants", {}).get("Rn222", RN222).half_life_s
+            )
             hl = cfg.get("time_fit", {}).get("hl_Po214", [default_rn])[0]
+            cov = _cov_entry(fit_result, "E_Po214", "N0_Po214")
             delta214, err_delta214 = radon_delta(
                 t_start_rel,
                 t_end_rel,
@@ -1312,17 +1325,22 @@ def main():
                 N0,
                 dN0,
                 hl,
+                cov,
             )
 
         delta218 = err_delta218 = None
         if "Po218" in time_fit_results:
-            fit = _fit_params(time_fit_results["Po218"])
+            fit_result = time_fit_results["Po218"]
+            fit = _fit_params(fit_result)
             E = fit.get("E_corrected", fit.get("E_Po218"))
             dE = fit.get("dE_Po218", 0.0)
             N0 = fit.get("N0_Po218", 0.0)
             dN0 = fit.get("dN0_Po218", 0.0)
-            default_rn = cfg.get("nuclide_constants", {}).get("Rn222", RN222).half_life_s
+            default_rn = (
+                cfg.get("nuclide_constants", {}).get("Rn222", RN222).half_life_s
+            )
             hl = cfg.get("time_fit", {}).get("hl_Po218", [default_rn])[0]
+            cov = _cov_entry(fit_result, "E_Po218", "N0_Po218")
             delta218, err_delta218 = radon_delta(
                 t_start_rel,
                 t_end_rel,
@@ -1331,6 +1349,7 @@ def main():
                 N0,
                 dN0,
                 hl,
+                cov,
             )
 
         d_radon, d_err = compute_radon_activity(
@@ -1390,7 +1409,9 @@ def main():
             "spike_periods": spike_periods_cfg,
             "run_periods": run_periods_cfg,
             "radon_interval": radon_interval_cfg,
-            "ambient_concentration": cfg.get("analysis", {}).get("ambient_concentration"),
+            "ambient_concentration": cfg.get("analysis", {}).get(
+                "ambient_concentration"
+            ),
         },
     }
 
@@ -1448,9 +1469,11 @@ def main():
     # Additional visualizations
     if efficiency_results.get("sources"):
         try:
-            errs_arr = np.array([s.get("error", 0.0) for s in efficiency_results["sources"].values()])
+            errs_arr = np.array(
+                [s.get("error", 0.0) for s in efficiency_results["sources"].values()]
+            )
             if errs_arr.size > 0:
-                cov = np.diag(errs_arr ** 2)
+                cov = np.diag(errs_arr**2)
                 cov_heatmap(
                     cov,
                     Path(out_dir) / "eff_cov.png",
@@ -1473,14 +1496,18 @@ def main():
 
         A214 = dA214 = None
         if "Po214" in time_fit_results:
-            fit = _fit_params(time_fit_results["Po214"])
+            fit_result = time_fit_results["Po214"]
+            fit = _fit_params(fit_result)
             E = fit.get("E_corrected", fit.get("E_Po214"))
             dE = fit.get("dE_Po214", 0.0)
             N0 = fit.get("N0_Po214", 0.0)
             dN0 = fit.get("dN0_Po214", 0.0)
-            default_rn = cfg.get("nuclide_constants", {}).get("Rn222", RN222).half_life_s
+            default_rn = (
+                cfg.get("nuclide_constants", {}).get("Rn222", RN222).half_life_s
+            )
             hl = cfg.get("time_fit", {}).get("hl_Po214", [default_rn])[0]
-            A214, dA214 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl)
+            cov = _cov_entry(fit_result, "E_Po214", "N0_Po214")
+            A214, dA214 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl, cov)
             plot_radon_activity(
                 times,
                 A214,
@@ -1491,14 +1518,18 @@ def main():
 
         A218 = dA218 = None
         if "Po218" in time_fit_results:
-            fit = _fit_params(time_fit_results["Po218"])
+            fit_result = time_fit_results["Po218"]
+            fit = _fit_params(fit_result)
             E = fit.get("E_corrected", fit.get("E_Po218"))
             dE = fit.get("dE_Po218", 0.0)
             N0 = fit.get("N0_Po218", 0.0)
             dN0 = fit.get("dN0_Po218", 0.0)
-            default_rn = cfg.get("nuclide_constants", {}).get("Rn222", RN222).half_life_s
+            default_rn = (
+                cfg.get("nuclide_constants", {}).get("Rn222", RN222).half_life_s
+            )
             hl = cfg.get("time_fit", {}).get("hl_Po218", [default_rn])[0]
-            A218, dA218 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl)
+            cov = _cov_entry(fit_result, "E_Po218", "N0_Po218")
+            A218, dA218 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl, cov)
 
         activity_arr = np.zeros_like(times, dtype=float)
         err_arr = np.zeros_like(times, dtype=float)
@@ -1539,24 +1570,36 @@ def main():
             rel_trend = times_trend - t0_global
             A214_tr = None
             if "Po214" in time_fit_results:
-                fit = _fit_params(time_fit_results["Po214"])
+                fit_result = time_fit_results["Po214"]
+                fit = _fit_params(fit_result)
                 E214 = fit.get("E_corrected", fit.get("E_Po214"))
                 dE214 = fit.get("dE_Po214", 0.0)
                 N0214 = fit.get("N0_Po214", 0.0)
                 dN0214 = fit.get("dN0_Po214", 0.0)
-                default_rn = cfg.get("nuclide_constants", {}).get("Rn222", RN222).half_life_s
+                default_rn = (
+                    cfg.get("nuclide_constants", {}).get("Rn222", RN222).half_life_s
+                )
                 hl214 = cfg.get("time_fit", {}).get("hl_Po214", [default_rn])[0]
-                A214_tr, _ = radon_activity_curve(rel_trend, E214, dE214, N0214, dN0214, hl214)
+                cov214 = _cov_entry(fit_result, "E_Po214", "N0_Po214")
+                A214_tr, _ = radon_activity_curve(
+                    rel_trend, E214, dE214, N0214, dN0214, hl214, cov214
+                )
             A218_tr = None
             if "Po218" in time_fit_results:
-                fit = _fit_params(time_fit_results["Po218"])
+                fit_result = time_fit_results["Po218"]
+                fit = _fit_params(fit_result)
                 E218 = fit.get("E_corrected", fit.get("E_Po218"))
                 dE218 = fit.get("dE_Po218", 0.0)
                 N0218 = fit.get("N0_Po218", 0.0)
                 dN0218 = fit.get("dN0_Po218", 0.0)
-                default_rn = cfg.get("nuclide_constants", {}).get("Rn222", RN222).half_life_s
+                default_rn = (
+                    cfg.get("nuclide_constants", {}).get("Rn222", RN222).half_life_s
+                )
                 hl218 = cfg.get("time_fit", {}).get("hl_Po218", [default_rn])[0]
-                A218_tr, _ = radon_activity_curve(rel_trend, E218, dE218, N0218, dN0218, hl218)
+                cov218 = _cov_entry(fit_result, "E_Po218", "N0_Po218")
+                A218_tr, _ = radon_activity_curve(
+                    rel_trend, E218, dE218, N0218, dN0218, hl218, cov218
+                )
             trend = np.zeros_like(times_trend)
             for i in range(times_trend.size):
                 r214 = A214_tr[i] if A214_tr is not None else None
@@ -1577,7 +1620,9 @@ def main():
                 dat = np.loadtxt(args.ambient_file, usecols=(0, 1))
                 ambient_interp = np.interp(times, dat[:, 0], dat[:, 1])
             except Exception as e:
-                print(f"WARNING: Could not read ambient file '{args.ambient_file}': {e}")
+                print(
+                    f"WARNING: Could not read ambient file '{args.ambient_file}': {e}"
+                )
 
         if ambient_interp is not None:
             vol_arr = activity_arr / ambient_interp


### PR DESCRIPTION
## Summary
- add optional `cov_en0` arg to `radon_activity_curve` and `radon_delta`
- extract covariance elements from `FitResult` in `analyze.py`
- propagate covariance when plotting radon activity and computing radon delta
- test uncertainty propagation with non-zero covariance

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c53172fa4832ba5415be800c7e9b3