### PR TITLE
Fix duplicate numpy import in ADC drift test

### DIFF
--- a/tests/test_adc_drift.py
+++ b/tests/test_adc_drift.py
@@ -6,7 +6,6 @@ import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
-import numpy as np
 from fitting import FitResult
 
 


### PR DESCRIPTION
## Summary
- clean up `tests/test_adc_drift.py` by removing a repeated `numpy` import

## Testing
- `pytest -q` *(fails: Package 'numpy' is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_684f35daf5c0832bbc80de27eb36fea3