### PR TITLE
Rename peak finder helper

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -84,7 +84,7 @@ from plot_utils import (
 )
 from systematics import scan_systematics, apply_linear_adc_shift
 from visualize import cov_heatmap, efficiency_bar
-from utils import find_adc_peaks, cps_to_bq
+from utils import find_adc_bin_peaks, cps_to_bq
 
 
 def _fit_params(obj):
@@ -820,8 +820,8 @@ def main():
 
         expected_peaks = cfg["spectral_fit"]["expected_peaks"]
 
-        # `find_adc_peaks` will return a dict: e.g. { "Po210": adc_centroid, … }
-        adc_peaks = find_adc_peaks(
+        # `find_adc_bin_peaks` will return a dict: e.g. { "Po210": adc_centroid, … }
+        adc_peaks = find_adc_bin_peaks(
             events["adc"].values,
             expected=expected_peaks,
             window=cfg["spectral_fit"].get("peak_search_width_adc", 50),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from utils import cps_to_cpd, cps_to_bq
+from utils import cps_to_cpd, cps_to_bq, find_adc_bin_peaks
 
 
 def test_cps_to_cpd():
@@ -28,3 +28,12 @@ def test_cps_to_bq_zero_volume():
 def test_cps_to_bq_negative_volume():
     with pytest.raises(ValueError):
         cps_to_bq(1.0, volume_liters=-1.0)
+
+
+def test_find_adc_bin_peaks_simple():
+    adc = [5, 10, 10, 10, 15, 20, 20, 20, 25]
+    expected = {"peak1": 10, "peak2": 20}
+    res = find_adc_bin_peaks(adc, expected, window=3)
+    assert set(res) == {"peak1", "peak2"}
+    assert pytest.approx(res["peak1"], rel=1e-3) == 10.5
+    assert pytest.approx(res["peak2"], rel=1e-3) == 20.5

--- a/utils.py
+++ b/utils.py
@@ -5,7 +5,7 @@ from scipy.signal import find_peaks
 import math
 from dataclasses import is_dataclass, asdict
 
-__all__ = ["to_native", "find_adc_peaks", "cps_to_cpd", "cps_to_bq"]
+__all__ = ["to_native", "find_adc_bin_peaks", "cps_to_cpd", "cps_to_bq"]
 
 try:
     import pandas as pd
@@ -46,7 +46,7 @@ def to_native(obj):
     return obj
 
 
-def find_adc_peaks(adc_values, expected, window=50, prominence=0.0, width=None):
+def find_adc_bin_peaks(adc_values, expected, window=50, prominence=0.0, width=None):
     """Locate peak centroids in an ADC array.
 
     Parameters
@@ -65,7 +65,7 @@ def find_adc_peaks(adc_values, expected, window=50, prominence=0.0, width=None):
     Returns
     -------
     dict
-        {peak_name: adc_centroid}
+        Mapping of peak name to centroid position in ADC units.
     """
     adc_arr = np.asarray(adc_values, dtype=float)
     if adc_arr.size == 0:


### PR DESCRIPTION
## Summary
- rename `find_adc_peaks` -> `find_adc_bin_peaks`
- update analyze pipeline to use the new helper
- document ADC units in utils docstring
- unit test new helper

## Testing
- `bash scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c53a24c00832bb44e2775bf7c2dcf