### PR TITLE
Add covariance helper tests

### DIFF
--- a/tests/test_cov_entry.py
+++ b/tests/test_cov_entry.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+from fitting import FitResult
+
+
+def test_cov_entry_valid_params():
+    params = {
+        "fit_valid": True,
+        "dextra": 0.0,
+        "A": 1.0,
+        "B": 2.0,
+        "C": 3.0,
+    }
+    cov = np.array(
+        [
+            [1.0, 0.1, 0.2],
+            [0.1, 4.0, 0.3],
+            [0.2, 0.3, 9.0],
+        ]
+    )
+    fr = FitResult(params, cov, 0)
+    assert analyze._cov_entry(fr, "A", "B") == pytest.approx(0.1)
+    assert analyze._cov_entry(fr, "C", "A") == pytest.approx(0.2)
+    assert analyze._cov_entry(fr, "B", "C") == pytest.approx(0.3)
+
+
+def test_cov_entry_missing_or_none():
+    params = {"A": 1.0, "B": 2.0}
+    cov = np.eye(2)
+    fr = FitResult(params, cov, 0)
+    assert analyze._cov_entry(fr, "A", "C") == 0.0
+    fr_none = FitResult(params, None, 0)
+    assert analyze._cov_entry(fr_none, "A", "B") == 0.0


### PR DESCRIPTION
## Summary
- add unit test for `_cov_entry` helper
- verify values are read from covariance matrix
- test fallback behaviour when parameters are missing or covariance is `None`

## Testing
- `pytest tests/test_cov_entry.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c88b33c64832b914c98287c294f7f