### PR TITLE
Document and enforce radon-equilibrium assumption

### DIFF
--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -134,6 +134,22 @@ def test_compute_radon_activity_negative_eff214():
         compute_radon_activity(10.0, 1.0, 1.0, 12.0, 2.0, -0.5)
 
 
+def test_compute_radon_activity_equilibrium_check():
+    """Fail when times are before secular equilibrium if required."""
+    with pytest.raises(ValueError):
+        compute_radon_activity(
+            10.0,
+            1.0,
+            1.0,
+            12.0,
+            2.0,
+            1.0,
+            t_since_start=1.0,
+            settle_time=10.0,
+            require_equilibrium=True,
+        )
+
+
 def test_compute_total_radon():
     conc, dconc, tot, dtot = compute_total_radon(5.0, 0.5, 10.0, 20.0)
     assert conc == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- warn in `compute_radon_activity` docstring to use equilibrium rates
- allow optional equilibrium validation via `t_since_start`/`settle_time`
- raise `ValueError` if rates are taken before equilibrium when required
- test new error condition

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850ef299da8832bb8a3c169203525e6