### PR TITLE
Add settle_s CLI override support

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -431,6 +431,10 @@ def main():
         _log_override("analysis", "radon_interval", args.radon_interval)
         cfg.setdefault("analysis", {})["radon_interval"] = args.radon_interval
 
+    if args.settle_s is not None:
+        _log_override("analysis", "settle_s", float(args.settle_s))
+        cfg.setdefault("analysis", {})["settle_s"] = float(args.settle_s)
+
     if args.hl_po214 is not None:
         tf = cfg.setdefault("time_fit", {})
         sig = 0.0
@@ -1458,6 +1462,7 @@ def main():
             "ambient_concentration": cfg.get("analysis", {}).get(
                 "ambient_concentration"
             ),
+            "settle_s": cfg.get("analysis", {}).get("settle_s"),
         },
     }
 

--- a/io_utils.py
+++ b/io_utils.py
@@ -128,6 +128,7 @@ CONFIG_SCHEMA = {
                 },
                 "radon_interval": {"type": "array", "items": {"type": ["string", "number"]}, "minItems": 2, "maxItems": 2},
                 "ambient_concentration": {"type": ["number", "null"]},
+                "settle_s": {"type": ["number", "null"], "minimum": 0},
             },
         },
     },

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -884,6 +884,59 @@ def test_settle_s_cli(tmp_path, monkeypatch):
     assert captured["times"] == [10.0]
 
 
+def test_settle_s_summary(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+
+    captured = {}
+
+    def fake_write(out_dir, summary, timestamp=None):
+        captured["summary"] = summary
+        d = Path(out_dir) / "x"
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+        "--settle-s",
+        "5",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert captured["summary"]["analysis"]["settle_s"] == 5.0
+
+
 def test_analysis_end_time_cli(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},


### PR DESCRIPTION
## Summary
- allow `--settle-s` CLI flag to override config
- expose settle_s in config schema
- include settle_s in analysis summary output
- test that settle_s is written to summary JSON

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850f401bc1c832bba8f4e04f557f29e