### PR TITLE
Add compatibility wrappers for adc drift and BLUE combination

### DIFF
--- a/adc_drift.py
+++ b/adc_drift.py
@@ -1,0 +1,5 @@
+"""Compatibility wrapper for ADC drift correction."""
+
+from systematics import apply_linear_adc_shift as correct
+
+__all__ = ["correct"]

--- a/blue_combine.py
+++ b/blue_combine.py
@@ -1,0 +1,22 @@
+"""Compatibility layer for BLUE combination."""
+
+from dataclasses import dataclass
+from typing import Sequence, Optional
+import numpy as np
+
+from efficiency import blue_combine
+
+CovarianceMatrix = np.ndarray
+
+@dataclass
+class Measurements:
+    values: Sequence[float]
+    errors: Sequence[float]
+    corr: Optional[np.ndarray] = None
+
+
+def BLUE(measurements: Measurements):
+    """Return BLUE combination of the given measurements."""
+    return blue_combine(measurements.values, measurements.errors, measurements.corr)
+
+__all__ = ["BLUE", "Measurements", "CovarianceMatrix"]


### PR DESCRIPTION
## Summary
- add `adc_drift.correct` alias for `apply_linear_adc_shift`
- restore `blue_combine` module with `BLUE` compatibility API

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f22d25728832ba7f179ea9c8bca73