### PR TITLE
Expose BLUE weights in summary

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1207,6 +1207,7 @@ def main():
     # 7b. Optional efficiency calculations
     # ────────────────────────────────────────────────────────────
     efficiency_results = {}
+    weights = None
     eff_cfg = cfg.get("efficiency", {})
     if eff_cfg:
         from efficiency import (
@@ -1463,6 +1464,9 @@ def main():
             ),
         },
     }
+
+    if weights is not None:
+        summary["efficiency"]["blue_weights"] = list(weights)
 
     out_dir = write_summary(args.output_dir, summary, args.job_id or now_str)
     copy_config(out_dir, args.config)

--- a/tests/test_blue_weights.py
+++ b/tests/test_blue_weights.py
@@ -1,0 +1,76 @@
+import json
+import sys
+from pathlib import Path
+import pandas as pd
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+from fitting import FitResult
+
+
+def test_blue_weights_summary(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "efficiency": {
+            "assay": [
+                {"rate_cps": 1.0, "reference_bq": 10.0, "error": 0.1},
+                {"rate_cps": 2.0, "reference_bq": 20.0, "error": 0.2},
+            ]
+        },
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    data_path = tmp_path / "data.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0, 0)), 0))
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+
+    import efficiency
+
+    monkeypatch.setattr(efficiency, "calc_spike_efficiency", lambda *a, **k: 0.1)
+    monkeypatch.setattr(efficiency, "calc_assay_efficiency", lambda *a, **k: 0.05)
+    monkeypatch.setattr(efficiency, "calc_decay_efficiency", lambda *a, **k: 0.1)
+
+    def fake_blue(vals, errs):
+        return 0.1, 0.01, np.array([0.8, 0.2])
+
+    monkeypatch.setattr(efficiency, "blue_combine", fake_blue)
+
+    captured = {}
+
+    def fake_write(out_dir, summary, timestamp=None):
+        captured["summary"] = summary
+        d = Path(out_dir) / (timestamp or "x")
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config", str(cfg_path),
+        "--input", str(data_path),
+        "--output_dir", str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+
+    analyze.main()
+
+    weights = captured["summary"]["efficiency"].get("blue_weights")
+    assert weights == [0.8, 0.2]


### PR DESCRIPTION
## Summary
- store BLUE combination weights separately
- attach BLUE weights to summary JSON
- test blue_weights field in summary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f254e1558832b816811b5cdb56311