### PR TITLE
Add tests for unweighted radon averaging

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -74,11 +74,10 @@ def compute_radon_activity(
         sigma = math.sqrt(1.0 / (w1 + w2))
         return A, sigma
 
-    if len(values) == 2 and sum(w is not None for w in weights) == 1:
-        # Identify the isotope with a valid uncertainty
-        for idx, w in enumerate(weights):
-            if w is not None:
-                return values[idx], math.sqrt(1.0 / w)
+    if len(values) == 2:
+        # Unweighted average when any uncertainty is missing or invalid
+        A = (values[0] + values[1]) / 2.0
+        return A, math.nan
 
     # Only one valid value or missing errors
     A = values[0]

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -33,14 +33,14 @@ def test_compute_radon_activity_efficiencies_not_weighted():
 
 def test_compute_radon_activity_only_214_error():
     a, s = compute_radon_activity(10.0, None, 1.0, 12.0, 2.0, 1.0)
-    assert a == pytest.approx(12.0)
-    assert s == pytest.approx(2.0)
+    assert a == pytest.approx((10.0 + 12.0) / 2)
+    assert math.isnan(s)
 
 
 def test_compute_radon_activity_only_214_error_eff_not_one():
     a, s = compute_radon_activity(10.0, None, 0.8, 12.0, 2.0, 0.9)
-    assert a == pytest.approx(12.0)
-    assert s == pytest.approx(2.0)
+    assert a == pytest.approx((10.0 + 12.0) / 2)
+    assert math.isnan(s)
 
 
 def test_compute_radon_activity_mixed_efficiency():
@@ -51,38 +51,38 @@ def test_compute_radon_activity_mixed_efficiency():
 
 def test_compute_radon_activity_only_218_error():
     a, s = compute_radon_activity(10.0, 1.0, 1.0, 12.0, None, 1.0)
-    assert a == pytest.approx(10.0)
-    assert s == pytest.approx(1.0)
+    assert a == pytest.approx((10.0 + 12.0) / 2)
+    assert math.isnan(s)
 
 
 def test_compute_radon_activity_only_218_error_eff_not_one():
     a, s = compute_radon_activity(10.0, 1.0, 0.7, 12.0, None, 0.6)
-    assert a == pytest.approx(10.0)
-    assert s == pytest.approx(1.0)
+    assert a == pytest.approx((10.0 + 12.0) / 2)
+    assert math.isnan(s)
 
 
 def test_compute_radon_activity_only_214_error_zero_218_error():
     a, s = compute_radon_activity(10.0, 0.0, 1.0, 12.0, 2.0, 1.0)
-    assert a == pytest.approx(12.0)
-    assert s == pytest.approx(2.0)
+    assert a == pytest.approx((10.0 + 12.0) / 2)
+    assert math.isnan(s)
 
 
 def test_compute_radon_activity_only_218_error_zero_214_error():
     a, s = compute_radon_activity(10.0, 1.0, 1.0, 12.0, 0.0, 1.0)
-    assert a == pytest.approx(10.0)
-    assert s == pytest.approx(1.0)
+    assert a == pytest.approx((10.0 + 12.0) / 2)
+    assert math.isnan(s)
 
 
 def test_compute_radon_activity_mixed_error_sign():
     a, s = compute_radon_activity(10.0, -1.0, 1.0, 12.0, 2.0, 1.0)
-    assert a == pytest.approx(12.0)
-    assert s == pytest.approx(2.0)
+    assert a == pytest.approx((10.0 + 12.0) / 2)
+    assert math.isnan(s)
 
 
 def test_compute_radon_activity_mixed_error_sign_214():
     a, s = compute_radon_activity(10.0, 1.0, 1.0, 12.0, -2.0, 1.0)
-    assert a == pytest.approx(10.0)
-    assert s == pytest.approx(1.0)
+    assert a == pytest.approx((10.0 + 12.0) / 2)
+    assert math.isnan(s)
 
 
 def test_compute_radon_activity_mixed_efficiency_214():
@@ -118,10 +118,10 @@ def test_compute_radon_activity_single_218_eff_not_one():
 
 
 def test_compute_radon_activity_uncertainty_po214_only():
-    """Returns Po-214 values when only its error is valid."""
+    """Returns unweighted average when only Po-214 error is valid."""
     a, s = compute_radon_activity(4.0, None, 1.0, 5.0, 0.3, 1.0)
-    assert a == pytest.approx(5.0)
-    assert s == pytest.approx(0.3)
+    assert a == pytest.approx((4.0 + 5.0) / 2)
+    assert math.isnan(s)
 
 
 def test_compute_radon_activity_negative_eff218():
@@ -146,6 +146,20 @@ def test_compute_radon_activity_missing_uncertainty_returns_nan():
     """Single rate without uncertainty should propagate NaN error."""
     a, s = compute_radon_activity(5.0, None, 1.0, None, None, 1.0)
     assert a == pytest.approx(5.0)
+    assert math.isnan(s)
+
+
+def test_compute_radon_activity_unweighted_one_error_missing():
+    """Average both rates when one uncertainty is missing."""
+    a, s = compute_radon_activity(5.0, 0.5, 1.0, 7.0, None, 1.0)
+    assert a == pytest.approx(6.0)
+    assert math.isnan(s)
+
+
+def test_compute_radon_activity_unweighted_both_errors_missing():
+    """Average both rates when no uncertainties are provided."""
+    a, s = compute_radon_activity(5.0, None, 1.0, 7.0, None, 1.0)
+    assert a == pytest.approx(6.0)
     assert math.isnan(s)
 
 


### PR DESCRIPTION
## Summary
- allow computing an unweighted average when isotope uncertainties are missing
- update radon activity tests for the new behaviour
- add explicit tests for missing-error averaging scenarios

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850ef2a1f5c832b8b922f09127b1078