### PR TITLE
Remove obsolete sigma_shifts

### DIFF
--- a/config.json
+++ b/config.json
@@ -102,12 +102,6 @@
     },
     "systematics": {
         "enable": false,
-        "sigma_shifts": {
-            "calibration_a_shift_pct": 0.05,
-            "calibration_c_shift_abs": 0.05,
-            "efficiency_Po214_shift_pct": 0.10,
-            "efficiency_Po218_shift_pct": 0.10
-        },
         "sigma_E_frac": 0.10,
         "tail_fraction": 0.05,
         "energy_shift_keV": 1.0,

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -296,7 +296,7 @@ def test_systematics_json_cli(tmp_path, monkeypatch):
     data = tmp_path / "d.csv"
     df.to_csv(data, index=False)
 
-    sys_cfg = {"enable": True, "sigma_shifts": {}, "scan_keys": []}
+    sys_cfg = {"enable": True, "scan_keys": []}
     sys_path = tmp_path / "sys.json"
     with open(sys_path, "w") as f:
         json.dump(sys_cfg, f)

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -171,7 +171,7 @@ def test_n0_prior_from_baseline(tmp_path, monkeypatch):
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },
-        "systematics": {"enable": True, "sigma_shifts": {}, "scan_keys": []},
+        "systematics": {"enable": True, "scan_keys": []},
         "plotting": {"plot_save_formats": ["png"]},
     }
     cfg_path = tmp_path / "cfg.json"

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -38,15 +38,7 @@ def test_load_config(tmp_path):
             "baseline_range": None,
             "cl_level": 0.95,
         },
-        "systematics": {
-            "enable": False,
-            "sigma_shifts": {
-                "slope": 0.05,
-                "intercept": 0.05,
-                "eff_po214": 0.1,
-                "eff_po218": 0.1,
-            },
-        },
+        "systematics": {"enable": False},
         "pipeline": {"log_level": "INFO"},
         "spectral_fit": {
             "expected_peaks": {"Po210": 1250, "Po218": 1400, "Po214": 1800}


### PR DESCRIPTION
## Summary
- drop unused `sigma_shifts` settings from `config.json`
- update tests expecting the obsolete field

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c88ca3880832b9f70ad127b8c8569