### PR TITLE
Return mask from baseline noise estimation

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -781,10 +781,16 @@ def main():
 
             peak_adc = cal_params.get("peaks", {}).get("Po210", {}).get("centroid_adc")
             if peak_adc is not None:
-                noise_level, _ = estimate_baseline_noise(
+                result = estimate_baseline_noise(
                     base_events["adc"].values,
                     peak_adc=peak_adc,
+                    return_mask=True,
                 )
+                if isinstance(result, tuple) and len(result) == 3:
+                    noise_level, _, mask_noise = result
+                    baseline_info["n_noise_events"] = int(np.sum(mask_noise))
+                else:
+                    noise_level, _ = result
         except Exception as e:
             print(f"WARNING: Baseline noise estimation failed -> {e}")
 

--- a/tests/test_baseline_noise.py
+++ b/tests/test_baseline_noise.py
@@ -10,24 +10,36 @@ from baseline_noise import estimate_baseline_noise
 def test_constant_model():
     rng = np.random.default_rng(0)
     adc = rng.uniform(0, 200, 1000)
-    level, params = estimate_baseline_noise(adc, peak_adc=250, nbins=20, model="constant")
+    level, params, mask = estimate_baseline_noise(
+        adc, peak_adc=250, nbins=20, model="constant", return_mask=True
+    )
     assert level == pytest.approx(1000 / 20, rel=0.2)
     assert "A" in params
+    assert mask.dtype == bool
+    assert mask.shape == adc.shape
 
 
 def test_exponential_model():
     rng = np.random.default_rng(1)
     k_true = 0.02
     adc = rng.exponential(scale=1 / k_true, size=5000)
-    level, params = estimate_baseline_noise(adc, peak_adc=400, nbins=40, model="exponential")
+    level, params, mask = estimate_baseline_noise(
+        adc, peak_adc=400, nbins=40, model="exponential", return_mask=True
+    )
     assert params.get("k") == pytest.approx(k_true, rel=0.3)
     assert level > 0
+    assert mask.dtype == bool
+    assert mask.shape == adc.shape
+    assert not mask.all()
 
 
 def test_empty_adc_values():
-    level, params = estimate_baseline_noise([], peak_adc=200, nbins=10, model="constant")
+    level, params, mask = estimate_baseline_noise(
+        [], peak_adc=200, nbins=10, model="constant", return_mask=True
+    )
     assert level == 0.0
     assert params == {}
+    assert mask.size == 0
 
 
 def test_unknown_model_raises():


### PR DESCRIPTION
## Summary
- add optional return mask to `estimate_baseline_noise`
- record number of noisy baseline events in `analyze.py`
- test the mask behaviour in `test_baseline_noise`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68518acc601c832b9172260a5020e81e