### PR TITLE
Update baseline_range override behavior

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -736,8 +736,8 @@ def main():
     baseline_cfg = cfg.get("baseline", {})
     baseline_range = None
     if args.baseline_range:
-        if "range" in baseline_cfg:
-            _log_override("baseline", "range", args.baseline_range)
+        _log_override("baseline", "range", args.baseline_range)
+        cfg.setdefault("baseline", {})["range"] = args.baseline_range
         baseline_range = args.baseline_range
     elif "range" in baseline_cfg:
         baseline_range = baseline_cfg.get("range")

--- a/tests/test_baseline_range_cli.py
+++ b/tests/test_baseline_range_cli.py
@@ -52,6 +52,15 @@ def test_baseline_range_cli_overrides_config(tmp_path, monkeypatch):
 
     captured = {}
 
+    orig_load_config = analyze.load_config
+
+    def fake_load_config(path):
+        cfg_local = orig_load_config(path)
+        captured["cfg"] = cfg_local
+        return cfg_local
+
+    monkeypatch.setattr(analyze, "load_config", fake_load_config)
+
     def fake_fit(ts_dict, t_start, t_end, cfg):
         captured["times"] = ts_dict.get("Po214", []).tolist()
         return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
@@ -81,3 +90,4 @@ def test_baseline_range_cli_overrides_config(tmp_path, monkeypatch):
     assert summary["baseline"]["start"] == 10.0
     assert summary["baseline"]["end"] == 20.0
     assert summary["baseline"]["n_events"] == 1
+    assert captured.get("cfg", {}).get("baseline", {}).get("range") == ["10", "20"]

--- a/tests/test_cli_baseline_range.py
+++ b/tests/test_cli_baseline_range.py
@@ -54,6 +54,15 @@ def test_cli_baseline_range_overrides_config(tmp_path, monkeypatch):
 
     captured = {}
 
+    orig_load_config = analyze.load_config
+
+    def fake_load_config(path):
+        cfg_local = orig_load_config(path)
+        captured["cfg"] = cfg_local
+        return cfg_local
+
+    monkeypatch.setattr(analyze, "load_config", fake_load_config)
+
     def fake_fit(ts_dict, t_start, t_end, cfg):
         captured["times"] = ts_dict.get("Po214", []).tolist()
         return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
@@ -83,3 +92,4 @@ def test_cli_baseline_range_overrides_config(tmp_path, monkeypatch):
     assert summary.get("baseline", {}).get("start") == 1.0
     assert summary.get("baseline", {}).get("end") == 2.0
     assert summary.get("baseline", {}).get("n_events") == 1
+    assert captured.get("cfg", {}).get("baseline", {}).get("range") == ["1", "2"]

--- a/tests/test_cli_baseline_range_override2.py
+++ b/tests/test_cli_baseline_range_override2.py
@@ -54,6 +54,15 @@ def test_cli_baseline_range_overrides_config_again(tmp_path, monkeypatch):
 
     captured = {}
 
+    orig_load_config = analyze.load_config
+
+    def fake_load_config(path):
+        cfg_local = orig_load_config(path)
+        captured["cfg"] = cfg_local
+        return cfg_local
+
+    monkeypatch.setattr(analyze, "load_config", fake_load_config)
+
     def fake_fit(ts_dict, t_start, t_end, cfg):
         captured["times"] = ts_dict.get("Po214", []).tolist()
         return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
@@ -83,3 +92,4 @@ def test_cli_baseline_range_overrides_config_again(tmp_path, monkeypatch):
     assert summary.get("baseline", {}).get("start") == 2.0
     assert summary.get("baseline", {}).get("end") == 3.0
     assert summary.get("baseline", {}).get("n_events") == 1
+    assert captured.get("cfg", {}).get("baseline", {}).get("range") == ["2", "3"]


### PR DESCRIPTION
## Summary
- update analyze.py so --baseline_range also updates loaded config
- verify cfg update in baseline-range CLI tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68518c5ee774832ba212c1cc61e0195b