### PR TITLE
Add strict covariance option to fits

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ The time-series fit checks whether the covariance matrix returned by
 Minuit is positive definite.  If not, a tiny diagonal jitter is added
 before repeating the check.  When even the jittered matrix fails this
 test the result still contains the fitted values but ``fit_valid`` is set
-to ``False``.
+to ``False``.  Pass ``strict=True`` (or ``--strict`` on the command line)
+to instead raise an error when the covariance is not positive definite.
 
 ## Configuration
 

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -301,6 +301,9 @@ def test_fit_spectrum_covariance_checks(monkeypatch):
     out_bad = fit_spectrum(energies, priors)
     assert not out_bad.params["fit_valid"]
 
+    with pytest.raises(RuntimeError):
+        fit_spectrum(energies, priors, strict=True)
+
 
 def test_fit_time_series_covariance_checks(monkeypatch):
     """Minuit covariance validity should propagate to fit_valid."""
@@ -338,6 +341,9 @@ def test_fit_time_series_covariance_checks(monkeypatch):
     monkeypatch.setattr(linalg, "cholesky", cholesky_fail)
     res_bad = fit_time_series(times_dict, 0.0, T, cfg)
     assert not res_bad.params["fit_valid"]
+
+    with pytest.raises(RuntimeError):
+        fit_time_series(times_dict, 0.0, T, cfg, strict=True)
 
 
 def test_fit_time_series_half_life_zero_raises():


### PR DESCRIPTION
## Summary
- allow fit_spectrum and fit_time_series to optionally fail on non-positive definite covariance
- expose strict mode in analyze CLI and documentation
- test strict mode in both spectrum and time-series fits

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68518c59fdf8832b87dbd6b37d5e7881