### PR TITLE
Add unbinned spectrum fit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ fit.  Important keys include:
 - `expected_peaks` – approximate ADC centroids used to locate the
   Po‑210, Po‑218 and Po‑214 peaks before fitting. The default is
   `{"Po210": 1250, "Po218": 1400, "Po214": 1800}`.
+- `unbinned_likelihood` – when `true` use an extended unbinned likelihood
+  instead of the default χ² fit to histogrammed data.
 - `emg_left` evaluations are wrapped in `np.errstate` and passed through
   `np.nan_to_num` for stability so that NaN or infinite values never
   reach `curve_fit`.
@@ -288,7 +290,8 @@ Example snippet:
     "b0_prior": [0.0, 1.0],
     "b1_prior": [0.0, 1.0],
     "mu_sigma": 0.05,
-    "amp_prior_scale": 1.0
+    "amp_prior_scale": 1.0,
+    "unbinned_likelihood": false
 }
 ```
 

--- a/analyze.py
+++ b/analyze.py
@@ -954,6 +954,8 @@ def main():
             }
             if cfg["spectral_fit"].get("use_plot_bins_for_fit", False):
                 fit_kwargs.update({"bins": bins, "bin_edges": bin_edges})
+            if cfg["spectral_fit"].get("unbinned_likelihood", False):
+                fit_kwargs["unbinned"] = True
             bounds_cfg = cfg["spectral_fit"].get("mu_bounds", {})
             if bounds_cfg:
                 bounds_map = {}

--- a/config.json
+++ b/config.json
@@ -69,6 +69,7 @@
         "peak_search_prominence": 30,
         "peak_search_width_adc": 3,
         "use_plot_bins_for_fit": false,
+        "unbinned_likelihood": false,
         "expected_peaks": {"Po210": 1250, "Po218": 1405, "Po214": 1800},
         "mu_bounds": {
             "Po210": null,

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -258,6 +258,56 @@ def test_fit_spectrum_tau_lower_bound():
     assert result.params["tau_Po218"] >= _TAU_MIN
 
 
+def test_fit_spectrum_unbinned_runs():
+    rng = np.random.default_rng(7)
+    energies = np.concatenate([
+        rng.normal(5.3, 0.05, 150),
+        rng.normal(6.0, 0.05, 150),
+        rng.normal(7.7, 0.05, 150),
+    ])
+
+    priors = {
+        "sigma_E": (0.05, 0.01),
+        "mu_Po210": (5.3, 0.1),
+        "S_Po210": (150, 15),
+        "mu_Po218": (6.0, 0.1),
+        "S_Po218": (150, 15),
+        "mu_Po214": (7.7, 0.1),
+        "S_Po214": (150, 15),
+        "b0": (0.0, 1.0),
+        "b1": (0.0, 1.0),
+    }
+
+    out = fit_spectrum(energies, priors, unbinned=True)
+    assert "sigma_E" in out.params
+
+
+def test_fit_spectrum_unbinned_consistent():
+    rng = np.random.default_rng(8)
+    energies = np.concatenate([
+        rng.normal(5.3, 0.05, 200),
+        rng.normal(6.0, 0.05, 200),
+        rng.normal(7.7, 0.05, 200),
+    ])
+
+    priors = {
+        "sigma_E": (0.05, 0.01),
+        "mu_Po210": (5.3, 0.1),
+        "S_Po210": (200, 20),
+        "mu_Po218": (6.0, 0.1),
+        "S_Po218": (200, 20),
+        "mu_Po214": (7.7, 0.1),
+        "S_Po214": (200, 20),
+        "b0": (0.0, 1.0),
+        "b1": (0.0, 1.0),
+    }
+
+    out_hist = fit_spectrum(energies, priors)
+    out_unbinned = fit_spectrum(energies, priors, unbinned=True)
+    diff = abs(out_hist.params["mu_Po210"] - out_unbinned.params["mu_Po210"])
+    assert diff < 0.2
+
+
 def test_fit_spectrum_covariance_checks(monkeypatch):
     """fit_valid should reflect covariance positive definiteness."""
     rng = np.random.default_rng(5)


### PR DESCRIPTION
## Summary
- support extended unbinned likelihood in `fit_spectrum`
- expose option through configuration and analysis pipeline
- document new option in README
- add unit tests for the unbinned path

## Testing
- `pytest -q` *(fails: Package 'numpy' is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68518aceb30c832bb06820f9df05b4ec