### PR TITLE
Fix Po210 half-life default

### DIFF
--- a/plot_utils.py
+++ b/plot_utils.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 from datetime import datetime
 from color_schemes import COLOR_SCHEMES
-from constants import PO214, PO218, RN222
+from constants import PO214, PO218, PO210, RN222
 
 # Half-life constants used for the time-series overlay [seconds]
 PO214_HALF_LIFE_S = PO214.half_life_s
@@ -95,7 +95,7 @@ def plot_time_series(
                 _cfg_get(
                     config,
                     "hl_Po210",
-                    [default_const.get("Rn222", RN222).half_life_s],
+                    [default_const.get("Po210", PO210).half_life_s],
                 )[0]
             ),
         },

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -8,6 +8,7 @@ import logging
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 from fitting import FitResult
+from constants import PO210
 
 
 def test_plot_time_series_receives_merged_config(tmp_path, monkeypatch):
@@ -472,6 +473,8 @@ def test_po210_time_series_plot_generated(tmp_path, monkeypatch):
 
     def fake_plot(*args, **kwargs):
         outputs.append(Path(kwargs["out_png"]).name)
+        hl = kwargs["config"].get("hl_Po210", [PO210.half_life_s])[0]
+        assert hl == PO210.half_life_s
         Path(kwargs["out_png"]).touch()
         return None
 

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -5,6 +5,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from plot_utils import plot_time_series, plot_spectrum
+from constants import PO210
 
 
 def basic_config():
@@ -259,6 +260,40 @@ def test_plot_time_series_po210_no_model(tmp_path, monkeypatch):
     )
 
     assert "Model Po210" not in labels
+
+
+def test_plot_time_series_default_po210_half_life(tmp_path, monkeypatch):
+    times = np.array([1000.1, 1001.1])
+    energies = np.array([5.3, 5.35])
+    cfg = basic_config()
+    cfg.update({"window_Po210": [5.2, 5.4], "eff_Po210": [1.0]})
+
+    captured = {}
+
+    def fake_plot(x, y, *args, **kwargs):
+        if kwargs.get("label") == "Model Po210":
+            captured["y"] = np.array(y)
+        return type("obj", (), {})()
+
+    monkeypatch.setattr("plot_utils.plt.plot", fake_plot)
+    monkeypatch.setattr("plot_utils.plt.step", fake_plot)
+    monkeypatch.setattr("plot_utils.plt.savefig", lambda *a, **k: None)
+
+    plot_time_series(
+        times,
+        energies,
+        {"E": 0.2, "B": 0.0, "N0": 0.0},
+        1000.0,
+        1002.0,
+        cfg,
+        str(tmp_path / "ts_default_p210.png"),
+    )
+
+    lam = np.log(2.0) / PO210.half_life_s
+    centers = np.array([0.5, 1.5])
+    expected = 0.2 * (1.0 - np.exp(-lam * centers))
+    assert "y" in captured
+    assert np.allclose(captured["y"], expected, rtol=1e-4)
 
 
 def test_plot_time_series_rate_normalisation(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- import Po210 constant in plot_utils
- use Po210 half-life for Po210 time-series default
- test Po210 default in plot_utils
- verify Po210 default in config-merge tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c5362c8b0832b99e900e4aac59b83