### PR TITLE
Add extract_time_series util

### DIFF
--- a/plot_utils.py
+++ b/plot_utils.py
@@ -15,6 +15,7 @@ PO214_HALF_LIFE_S = PO214.half_life_s
 PO218_HALF_LIFE_S = PO218.half_life_s
 
 __all__ = [
+    "extract_time_series",
     "plot_time_series",
     "plot_spectrum",
     "plot_radon_activity",
@@ -22,6 +23,54 @@ __all__ = [
     "plot_modeled_radon_activity",
     "plot_radon_trend",
 ]
+
+
+def extract_time_series(timestamps, energies, window, t_start, t_end, bin_width_s=1.0):
+    """Return histogram counts for events within an energy window.
+
+    Parameters
+    ----------
+    timestamps : array-like
+        Absolute event times in seconds.
+    energies : array-like
+        Event energies in MeV.
+    window : tuple(float, float) or None
+        Inclusive energy range. If ``None`` an empty array is returned.
+    t_start, t_end : float
+        Start and end times for the histogram.
+    bin_width_s : float, optional
+        Width of each time bin in seconds.
+
+    Returns
+    -------
+    counts : np.ndarray
+        Counts in each time bin.
+    edges : np.ndarray
+        Bin edges relative to ``t_start``.
+    """
+
+    if window is None:
+        return np.array([]), np.array([])
+
+    lo, hi = window
+    timestamps = np.asarray(timestamps, dtype=float)
+    energies = np.asarray(energies, dtype=float)
+
+    mask = (
+        (energies >= lo)
+        & (energies <= hi)
+        & (timestamps >= float(t_start))
+        & (timestamps <= float(t_end))
+    )
+
+    rel_times = timestamps[mask] - float(t_start)
+
+    n_bins = int(np.floor((float(t_end) - float(t_start)) / float(bin_width_s)))
+    if n_bins < 1:
+        n_bins = 1
+    edges = np.arange(0, (n_bins + 1) * float(bin_width_s), float(bin_width_s))
+    counts, _ = np.histogram(rel_times, bins=edges)
+    return counts, edges
 
 
 def plot_time_series(

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -5,7 +5,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from constants import PO210
-from plot_utils import plot_time_series, plot_spectrum
+from plot_utils import plot_time_series, plot_spectrum, extract_time_series
 
 
 def basic_config():
@@ -687,4 +687,20 @@ def test_plot_equivalent_air_po214(tmp_path):
     plot_equivalent_air(times, volumes, errors, 5.0, str(out_png))
 
     assert out_png.exists()
+
+
+def test_extract_time_series_counts():
+    times = np.array([1000.1, 1000.8, 1001.1, 1001.5, 1001.9])
+    energies = np.full_like(times, 5.3)
+    counts, edges = extract_time_series(times, energies, (5.2, 5.4), 1000.0, 1002.0)
+    assert edges.tolist() == [0.0, 1.0, 2.0]
+    assert counts.tolist() == [2, 3]
+
+
+def test_extract_time_series_none_window():
+    times = np.array([1000.5, 1001.5])
+    energies = np.array([5.3, 5.3])
+    counts, edges = extract_time_series(times, energies, None, 1000.0, 1002.0)
+    assert counts.size == 0 and edges.size == 0
+
 


### PR DESCRIPTION
## Summary
- implement `extract_time_series` helper in `plot_utils`
- expose new function in module exports
- test Po‑210 time-series extraction

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850ef2f3ef0832b8af2a7295f49d578