### PR TITLE
Rename calibration slope key

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1738,7 +1738,7 @@ def main():
                         {
                             "half_life": hl,
                             "dhalf_life": dhl,
-                            "slope": slope,
+                            "slope_MeV_per_ch": slope,
                             "dslope": dslope,
                             "intercept": intercept,
                             "dintercept": dintercept,

--- a/calibration.py
+++ b/calibration.py
@@ -231,7 +231,7 @@ def calibrate_run(adc_values, config, hist_bins=None):
 
     # 8) Build result dict:
     calib_dict = {
-        "slope": a,
+        "slope_MeV_per_ch": a,
         "intercept": c,
         "sigma_E": float(sigma_E),
         "peaks": peak_fits,
@@ -243,7 +243,7 @@ def derive_calibration_constants(adc_values, config):
     """Wrapper returning calibration constants in legacy format."""
     res = calibrate_run(adc_values, config)
     out = {
-        "a": (float(res["slope"]), 0.0),
+        "a": (float(res["slope_MeV_per_ch"]), 0.0),
         "c": (float(res["intercept"]), 0.0),
         "sigma_E": (float(res["sigma_E"]), 0.0),
         "peaks": res.get("peaks", {}),
@@ -309,7 +309,7 @@ def derive_calibration_constants_auto(
     # Run calibration with custom histogram binning and convert to legacy format
     res = calibrate_run(adc_arr, config, hist_bins=hist_bins)
     out = {
-        "a": (float(res["slope"]), 0.0),
+        "a": (float(res["slope_MeV_per_ch"]), 0.0),
         "c": (float(res["intercept"]), 0.0),
         "sigma_E": (float(res["sigma_E"]), 0.0),
         "peaks": res.get("peaks", {}),

--- a/hierarchical.py
+++ b/hierarchical.py
@@ -11,7 +11,7 @@ def fit_hierarchical_runs(run_results, draws=2000, tune=1000, chains=2, random_s
     ----------
     run_results : list of dict
         Each entry must contain ``"half_life"`` and ``"dhalf_life"``. Optional
-        keys ``"slope"``, ``"dslope"``, ``"intercept"`` and ``"dintercept"`` add
+        keys ``"slope_MeV_per_ch"``, ``"dslope"``, ``"intercept"`` and ``"dintercept"`` add
         calibration parameters to the model.
     draws : int, optional
         Number of MCMC draws after tuning (default 2000).
@@ -26,7 +26,7 @@ def fit_hierarchical_runs(run_results, draws=2000, tune=1000, chains=2, random_s
     -------
     dict
         Posterior means, standard deviations and 95% HDIs for the global
-        parameters ``half_life``, ``slope`` and ``intercept``.
+        parameters ``half_life``, ``slope_MeV_per_ch`` and ``intercept``.
     """
 
     n = len(run_results)
@@ -36,9 +36,9 @@ def fit_hierarchical_runs(run_results, draws=2000, tune=1000, chains=2, random_s
     hl_obs = np.array([r["half_life"] for r in run_results], dtype=float)
     hl_err = np.array([max(r.get("dhalf_life", np.nan), 1e-6) for r in run_results], dtype=float)
 
-    use_slope = all("slope" in r and "dslope" in r for r in run_results)
+    use_slope = all("slope_MeV_per_ch" in r and "dslope" in r for r in run_results)
     if use_slope:
-        slope_obs = np.array([r["slope"] for r in run_results], dtype=float)
+        slope_obs = np.array([r["slope_MeV_per_ch"] for r in run_results], dtype=float)
         slope_err = np.array([max(r.get("dslope", np.nan), 1e-6) for r in run_results], dtype=float)
 
     use_intercept = all("intercept" in r and "dintercept" in r for r in run_results)
@@ -78,7 +78,7 @@ def fit_hierarchical_runs(run_results, draws=2000, tune=1000, chains=2, random_s
     }
 
     if use_slope:
-        out["slope"] = {
+        out["slope_MeV_per_ch"] = {
             "mean": float(summ.loc["mu_a", "mean"]),
             "sd": float(summ.loc["mu_a", "sd"]),
             "hdi": [float(summ.loc["mu_a", "hdi_2.5%"]), float(summ.loc["mu_a", "hdi_97.5%"])],

--- a/readme.txt
+++ b/readme.txt
@@ -247,7 +247,7 @@ The half-lives used in the decay fit can also be changed with
 
 When the spectrum is binned in raw ADC channels (`"spectral_binning_mode": "adc"`),
 the bin edges are internally converted to energy using the calibration
-slope_MeV_per_ch (MeV/channel) and intercept before plotting.  This ensures `spectrum.png`
+slope and intercept before plotting.  This ensures `spectrum.png`
 reflects the calibrated energy scale regardless of binning mode.
 
 The `spectral_fit` section provides priors for the unbinned likelihood
@@ -512,8 +512,8 @@ Example usage:
 from hierarchical import fit_hierarchical_runs
 
 run_results = [
-    {"half_life": 160.5, "dhalf_life": 1.2, "slope_MeV_per_ch": 0.001, "dslope": 0.0005},
-    {"half_life": 162.1, "dhalf_life": 1.0, "slope_MeV_per_ch": 0.0011, "dslope": 0.0004},
+    {"half_life": 160.5, "dhalf_life": 1.2, "slope": 0.001, "dslope": 0.0005},
+    {"half_life": 162.1, "dhalf_life": 1.0, "slope": 0.0011, "dslope": 0.0004},
 ]
 
 summary = fit_hierarchical_runs(run_results)

--- a/readme.txt
+++ b/readme.txt
@@ -247,7 +247,7 @@ The half-lives used in the decay fit can also be changed with
 
 When the spectrum is binned in raw ADC channels (`"spectral_binning_mode": "adc"`),
 the bin edges are internally converted to energy using the calibration
-slope and intercept before plotting.  This ensures `spectrum.png`
+slope_MeV_per_ch (MeV/channel) and intercept before plotting.  This ensures `spectrum.png`
 reflects the calibrated energy scale regardless of binning mode.
 
 The `spectral_fit` section provides priors for the unbinned likelihood
@@ -512,8 +512,8 @@ Example usage:
 from hierarchical import fit_hierarchical_runs
 
 run_results = [
-    {"half_life": 160.5, "dhalf_life": 1.2, "slope": 0.001, "dslope": 0.0005},
-    {"half_life": 162.1, "dhalf_life": 1.0, "slope": 0.0011, "dslope": 0.0004},
+    {"half_life": 160.5, "dhalf_life": 1.2, "slope_MeV_per_ch": 0.001, "dslope": 0.0005},
+    {"half_life": 162.1, "dhalf_life": 1.0, "slope_MeV_per_ch": 0.0011, "dslope": 0.0004},
 ]
 
 summary = fit_hierarchical_runs(run_results)

--- a/tests/test_hierarchical.py
+++ b/tests/test_hierarchical.py
@@ -8,13 +8,13 @@ from hierarchical import fit_hierarchical_runs
 
 def test_fit_hierarchical_runs_basic():
     runs = [
-        {"half_life": 1.0, "dhalf_life": 0.1, "slope": 0.5, "dslope": 0.1},
-        {"half_life": 1.2, "dhalf_life": 0.1, "slope": 0.55, "dslope": 0.1},
+        {"half_life": 1.0, "dhalf_life": 0.1, "slope_MeV_per_ch": 0.5, "dslope": 0.1},
+        {"half_life": 1.2, "dhalf_life": 0.1, "slope_MeV_per_ch": 0.55, "dslope": 0.1},
     ]
 
     res = fit_hierarchical_runs(runs, draws=50, tune=50, chains=1)
 
     assert "half_life" in res
     assert "mean" in res["half_life"]
-    assert "slope" in res
-    assert "mean" in res["slope"]
+    assert "slope_MeV_per_ch" in res
+    assert "mean" in res["slope_MeV_per_ch"]

--- a/tests/test_hierarchical_intervals.py
+++ b/tests/test_hierarchical_intervals.py
@@ -31,7 +31,7 @@ def test_credible_intervals_from_summaries(tmp_path):
             {
                 "half_life": dat.get("half_life"),
                 "dhalf_life": dat.get("dhalf_life"),
-                "slope": cal.get("a", [None, None])[0],
+                "slope_MeV_per_ch": cal.get("a", [None, None])[0],
                 "dslope": cal.get("a", [None, None])[1],
                 "intercept": cal.get("c", [None, None])[0],
                 "dintercept": cal.get("c", [None, None])[1],
@@ -40,7 +40,7 @@ def test_credible_intervals_from_summaries(tmp_path):
 
     res = fit_hierarchical_runs(run_results, draws=50, tune=50, chains=1, random_seed=42)
 
-    for key in ("half_life", "slope", "intercept"):
+    for key in ("half_life", "slope_MeV_per_ch", "intercept"):
         assert key in res
         assert "hdi" in res[key]
         hdi = res[key]["hdi"]


### PR DESCRIPTION
## Summary
- return `slope_MeV_per_ch` from `calibrate_run`
- read that key in `derive_calibration_constants*`
- expect `slope_MeV_per_ch` in hierarchical analysis
- update analyze hierarchical summary handling
- tweak docs and tests for the new name

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f35d8fa70832b99b0ec34a5bb45fe