### PR TITLE
Improve logging of CLI overrides

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -376,6 +376,13 @@ def main():
         print(f"ERROR: Could not load config '{args.config}': {e}")
         sys.exit(1)
 
+    def _log_override(section, key, new_val):
+        prev = cfg.get(section, {}).get(key)
+        if prev is not None and prev != new_val:
+            logging.info(
+                f"Overriding {section}.{key}={prev!r} with {new_val!r} from CLI"
+            )
+
     # Apply optional overrides from command-line arguments
     if args.efficiency_json:
         try:
@@ -398,26 +405,37 @@ def main():
             sys.exit(1)
 
     if args.seed is not None:
+        _log_override("pipeline", "random_seed", int(args.seed))
         cfg.setdefault("pipeline", {})["random_seed"] = int(args.seed)
 
     if args.ambient_concentration is not None:
+        _log_override(
+            "analysis",
+            "ambient_concentration",
+            float(args.ambient_concentration),
+        )
         cfg.setdefault("analysis", {})["ambient_concentration"] = float(
             args.ambient_concentration
         )
 
     if args.analysis_end_time is not None:
+        _log_override("analysis", "analysis_end_time", args.analysis_end_time)
         cfg.setdefault("analysis", {})["analysis_end_time"] = args.analysis_end_time
 
     if args.spike_end_time is not None:
+        _log_override("analysis", "spike_end_time", args.spike_end_time)
         cfg.setdefault("analysis", {})["spike_end_time"] = args.spike_end_time
 
     if args.spike_period:
+        _log_override("analysis", "spike_periods", args.spike_period)
         cfg.setdefault("analysis", {})["spike_periods"] = args.spike_period
 
     if args.run_period:
+        _log_override("analysis", "run_periods", args.run_period)
         cfg.setdefault("analysis", {})["run_periods"] = args.run_period
 
     if args.radon_interval:
+        _log_override("analysis", "radon_interval", args.radon_interval)
         cfg.setdefault("analysis", {})["radon_interval"] = args.radon_interval
 
     if args.hl_po214 is not None:
@@ -426,6 +444,7 @@ def main():
         current = tf.get("hl_Po214")
         if isinstance(current, list) and len(current) > 1:
             sig = current[1]
+        _log_override("time_fit", "hl_Po214", [float(args.hl_po214), sig])
         tf["hl_Po214"] = [float(args.hl_po214), sig]
 
     if args.hl_po218 is not None:
@@ -434,6 +453,7 @@ def main():
         current = tf.get("hl_Po218")
         if isinstance(current, list) and len(current) > 1:
             sig = current[1]
+        _log_override("time_fit", "hl_Po218", [float(args.hl_po218), sig])
         tf["hl_Po218"] = [float(args.hl_po218), sig]
 
     if args.hl_po210 is not None:
@@ -442,14 +462,8 @@ def main():
         current = tf.get("hl_Po210")
         if isinstance(current, list) and len(current) > 1:
             sig = current[1]
+        _log_override("time_fit", "hl_Po210", [float(args.hl_po210), sig])
         tf["hl_Po210"] = [float(args.hl_po210), sig]
-
-    def _log_override(section, key, new_val):
-        prev = cfg.get(section, {}).get(key)
-        if prev is not None and prev != new_val:
-            logging.info(
-                f"Overriding {section}.{key}={prev!r} with {new_val!r} from CLI"
-            )
 
     if args.time_bin_mode:
         _log_override("plotting", "plot_time_binning_mode", args.time_bin_mode)
@@ -474,6 +488,7 @@ def main():
             eff_sec["error"] = float(args.spike_count_err)
 
     if args.slope is not None:
+        _log_override("systematics", "adc_drift_rate", float(args.slope))
         cfg.setdefault("systematics", {})["adc_drift_rate"] = float(args.slope)
 
     if args.noise_cutoff is not None:

--- a/tests/test_override_logging.py
+++ b/tests/test_override_logging.py
@@ -1,0 +1,59 @@
+import json
+import sys
+import logging
+from pathlib import Path
+import pandas as pd
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+from fitting import FitResult
+
+
+def _minimal_patches(monkeypatch):
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0, 0)), 0))
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+
+def test_analysis_end_time_override_logs(tmp_path, monkeypatch, caplog):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "analysis": {"analysis_end_time": "1970-01-01T00:00:05Z"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    data_path = tmp_path / "data.csv"
+    df.to_csv(data_path, index=False)
+
+    _minimal_patches(monkeypatch)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+        "--analysis-end-time",
+        "1970-01-01T00:00:06Z",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    with caplog.at_level(logging.INFO):
+        analyze.main()
+
+    assert "analysis.analysis_end_time" in caplog.text


### PR DESCRIPTION
## Summary
- log CLI overrides in `analyze.main`
- add test for new override logging

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c88390374832b9d1769eba3fede3f