### PR TITLE
Fix duplicate config keys

### DIFF
--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -1721,7 +1721,6 @@ def test_hl_po210_cli_overrides(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_Po214": [0.0, 20.0],
-            "window_Po210": [5.0, 6.0],
             "window_Po218": [0.0, 20.0],
             "window_Po210": [5.2, 5.4],
             "hl_Po214": [1.0, 0.0],


### PR DESCRIPTION
## Summary
- drop repeated `window_Po210` entry in test config

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c5361dcb8832b931d786276c4736d