### PR TITLE
Fix README half-life default

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,10 @@ Example snippet:
 ```
 
 `plot_time_series` takes its half-life values from the `time_fit` section.
-When these keys are omitted, `hl_Po214` and `hl_Po218` default to the radon half-life (~3.8 days or about `3.28e5` s). `hl_Po210` falls back to the Po‑210 half-life (≈138 days). Specify them to use other values. These custom half-lives control the decay model drawn over the time-series histogram.
+When these keys are omitted, `hl_Po214` and `hl_Po218` fall back to their
+physical half-lives (≈164 µs and ≈183 s). `hl_Po210` defaults to its physical
+half-life (≈138 days). Specify them to use other values. These custom
+half-lives control the decay model drawn over the time-series histogram.
 The same values are used in the `time_fit` routine itself, so changing
 `hl_Po214` or `hl_Po218` affects both the unbinned fit and the overlay in
 `plot_time_series`. For monitoring that spans multiple days you may set


### PR DESCRIPTION
## Summary
- clarify default `hl_Po214`/`hl_Po218` behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850ef305154832bacd4333b856fbce3