### PR TITLE
Enable Po-210 time-series fitting

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -70,9 +70,10 @@ The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--j
  - `equivalent_air.png` – equivalent air volume plot when `--ambient-file` or
    `--ambient-concentration` is provided.
 
-The `time_fit` routine still fits only Po‑214 and Po‑218.
-When `window_Po210` is provided the Po‑210 events are extracted and a
-time‑series histogram is produced without a decay fit.
+The `time_fit` routine fits Po‑214 and Po‑218 by default and also Po‑210
+when `window_Po210` is provided.  Po‑210 fit results are written to
+`summary.json` and shown in the time‑series plot but are **not** used for
+the radon‑activity prediction.
 
 The time‐series model multiplies the decay rate by the detection efficiency
 internally.  Therefore the fitted `E_Po214` and `E_Po218` values correspond to
@@ -317,8 +318,8 @@ when invoking `plot_time_series`.  When set to `true` the analysis does
 not clear the other window, allowing Po‑214 and Po‑218 to be plotted
 together on a single overlay.
 Specifying `window_Po210` (and optional `eff_Po210`) adds a Po‑210
-histogram to the time-series plots. The model curve appears only when
-fit results for Po‑210 are available.
+histogram to the time-series plots. The decay model is drawn when the
+time‑series fit for Po‑210 succeeds.
 
 `palette` under `plotting` selects the color scheme used for all plots.
 Available options are `"default"`, `"colorblind"` and `"grayscale"`.
@@ -437,7 +438,8 @@ python utils.py 0.5 --to bq --volume_liters 10
 ## Radon Activity Output
 
 After the decay fits a weighted average of the Po‑218 and Po‑214 rates is
-converted to an instantaneous radon activity.  The result is written to
+converted to an instantaneous radon activity.  Po‑210 is ignored in this
+calculation since it may not be in equilibrium.  The result is written to
 `summary.json` under `radon_results` together with the corresponding
 concentration (per liter) and the total amount of radon contained in the
 sample volume.  The file `radon_activity.png` visualises this

--- a/tests/test_po210_summary.py
+++ b/tests/test_po210_summary.py
@@ -1,0 +1,90 @@
+import json
+import sys
+from pathlib import Path
+import pandas as pd
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+from fitting import FitResult
+import radon_activity
+
+
+def test_po210_fit_results_in_summary(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": True,
+            "window_Po210": [5.2, 5.4],
+            "hl_Po210": [1.0, 0.0],
+            "eff_Po210": [1.0, 0.0],
+            "flags": {},
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1],
+        "fBits": [0],
+        "timestamp": [0.1],
+        "adc": [100],
+        "fchannel": [1],
+    })
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {}}
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "apply_burst_filter", lambda df, cfg, mode="rate": (df, 0))
+
+    def fake_fit(ts_dict, t_start, t_end, cfg, weights=None):
+        assert list(ts_dict.keys()) == ["Po210"]
+        return FitResult({"E_Po210": 2.0}, np.zeros((1, 1)), 0)
+
+    monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
+
+    called = {}
+
+    def fake_radon(*args, **kwargs):
+        called["args"] = args
+        return 0.0, float("nan")
+
+    monkeypatch.setattr(radon_activity, "compute_radon_activity", fake_radon)
+
+    captured = {}
+
+    def fake_write(out_dir, summary, timestamp=None):
+        captured["summary"] = summary
+        d = Path(out_dir) / (timestamp or "x")
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config", str(cfg_path),
+        "--input", str(data_path),
+        "--output_dir", str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    summary = captured.get("summary", {})
+    assert summary["time_fit"].get("Po210", {}).get("E_Po210") == 2.0
+    # compute_radon_activity should not receive Po-210 rate
+    assert len(called.get("args", [])) == 6
+    assert called["args"] == (None, None, 1.0, None, None, 1.0)
+


### PR DESCRIPTION
## Summary
- include Po-210 in the decay-fit loop
- default to nuclide constants for missing half-lives
- skip Po-210 plot extraction when already fitted
- document Po-210 support and exclusion from radon activity
- add regression test for Po-210 fit propagation

## Testing
- `pytest tests/test_po210_summary.py::test_po210_fit_results_in_summary -q`
- `pytest -q` *(fails: KeyError: 'times')*

------
https://chatgpt.com/codex/tasks/task_e_684cb140fe38832b801e6ecb929e565f