### PR TITLE
Remove obsolete scan_keys references

### DIFF
--- a/config.json
+++ b/config.json
@@ -111,7 +111,6 @@
         "sigma_E_frac": 0.10,
         "tail_fraction": 0.05,
         "energy_shift_keV": 1.0,
-        "scan_keys": [],
         "adc_drift_rate": 0.0
     },
     "plotting": {

--- a/readme.txt
+++ b/readme.txt
@@ -292,9 +292,6 @@ Example snippet:
 `dump_time_series_json` under `plotting` saves a `*_ts.json` file
 containing the binned time-series data when set to `true`.
 
-`scan_keys` in the `systematics` section selects which fit parameters
-are varied during the systematic uncertainty scan.  By default no
-parameters are scanned.
 
 `adc_drift_rate` under `systematics` applies a linear time-dependent
 shift to the raw ADC values before calibration.  The value is in ADC

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -296,7 +296,7 @@ def test_systematics_json_cli(tmp_path, monkeypatch):
     data = tmp_path / "d.csv"
     df.to_csv(data, index=False)
 
-    sys_cfg = {"enable": True, "sigma_shifts": {}, "scan_keys": []}
+    sys_cfg = {"enable": True, "sigma_shifts": {}}
     sys_path = tmp_path / "sys.json"
     with open(sys_path, "w") as f:
         json.dump(sys_cfg, f)

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -171,7 +171,7 @@ def test_n0_prior_from_baseline(tmp_path, monkeypatch):
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },
-        "systematics": {"enable": True, "sigma_shifts": {}, "scan_keys": []},
+        "systematics": {"enable": True, "sigma_shifts": {}},
         "plotting": {"plot_save_formats": ["png"]},
     }
     cfg_path = tmp_path / "cfg.json"


### PR DESCRIPTION
## Summary
- remove `scan_keys` references from documentation
- drop `scan_keys` from example config
- update unit test config fixtures

## Testing
- `pytest -q` *(fails: Package 'numpy' is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_684c87d95df0832b95e6c40128b302cf