### PR TITLE
Remove duplicate numpy import

### DIFF
--- a/tests/test_adc_drift.py
+++ b/tests/test_adc_drift.py
@@ -6,7 +6,6 @@ import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
-import numpy as np
 from fitting import FitResult
 
 

--- a/tests/test_linear_background.py
+++ b/tests/test_linear_background.py
@@ -10,7 +10,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from background import estimate_linear_background
 import analyze
-import numpy as np
 from fitting import FitResult
 
 


### PR DESCRIPTION
## Summary
- dedupe numpy imports in `tests/test_linear_background.py`
- remove duplicate numpy import in `tests/test_adc_drift.py`

## Testing
- `pip install numpy pandas scipy matplotlib pytest iminuit pymc jsonschema`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f35dad818832bab331d7d61ccfe4d