### PR TITLE
Update half-life fetch for plot_time_series

### DIFF
--- a/plot_utils.py
+++ b/plot_utils.py
@@ -64,12 +64,12 @@ def plot_time_series(
     po214_hl = (
         float(hl_Po214)
         if hl_Po214 is not None
-        else float(config.get("hl_Po214", [default214])[0])
+        else float(_cfg_get(config, "hl_Po214", [default214])[0])
     )
     po218_hl = (
         float(hl_Po218)
         if hl_Po218 is not None
-        else float(config.get("hl_Po218", [default218])[0])
+        else float(_cfg_get(config, "hl_Po218", [default218])[0])
     )
 
     if po214_hl <= 0:


### PR DESCRIPTION
## Summary
- fetch Po214 and Po218 half-lives using `_cfg_get`
- test nested `time_fit` configuration

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850ec69efec832bad20da12ef87abb3