### PR TITLE
Add fallback for missing radon uncertainties

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -65,7 +65,8 @@ def compute_radon_activity(
         Propagated 1-sigma uncertainty.  When the mean is unweighted the
         errors are combined as ``sqrt(err218**2 + err214**2) / N`` where
         ``N`` is the number of rates included and invalid uncertainties are
-        treated as zero.
+        treated as zero.  If two rates are provided but neither uncertainty
+        is valid, the returned uncertainty is ``math.nan``.
     """
     if eff218 < 0:
         raise ValueError("eff218 must be non-negative")
@@ -106,8 +107,10 @@ def compute_radon_activity(
         return A, sigma
 
     if len(values) == 2:
-        # Unweighted average when any uncertainty is missing or invalid
         A = (values[0] + values[1]) / 2.0
+        if all(w is None for w in weights):
+            return A, math.nan
+        # Unweighted average when any uncertainty is missing or invalid
         e218 = err218 if err218 is not None and err218 > 0 else 0.0
         e214 = err214 if err214 is not None and err214 > 0 else 0.0
         sigma = math.sqrt(e218**2 + e214**2) / 2.0

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -172,11 +172,11 @@ def test_compute_radon_activity_unweighted_one_error_missing():
     assert s == pytest.approx(0.25)
 
 
-def test_compute_radon_activity_unweighted_both_errors_missing():
-    """Average both rates when no uncertainties are provided."""
+def test_compute_radon_activity_both_missing_errors():
+    """Average both rates with NaN uncertainty when no errors are given."""
     a, s = compute_radon_activity(5.0, None, 1.0, 7.0, None, 1.0)
     assert a == pytest.approx(6.0)
-    assert s == pytest.approx(0.0)
+    assert math.isnan(s)
 
 
 def test_compute_total_radon_negative_sample_volume():


### PR DESCRIPTION
## Summary
- handle case where both Po-218 and Po-214 uncertainties are invalid
- return NaN uncertainty when averaging two rates without errors
- document this in `compute_radon_activity`
- test missing-error behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850f5fa8254832b81e5b303e8ce9ef3