### PR TITLE
Improve radon activity averaging

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -58,9 +58,14 @@ def compute_radon_activity(
     Returns
     -------
     float
-        Weighted average radon activity in Bq.
+        Average radon activity in Bq.  A weighted mean is used only when
+        both rates have valid uncertainties; otherwise an unweighted mean
+        of the available rates is returned.
     float
-        Propagated 1-sigma uncertainty.
+        Propagated 1-sigma uncertainty.  When the mean is unweighted the
+        errors are combined as ``sqrt(err218**2 + err214**2) / N`` where
+        ``N`` is the number of rates included and invalid uncertainties are
+        treated as zero.
     """
     if eff218 < 0:
         raise ValueError("eff218 must be non-negative")
@@ -103,7 +108,10 @@ def compute_radon_activity(
     if len(values) == 2:
         # Unweighted average when any uncertainty is missing or invalid
         A = (values[0] + values[1]) / 2.0
-        return A, math.nan
+        e218 = err218 if err218 is not None and err218 > 0 else 0.0
+        e214 = err214 if err214 is not None and err214 > 0 else 0.0
+        sigma = math.sqrt(e218**2 + e214**2) / 2.0
+        return A, sigma
 
     # Only one valid value or missing errors
     A = values[0]

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -34,13 +34,13 @@ def test_compute_radon_activity_efficiencies_not_weighted():
 def test_compute_radon_activity_only_214_error():
     a, s = compute_radon_activity(10.0, None, 1.0, 12.0, 2.0, 1.0)
     assert a == pytest.approx((10.0 + 12.0) / 2)
-    assert math.isnan(s)
+    assert s == pytest.approx(1.0)
 
 
 def test_compute_radon_activity_only_214_error_eff_not_one():
     a, s = compute_radon_activity(10.0, None, 0.8, 12.0, 2.0, 0.9)
     assert a == pytest.approx((10.0 + 12.0) / 2)
-    assert math.isnan(s)
+    assert s == pytest.approx(1.0)
 
 
 def test_compute_radon_activity_mixed_efficiency():
@@ -52,37 +52,37 @@ def test_compute_radon_activity_mixed_efficiency():
 def test_compute_radon_activity_only_218_error():
     a, s = compute_radon_activity(10.0, 1.0, 1.0, 12.0, None, 1.0)
     assert a == pytest.approx((10.0 + 12.0) / 2)
-    assert math.isnan(s)
+    assert s == pytest.approx(0.5)
 
 
 def test_compute_radon_activity_only_218_error_eff_not_one():
     a, s = compute_radon_activity(10.0, 1.0, 0.7, 12.0, None, 0.6)
     assert a == pytest.approx((10.0 + 12.0) / 2)
-    assert math.isnan(s)
+    assert s == pytest.approx(0.5)
 
 
 def test_compute_radon_activity_only_214_error_zero_218_error():
     a, s = compute_radon_activity(10.0, 0.0, 1.0, 12.0, 2.0, 1.0)
     assert a == pytest.approx((10.0 + 12.0) / 2)
-    assert math.isnan(s)
+    assert s == pytest.approx(1.0)
 
 
 def test_compute_radon_activity_only_218_error_zero_214_error():
     a, s = compute_radon_activity(10.0, 1.0, 1.0, 12.0, 0.0, 1.0)
     assert a == pytest.approx((10.0 + 12.0) / 2)
-    assert math.isnan(s)
+    assert s == pytest.approx(0.5)
 
 
 def test_compute_radon_activity_mixed_error_sign():
     a, s = compute_radon_activity(10.0, -1.0, 1.0, 12.0, 2.0, 1.0)
     assert a == pytest.approx((10.0 + 12.0) / 2)
-    assert math.isnan(s)
+    assert s == pytest.approx(1.0)
 
 
 def test_compute_radon_activity_mixed_error_sign_214():
     a, s = compute_radon_activity(10.0, 1.0, 1.0, 12.0, -2.0, 1.0)
     assert a == pytest.approx((10.0 + 12.0) / 2)
-    assert math.isnan(s)
+    assert s == pytest.approx(0.5)
 
 
 def test_compute_radon_activity_mixed_efficiency_214():
@@ -121,7 +121,7 @@ def test_compute_radon_activity_uncertainty_po214_only():
     """Returns unweighted average when only Po-214 error is valid."""
     a, s = compute_radon_activity(4.0, None, 1.0, 5.0, 0.3, 1.0)
     assert a == pytest.approx((4.0 + 5.0) / 2)
-    assert math.isnan(s)
+    assert s == pytest.approx(0.15)
 
 
 def test_compute_radon_activity_negative_eff218():
@@ -169,14 +169,14 @@ def test_compute_radon_activity_unweighted_one_error_missing():
     """Average both rates when one uncertainty is missing."""
     a, s = compute_radon_activity(5.0, 0.5, 1.0, 7.0, None, 1.0)
     assert a == pytest.approx(6.0)
-    assert math.isnan(s)
+    assert s == pytest.approx(0.25)
 
 
 def test_compute_radon_activity_unweighted_both_errors_missing():
     """Average both rates when no uncertainties are provided."""
     a, s = compute_radon_activity(5.0, None, 1.0, 7.0, None, 1.0)
     assert a == pytest.approx(6.0)
-    assert math.isnan(s)
+    assert s == pytest.approx(0.0)
 
 
 def test_compute_total_radon_negative_sample_volume():


### PR DESCRIPTION
## Summary
- allow `compute_radon_activity` to average rates even when an uncertainty is missing
- propagate error as `sqrt(err218^2 + err214^2)/N`
- expand docstring to document the new behaviour
- update unit tests for the new averaging rule

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850f31593fc832b991355de2ea79061