### PR TITLE
Propagate calibration covariance

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -731,10 +731,14 @@ def main():
     a, a_sig = cal_params["a"]
     c, c_sig = cal_params["c"]
     sigE_mean, sigE_sigma = cal_params["sigma_E"]
+    cov_mat = np.asarray(cal_params.get("ac_covariance", [[0.0, 0.0], [0.0, 0.0]]), dtype=float)
+    cov_ac = float(cov_mat[0, 1])
 
     # Apply linear calibration -> new column “energy_MeV” and its uncertainty
     events["energy_MeV"] = events["adc"] * a + c
-    events["denergy_MeV"] = np.sqrt((events["adc"] * a_sig) ** 2 + c_sig**2)
+    events["denergy_MeV"] = np.sqrt(
+        (events["adc"] * a_sig) ** 2 + c_sig ** 2 + 2 * events["adc"] * cov_ac
+    )
 
     # ────────────────────────────────────────────────────────────
     # 4. Baseline run (optional)


### PR DESCRIPTION
## Summary
- propagate centroid uncertainty to slope and intercept in `calibrate_run`
- return covariance and use it in `derive_calibration_constants`
- factor covariance into event energy uncertainties

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68518de74380832b82ebd5855186111f