### PR TITLE
Log config overrides for more CLI options

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -376,6 +376,13 @@ def main():
         print(f"ERROR: Could not load config '{args.config}': {e}")
         sys.exit(1)
 
+    def _log_override(section, key, new_val):
+        prev = cfg.get(section, {}).get(key)
+        if prev is not None and prev != new_val:
+            logging.info(
+                f"Overriding {section}.{key}={prev!r} with {new_val!r} from CLI"
+            )
+
     # Apply optional overrides from command-line arguments
     if args.efficiency_json:
         try:
@@ -406,18 +413,22 @@ def main():
         )
 
     if args.analysis_end_time is not None:
+        _log_override("analysis", "analysis_end_time", args.analysis_end_time)
         cfg.setdefault("analysis", {})["analysis_end_time"] = args.analysis_end_time
 
     if args.spike_end_time is not None:
+        _log_override("analysis", "spike_end_time", args.spike_end_time)
         cfg.setdefault("analysis", {})["spike_end_time"] = args.spike_end_time
 
     if args.spike_period:
         cfg.setdefault("analysis", {})["spike_periods"] = args.spike_period
 
     if args.run_period:
+        _log_override("analysis", "run_periods", args.run_period)
         cfg.setdefault("analysis", {})["run_periods"] = args.run_period
 
     if args.radon_interval:
+        _log_override("analysis", "radon_interval", args.radon_interval)
         cfg.setdefault("analysis", {})["radon_interval"] = args.radon_interval
 
     if args.hl_po214 is not None:
@@ -444,13 +455,6 @@ def main():
             sig = current[1]
         tf["hl_Po210"] = [float(args.hl_po210), sig]
 
-    def _log_override(section, key, new_val):
-        prev = cfg.get(section, {}).get(key)
-        if prev is not None and prev != new_val:
-            logging.info(
-                f"Overriding {section}.{key}={prev!r} with {new_val!r} from CLI"
-            )
-
     if args.time_bin_mode:
         _log_override("plotting", "plot_time_binning_mode", args.time_bin_mode)
         cfg.setdefault("plotting", {})["plot_time_binning_mode"] = args.time_bin_mode
@@ -474,6 +478,7 @@ def main():
             eff_sec["error"] = float(args.spike_count_err)
 
     if args.slope is not None:
+        _log_override("systematics", "adc_drift_rate", float(args.slope))
         cfg.setdefault("systematics", {})["adc_drift_rate"] = float(args.slope)
 
     if args.noise_cutoff is not None:


### PR DESCRIPTION
## Summary
- log when CLI overrides analysis_end_time, spike_end_time, run_periods, radon_interval and slope
- move `_log_override` earlier so it can be reused
- keep baseline range logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c8826f1a8832ba628d667a3c9bd2f