### PR TITLE
Fix timedelta bin width handling

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -839,8 +839,15 @@ def main():
             n = E_all.size
             if (iqr > 0) and (n > 0):
                 fd_width = 2 * iqr / (n ** (1 / 3))
-                emin, emax = E_all.min(), E_all.max()
-                nbins = max(1, int(np.ceil((emax - emin) / fd_width)))
+                # fd_width is measured in MeV since energies are in MeV
+                nbins = max(
+                    1,
+                    int(
+                        np.ceil(
+                            (E_all.max() - E_all.min()) / float(fd_width)
+                        )
+                    ),
+                )
             else:
                 nbins = default_bins
 

--- a/plot_utils.py
+++ b/plot_utils.py
@@ -125,8 +125,12 @@ def plot_time_series(
                 n_bins = int(config.get("time_bins_fallback", 1))
             else:
                 bin_width = 2 * iqr / (len(data) ** (1.0 / 3.0))
-                n_bins = max(
-                    1, int(np.ceil((data.max() - data.min()) / bin_width)))
+                if isinstance(bin_width, np.timedelta64):
+                    bin_width = bin_width / np.timedelta64(1, "s")
+                    data_range = (data.max() - data.min()) / np.timedelta64(1, "s")
+                else:
+                    data_range = data.max() - data.min()
+                n_bins = max(1, int(np.ceil(data_range / float(bin_width))))
     else:
         # fixed-width bins (integer-second data) – use floor so the
         # very last partial bin is dropped and every remaining bin has


### PR DESCRIPTION
## Summary
- prevent np.timedelta64 issues when binning time series
- clarify units for energy binning in spectrum routine

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f35d9700c832bac21de490a398b0d