### PR TITLE
Add Po-210 time-series support and radon activity

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -61,8 +61,7 @@ The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--j
 - `summary.json` – calibration and fit summary.
 - `config_used.json` – copy of the configuration used.
 - `spectrum.png` – spectrum plot with fitted peaks.
-- `time_series_Po214.png` and `time_series_Po218.png` – decay time-series plots.
-- `time_series_Po210.png` when `window_Po210` is set.
+ - `time_series_Po214.png`, `time_series_Po218.png` and `time_series_Po210.png` – decay time-series plots when the corresponding windows are provided.
 - Optional `*_ts.json` files containing binned time series when enabled.
 - `efficiency.png` – bar chart of individual efficiencies and the BLUE result.
 - `eff_cov.png` – heatmap of the efficiency covariance matrix.
@@ -70,9 +69,9 @@ The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--j
  - `equivalent_air.png` – equivalent air volume plot when `--ambient-file` or
    `--ambient-concentration` is provided.
 
-The `time_fit` routine still fits only Po‑214 and Po‑218.
-When `window_Po210` is provided the Po‑210 events are extracted and a
-time‑series histogram is produced without a decay fit.
+The `time_fit` routine fits Po‑214 and Po‑218 by default. When
+`window_Po210` (and optional `eff_Po210`) is supplied Po‑210 is fitted as
+well and its model curve appears in the time-series plot.
 
 The time‐series model multiplies the decay rate by the detection efficiency
 internally.  Therefore the fitted `E_Po214` and `E_Po218` values correspond to
@@ -421,8 +420,8 @@ python utils.py 0.5 --to bq --volume_liters 10
 
 ## Radon Activity Output
 
-After the decay fits a weighted average of the Po‑218 and Po‑214 rates is
-converted to an instantaneous radon activity.  The result is written to
+After the decay fits a weighted average of the Po‑218, Po‑214 and, when
+available, Po‑210 rates is converted to an instantaneous radon activity.  The result is written to
 `summary.json` under `radon_results` together with the corresponding
 concentration (per liter) and the total amount of radon contained in the
 sample volume.  The file `radon_activity.png` visualises this
@@ -431,8 +430,9 @@ activity versus time.  When either `--ambient-file` or
 `equivalent_air.png` shows the volume of ambient air containing the same
 activity.
 The Po‑214 activity alone is plotted in `radon_activity_po214.png`. When
+Po‑210 is fitted, `radon_activity_po210.png` shows its contribution. When
 ambient concentration data are available, `equivalent_air_po214.png`
-shows the equivalent air volume derived from this Po‑214 activity.
+shows the equivalent air volume derived from the Po‑214 activity.
 
 ## Efficiency Calculations
 

--- a/tests/test_po210_summary.py
+++ b/tests/test_po210_summary.py
@@ -1,0 +1,73 @@
+import sys
+from pathlib import Path
+import json
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+import radon_activity
+from fitting import FitResult
+
+
+def test_po210_time_fit_written(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": True,
+            "window_Po210": [5.0, 6.0],
+            "hl_Po210": [1.0, 0.0],
+            "eff_Po210": [1.0, 0.0],
+            "flags": {},
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0.0], "adc": [5.5], "fchannel": [1]})
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+
+    import numpy as np
+
+    def fake_fit(ts, start, end, cfg, weights=None):
+        assert "Po210" in ts
+        return FitResult({"E_Po210": 2.0, "dE_Po210": 0.1}, np.zeros((1, 1)), 0)
+    monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
+
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+
+    calls = []
+    def fake_radon(*args, **kwargs):
+        calls.append(args)
+        return (1.0, 0.1)
+    monkeypatch.setattr(radon_activity, "compute_radon_activity", fake_radon)
+
+    captured = {}
+    def fake_write(out_dir, summary, timestamp=None):
+        captured["summary"] = summary
+        d = Path(out_dir) / (timestamp or "x")
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = ["analyze.py", "--config", str(cfg_path), "--input", str(data_path), "--output_dir", str(tmp_path)]
+    monkeypatch.setattr(sys, "argv", args)
+
+    analyze.main()
+
+    summary = captured.get("summary", {})
+    assert summary["time_fit"]["Po210"]["E_Po210"] == pytest.approx(2.0)
+    assert calls and calls[0][6] == 2.0


### PR DESCRIPTION
## Summary
- extend `compute_radon_activity` to handle optional Po‑210 input
- loop over Po‑218, Po‑214 and Po‑210 when fitting time series
- include Po‑210 in radon activity calculations and plots
- document Po‑210 fitting in README
- test propagation of Po‑210 fit results to summary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c52665034832bad2068c2c5f6156a