### PR TITLE
Add JSON schema validation and duplicate key checks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest>=6.0
 pandas>=1.2
 iminuit>=2.0
 pymc
+jsonschema>=4.0


### PR DESCRIPTION
## Summary
- validate configuration with jsonschema in `load_config`
- detect duplicate keys when loading JSON
- enforce positive half-life for nuclide overrides
- extend tests for validation errors and duplicate key detection
- add jsonschema to requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c53651fdc832bb548cc7c4341bab8