### PR TITLE
Add warning for negative BLUE weights

### DIFF
--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -56,3 +56,11 @@ def test_blue_combine_correlated():
     assert combined == pytest.approx(exp_val)
     assert sigma == pytest.approx(exp_sigma)
 
+
+def test_blue_combine_negative_weights_warning():
+    vals = np.array([1.0, 2.0])
+    errs = np.array([0.1, 0.2])
+    corr = np.array([[1.0, 0.99], [0.99, 1.0]])
+    with pytest.warns(UserWarning):
+        _, _, weights = blue_combine(vals, errs, corr)
+    assert np.any(weights < 0)


### PR DESCRIPTION
## Summary
- issue a warning if BLUE weights are negative
- document the warning in `blue_combine`
- test warning handling for negative BLUE weights

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68518acdaab0832b9d925240de79f9c1