### PR TITLE
Handle weighted integral in time-series fits

### DIFF
--- a/fitting.py
+++ b/fitting.py
@@ -322,8 +322,15 @@ def _neg_log_likelihood_time(
         B_iso = 0.0 if fix_b_map[iso] else p[f"B_{iso}"]
         N0_iso = 0.0 if fix_n0_map[iso] else p[f"N0_{iso}"]
 
-        # 1) Integral term:
+        # 1) Integral term. When per-event weights are supplied we
+        # scale the integral by the average weight so that a uniform
+        # scaling of all weights cancels between the log and integral
+        # contributions.
         integral = _integral_model(E_iso, N0_iso, B_iso, lam, eff, T_rel)
+        weights = weights_dict.get(iso)
+        if weights is not None and len(weights) > 0:
+            integral *= float(np.mean(weights))
+
         # 2) Sum of log[r(t_i)] for each event t_i in times_dict[iso]:
         times_iso = times_dict.get(iso, np.empty(0))
         weights = weights_dict.get(iso)

--- a/tests/test_time_series_weights.py
+++ b/tests/test_time_series_weights.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from fitting import fit_time_series
+
+
+def simulate_times(n, T, seed=0):
+    rng = np.random.default_rng(seed)
+    return np.sort(rng.uniform(0, T, n))
+
+
+def base_config(T):
+    return {
+        "isotopes": {"Po214": {"half_life_s": 1.0, "efficiency": 1.0}},
+        "fit_background": False,
+        "fit_initial": False,
+    }
+
+
+def test_uniform_weight_scaling_invariant():
+    times = simulate_times(50, 10, seed=1)
+    cfg = base_config(10)
+    res0 = fit_time_series({"Po214": times}, 0.0, 10, cfg)
+    res_half = fit_time_series(
+        {"Po214": times}, 0.0, 10, cfg, weights={"Po214": np.ones_like(times) * 0.5}
+    )
+    res_double = fit_time_series(
+        {"Po214": times}, 0.0, 10, cfg, weights={"Po214": np.ones_like(times) * 2.0}
+    )
+    assert res0.params["E_Po214"] == pytest.approx(res_half.params["E_Po214"], rel=1e-2)
+    assert res0.params["E_Po214"] == pytest.approx(res_double.params["E_Po214"], rel=1e-2)
+
+
+def test_variable_weights_scale_independent():
+    times = simulate_times(60, 20, seed=2)
+    cfg = base_config(20)
+    rng = np.random.default_rng(3)
+    w = rng.uniform(0.2, 1.5, size=times.size)
+    res_base = fit_time_series({"Po214": times}, 0.0, 20, cfg, weights={"Po214": w})
+    res_scaled = fit_time_series({"Po214": times}, 0.0, 20, cfg, weights={"Po214": 3 * w})
+    assert res_base.params["E_Po214"] == pytest.approx(res_scaled.params["E_Po214"], rel=1e-2)


### PR DESCRIPTION
## Summary
- ensure per-event weights affect integral term by average weight
- add regression tests for consistent weighting

## Testing
- `pytest -q tests/test_time_series_weights.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68518acddc58832ba350b80c804e8104