### PR TITLE
Improve numeric robustness and baseline checks

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -565,7 +565,7 @@ def main():
 
     # Optional burst filter to remove high-rate clusters
     total_span = events["timestamp"].max() - events["timestamp"].min()
-    rate_cps = len(events) / total_span if total_span > 0 else 0.0
+    rate_cps = len(events) / max(total_span, 1e-9)
     if args.burst_mode is None:
         current_mode = cfg.get("burst_filter", {}).get("burst_mode", "rate")
         if current_mode == "rate" and rate_cps < 0.1:
@@ -769,6 +769,8 @@ def main():
             events["timestamp"] < t_end_base
         )
         base_events = events[mask_base].copy()
+        if len(base_events) == 0:
+            raise ValueError("Selected baseline window contains zero events")
         baseline_live_time = float(t_end_base - t_start_base)
         baseline_info = {
             "start": t_start_base,

--- a/baseline_noise.py
+++ b/baseline_noise.py
@@ -45,6 +45,8 @@ def estimate_baseline_noise(adc_values, peak_adc=None, nbins=50, model="constant
 
     if model == "constant":
         A = float(np.mean(hist))
+        if A > 1e300:
+            A = 1e300
         return A, {"A": A}
 
     if model == "exponential":
@@ -54,9 +56,14 @@ def estimate_baseline_noise(adc_values, peak_adc=None, nbins=50, model="constant
                 _exponential, centers, hist, p0=p0, maxfev=CURVE_FIT_MAX_EVALS
             )
             A, k = popt
-            return float(A), {"A": float(A), "k": float(k)}
+            A = float(A)
+            if A > 1e300:
+                A = 1e300
+            return A, {"A": A, "k": float(k)}
         except Exception:
             A = float(np.mean(hist))
+            if A > 1e300:
+                A = 1e300
             return A, {"A": A}
 
     raise ValueError("Unsupported model: %s" % model)

--- a/calibration.py
+++ b/calibration.py
@@ -41,10 +41,9 @@ def emg_left(x, mu, sigma, tau):
 
 
 def gaussian(x, mu, sigma):
-    """Standard Gaussian PDF (unit area)."""
-    return np.exp(-0.5 * ((x - mu) / sigma) ** 2) / (
-        sigma * np.sqrt(2 * np.pi)
-    )
+    """Standard Gaussian PDF (unit area) using safe exponentiation."""
+    arg = -0.5 * ((np.asarray(x, dtype=float) - mu) / sigma) ** 2
+    return _safe_exp(arg) / (sigma * np.sqrt(2 * np.pi))
 
 
 def two_point_calibration(adc_centroids, energies):

--- a/systematics.py
+++ b/systematics.py
@@ -23,19 +23,16 @@ def apply_linear_adc_shift(adc_values, timestamps, rate, t_ref=None):
         Array of shifted ADC values.
     """
 
-    adc_arr = [float(v) for v in adc_values]
-    time_arr = [float(t) for t in timestamps]
+    adc_arr = np.asarray(adc_values, dtype=float)
+    time_arr = np.asarray(timestamps, dtype=float)
 
-    if len(adc_arr) != len(time_arr):
+    if adc_arr.shape != time_arr.shape:
         raise ValueError("adc_values and timestamps must have the same shape")
 
     if t_ref is None:
-        t_ref = float(time_arr[0]) if len(time_arr) else 0.0
+        t_ref = float(time_arr[0]) if time_arr.size else 0.0
 
-    return np.array(
-        [a + rate * (t - t_ref) for a, t in zip(adc_arr, time_arr)],
-        dtype=float,
-    )
+    return adc_arr + rate * (time_arr - t_ref)
 
 
 def scan_systematics(

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -293,11 +293,8 @@ def test_run_period_filters_events(tmp_path, monkeypatch):
         str(tmp_path),
     ]
     monkeypatch.setattr(sys, "argv", args)
-    analyze.main()
-
-    summary = captured.get("summary", {})
-    assert summary["baseline"]["n_events"] == 0
-    assert captured.get("times") == [2.0, 5.0]
+    with pytest.raises(ValueError):
+        analyze.main()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- vectorize `apply_linear_adc_shift`
- guard `rate_cps` division by zero
- require non-empty baseline window
- clip exponentiation in Gaussian and clamp baseline amplitude
- update test for new baseline error condition

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f258b8a1c832b8f04b228d8ff4d4a