### PR TITLE
Add requirements hash to analysis summary

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -346,6 +346,13 @@ def main():
     except Exception:
         commit = "unknown"
 
+    try:
+        req_path = Path(__file__).resolve().parent / "requirements.txt"
+        with open(req_path, "rb") as f:
+            requirements_sha256 = hashlib.sha256(f.read()).hexdigest()
+    except Exception:
+        requirements_sha256 = "unknown"
+
     args = parse_args()
     # Convert CLI paths to Path objects
     args.config = Path(args.config)
@@ -1457,6 +1464,7 @@ def main():
         "efficiency": efficiency_results,
         "random_seed": seed_used,
         "git_commit": commit,
+        "requirements_sha256": requirements_sha256,
         "cli_sha256": cli_sha256,
         "cli_args": cli_args,
         "analysis": {

--- a/tests/test_cli_metadata.py
+++ b/tests/test_cli_metadata.py
@@ -66,5 +66,6 @@ def test_summary_includes_git_and_cli(tmp_path, monkeypatch):
     summary = captured.get("summary")
     assert summary is not None
     assert "git_commit" in summary
+    assert "requirements_sha256" in summary
     assert "cli_sha256" in summary
     assert "cli_args" in summary


### PR DESCRIPTION
## Summary
- compute SHA256 of `requirements.txt` inside `analyze.py`
- include that checksum as `requirements_sha256` in the saved summary
- expect this field in CLI metadata test

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68518acc29a8832bbd92db82fd692bc8