### PR TITLE
Add DEFAULT_NOMINAL_ADC constant

### DIFF
--- a/calibration.py
+++ b/calibration.py
@@ -2,7 +2,12 @@ import numpy as np
 from scipy.signal import find_peaks
 from scipy.optimize import curve_fit
 from scipy.stats import exponnorm
-from constants import _TAU_MIN, EXP_OVERFLOW_DOUBLE, DEFAULT_NOISE_CUTOFF
+from constants import (
+    _TAU_MIN,
+    EXP_OVERFLOW_DOUBLE,
+    DEFAULT_NOISE_CUTOFF,
+    DEFAULT_NOMINAL_ADC,
+)
 
 # Limit for stable exponentiation when evaluating the EMG tail. Values
 # beyond ~700 in magnitude overflow in IEEE-754 doubles.  Match the
@@ -363,9 +368,8 @@ def derive_calibration_constants_auto(
     nominal_adc : dict or None
         Optional mapping of isotope -> ADC guess.
         Expected ADC centroids for each isotope.  Keys should be
-        ``"Po210"``, ``"Po218"`` and ``"Po214"``.  If ``None`` a
-        reasonable default of ``{"Po210": 1250, "Po218": 1400, "Po214": 1800}``
-        is used.
+        ``"Po210"``, ``"Po218"`` and ``"Po214"``.  If ``None`` the
+        :data:`constants.DEFAULT_NOMINAL_ADC` values are used.
 
     """
     if len(adc_values) == 0:
@@ -376,7 +380,7 @@ def derive_calibration_constants_auto(
     adc_arr = adc_arr[mask]
 
     if nominal_adc is None:
-        nominal_adc = {"Po210": 1250, "Po218": 1400, "Po214": 1800}
+        nominal_adc = DEFAULT_NOMINAL_ADC
 
     config = {
         "calibration": {

--- a/constants.py
+++ b/constants.py
@@ -12,6 +12,14 @@ DEFAULT_NOISE_CUTOFF = 400
 # Iteration cap for ``scipy.optimize.curve_fit``
 CURVE_FIT_MAX_EVALS = 10000
 
+# Nominal ADC centroids for the Po-210, Po-218 and Po-214 peaks used
+# when calibration data does not specify otherwise.
+DEFAULT_NOMINAL_ADC = {
+    "Po210": 1250,
+    "Po218": 1400,
+    "Po214": 1800,
+}
+
 from dataclasses import dataclass
 
 
@@ -80,6 +88,7 @@ __all__ = [
     "EXP_OVERFLOW_DOUBLE",
     "DEFAULT_NOISE_CUTOFF",
     "CURVE_FIT_MAX_EVALS",
+    "DEFAULT_NOMINAL_ADC",
     "NuclideConst",
     "PO214",
     "PO218",


### PR DESCRIPTION
## Summary
- centralize nominal ADC centroids in constants.py
- reference constants.DEFAULT_NOMINAL_ADC from calibration

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851929c3894832b8c707c45c445ce8d