### PR TITLE
Add burst_mode override handling

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -465,6 +465,10 @@ def main():
     if args.dump_ts_json:
         cfg.setdefault("plotting", {})["dump_time_series_json"] = True
 
+    if args.burst_mode is not None:
+        _log_override("burst_filter", "burst_mode", args.burst_mode)
+        cfg.setdefault("burst_filter", {})["burst_mode"] = args.burst_mode
+
     if args.spike_count is not None or args.spike_count_err is not None:
         eff_sec = cfg.setdefault("efficiency", {}).setdefault("spike", {})
         if args.spike_count is not None:
@@ -1441,7 +1445,10 @@ def main():
         "baseline": baseline_info,
         "radon_results": radon_results,
         "noise_cut": {"removed_events": int(n_removed_noise)},
-        "burst_filter": {"removed_events": int(n_removed_burst)},
+        "burst_filter": {
+            "removed_events": int(n_removed_burst),
+            "burst_mode": cfg.get("burst_filter", {}).get("burst_mode", burst_mode),
+        },
         "adc_drift_rate": drift_rate,
         "efficiency": efficiency_results,
         "random_seed": seed_used,

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -1478,6 +1478,60 @@ def test_burst_mode_cli_overrides(tmp_path, monkeypatch):
     assert recorded.get("mode") == "micro"
 
 
+def test_burst_mode_summary_config(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "apply_burst_filter", lambda df, cfg, mode="rate": (df, 0))
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+
+    saved = {}
+
+    def fake_write(out_dir, summary, timestamp=None):
+        saved["summary"] = summary
+        d = Path(out_dir) / "x"
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+        "--burst-mode",
+        "micro",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert saved["summary"]["burst_filter"]["burst_mode"] == "micro"
+
+
 def test_burst_filter_auto_disabled(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},


### PR DESCRIPTION
## Summary
- log and set `burst_filter.burst_mode` when overridden via CLI
- record burst-mode in `summary.json`
- test that summary reflects CLI burst mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850f31d414c832b8915d7c6ef3efb10