### PR TITLE
Handle missing radon rate uncertainties

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -40,7 +40,9 @@ def compute_radon_activity(
     float
         Weighted average radon activity in Bq.
     float
-        Propagated 1-sigma uncertainty.
+        Propagated 1-sigma uncertainty.  If two rates are given but both
+        associated errors are ``None`` the simple arithmetic mean is returned
+        with ``math.nan`` for the uncertainty.
     """
     if eff218 < 0:
         raise ValueError("eff218 must be non-negative")
@@ -79,6 +81,10 @@ def compute_radon_activity(
         for idx, w in enumerate(weights):
             if w is not None:
                 return values[idx], math.sqrt(1.0 / w)
+
+    if len(values) == 2 and all(w is None for w in weights):
+        A = 0.5 * (values[0] + values[1])
+        return A, math.nan
 
     # Only one valid value or missing errors
     A = values[0]

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -149,6 +149,13 @@ def test_compute_radon_activity_missing_uncertainty_returns_nan():
     assert math.isnan(s)
 
 
+def test_compute_radon_activity_both_missing_errors():
+    """Both rates present but without uncertainties should use mean and NaN."""
+    a, s = compute_radon_activity(5.0, None, 1.0, 7.0, None, 1.0)
+    assert a == pytest.approx(0.5 * (5.0 + 7.0))
+    assert math.isnan(s)
+
+
 def test_compute_total_radon_negative_sample_volume():
     with pytest.raises(ValueError):
         compute_total_radon(5.0, 0.5, 10.0, -1.0)


### PR DESCRIPTION
## Summary
- update `compute_radon_activity` to average rates when both errors are missing
- document the new behaviour
- test for the mean+NaN case

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850f256d894832baaea49999dbe2cf8