### PR TITLE
Remove redundant config structure checks

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -124,21 +124,7 @@ def load_config(config_path):
 
     cfg["nuclide_constants"] = load_nuclide_overrides(cfg)
 
-    # Basic validation: check for required keys within each section
-    required_structure = {
-        "pipeline": ["log_level"],
-        "spectral_fit": ["expected_peaks"],
-        "time_fit": ["do_time_fit"],
-        "systematics": ["enable"],
-        "plotting": ["plot_save_formats"],
-    }
-
-    for section, keys in required_structure.items():
-        if section not in cfg:
-            raise KeyError(f"Missing required config section: '{section}'")
-        for key in keys:
-            if key not in cfg.get(section, {}):
-                raise KeyError(f"Missing key '{section}.{key}' in config")
+    # CONFIG_SCHEMA validation already checks required keys
 
     return cfg
 


### PR DESCRIPTION
## Summary
- rely solely on CONFIG_SCHEMA for configuration validation
- drop duplicate required key checks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c88bbedb8832b8c1d372ce0b7e702