### PR TITLE
Add strict covariance option to fitting routines

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ The time-series fit checks whether the covariance matrix returned by
 Minuit is positive definite.  If not, a tiny diagonal jitter is added
 before repeating the check.  When even the jittered matrix fails this
 test the result still contains the fitted values but ``fit_valid`` is set
-to ``False``.
+to ``False``.  Passing ``strict=True`` (or ``--strict-covariance`` on the
+command line) instead raises a ``RuntimeError`` as soon as the matrix is
+found to be non-positive definite.
 
 ## Configuration
 

--- a/analyze.py
+++ b/analyze.py
@@ -326,6 +326,11 @@ def parse_args():
         help="Color palette for plots. Providing this option overrides `plotting.palette` in config.json",
     )
     p.add_argument(
+        "--strict-covariance",
+        action="store_true",
+        help="Fail if fit covariance matrices are not positive definite",
+    )
+    p.add_argument(
         "--hierarchical-summary",
         metavar="OUTFILE",
         help=(
@@ -980,6 +985,8 @@ def main():
                 fit_kwargs.update({"bins": bins, "bin_edges": bin_edges})
             if cfg["spectral_fit"].get("unbinned_likelihood", False):
                 fit_kwargs["unbinned"] = True
+            if args.strict_covariance:
+                fit_kwargs["strict"] = True
             bounds_cfg = cfg["spectral_fit"].get("mu_bounds", {})
             if bounds_cfg:
                 bounds_map = {}
@@ -1120,6 +1127,7 @@ def main():
                     t_end_global,
                     fit_cfg,
                     weights=weights_map,
+                    strict=args.strict_covariance,
                 )
             except TypeError:
                 decay_out = fit_time_series(
@@ -1127,6 +1135,7 @@ def main():
                     t_start_fit,
                     t_end_global,
                     fit_cfg,
+                    strict=args.strict_covariance,
                 )
             time_fit_results[iso] = decay_out
         except Exception as e:
@@ -1213,6 +1222,7 @@ def main():
                         t_end_global,
                         cfg_fit,
                         weights=weights_local,
+                        strict=args.strict_covariance,
                     )
                 except TypeError:
                     out = fit_time_series(
@@ -1220,6 +1230,7 @@ def main():
                         t0_global,
                         t_end_global,
                         cfg_fit,
+                        strict=args.strict_covariance,
                     )
                 # Return only the parameter dictionary so scan_systematics
                 # works with a simple mapping.

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -122,7 +122,7 @@ def test_analysis_start_time_applied(tmp_path, monkeypatch):
 
     captured = {}
 
-    def fake_fit_time_series(times_dict, t_start, t_end, config):
+    def fake_fit_time_series(times_dict, t_start, t_end, config, **kwargs):
         captured["t_start"] = t_start
         return FitResult({}, np.zeros((0, 0)), 0)
 
@@ -861,7 +861,7 @@ def test_settle_s_cli(tmp_path, monkeypatch):
 
     captured = {}
 
-    def fake_fit(ts_dict, t_start, t_end, config):
+    def fake_fit(ts_dict, t_start, t_end, config, **kwargs):
         captured["times"] = ts_dict["Po214"].tolist()
         return FitResult({}, np.zeros((0, 0)), 0)
 
@@ -973,7 +973,7 @@ def test_analysis_end_time_cli(tmp_path, monkeypatch):
 
     captured = {}
 
-    def fake_fit(ts_dict, t_start, t_end, config):
+    def fake_fit(ts_dict, t_start, t_end, config, **kwargs):
         captured["times"] = ts_dict["Po214"].tolist()
         return FitResult({}, np.zeros((0, 0)), 0)
 
@@ -1032,7 +1032,7 @@ def test_spike_end_time_cli(tmp_path, monkeypatch):
 
     captured = {}
 
-    def fake_fit(ts_dict, t_start, t_end, config):
+    def fake_fit(ts_dict, t_start, t_end, config, **kwargs):
         captured["times"] = ts_dict["Po214"].tolist()
         return FitResult({}, np.zeros((0, 0)), 0)
 
@@ -1091,7 +1091,7 @@ def test_spike_period_cli(tmp_path, monkeypatch):
 
     captured = {}
 
-    def fake_fit(ts_dict, t_start, t_end, config):
+    def fake_fit(ts_dict, t_start, t_end, config, **kwargs):
         captured["times"] = ts_dict["Po214"].tolist()
         return FitResult({}, np.zeros((0, 0)), 0)
 
@@ -1852,7 +1852,7 @@ def test_hl_po214_cli_overrides(tmp_path, monkeypatch):
 
     calls = []
 
-    def fake_fit(ts_dict, t_start, t_end, config):
+    def fake_fit(ts_dict, t_start, t_end, config, **kwargs):
         iso = list(ts_dict.keys())[0]
         calls.append((iso, config))
         return FitResult({}, np.zeros((0, 0)), 0)

--- a/tests/test_analyze_noise_cutoff.py
+++ b/tests/test_analyze_noise_cutoff.py
@@ -55,7 +55,7 @@ def test_analyze_noise_cutoff(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "plot_time_series", fake_plot_time_series)
 
-    def fake_fit_time_series(times_dict, t_start, t_end, cfg, weights=None):
+    def fake_fit_time_series(times_dict, t_start, t_end, cfg, weights=None, **kwargs):
         captured["fit_times"] = list(times_dict.get("Po214", []))
         return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
 

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -45,7 +45,7 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     captured = {}
 
-    def fake_fit_time_series(times_dict, t_start, t_end, cfg):
+    def fake_fit_time_series(times_dict, t_start, t_end, cfg, **kwargs):
         captured["times"] = times_dict.get("Po214")
         return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
 
@@ -194,7 +194,7 @@ def test_n0_prior_from_baseline(tmp_path, monkeypatch):
 
     captured = {}
 
-    def fake_fit_time_series(times_dict, t_start, t_end, cfg):
+    def fake_fit_time_series(times_dict, t_start, t_end, cfg, **kwargs):
         return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit_time_series)

--- a/tests/test_cli_baseline_range_override2.py
+++ b/tests/test_cli_baseline_range_override2.py
@@ -63,7 +63,7 @@ def test_cli_baseline_range_overrides_config_again(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "load_config", fake_load_config)
 
-    def fake_fit(ts_dict, t_start, t_end, cfg):
+    def fake_fit(ts_dict, t_start, t_end, cfg, **kwargs):
         captured["times"] = ts_dict.get("Po214", []).tolist()
         return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
 

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -351,6 +351,9 @@ def test_fit_spectrum_covariance_checks(monkeypatch):
     out_bad = fit_spectrum(energies, priors)
     assert not out_bad.params["fit_valid"]
 
+    with pytest.raises(RuntimeError):
+        fit_spectrum(energies, priors, strict=True)
+
 
 def test_fit_time_series_covariance_checks(monkeypatch):
     """Minuit covariance validity should propagate to fit_valid."""
@@ -388,6 +391,9 @@ def test_fit_time_series_covariance_checks(monkeypatch):
     monkeypatch.setattr(linalg, "cholesky", cholesky_fail)
     res_bad = fit_time_series(times_dict, 0.0, T, cfg)
     assert not res_bad.params["fit_valid"]
+
+    with pytest.raises(RuntimeError):
+        fit_time_series(times_dict, 0.0, T, cfg, strict=True)
 
 
 def test_fit_time_series_half_life_zero_raises():

--- a/tests/test_noise_cut.py
+++ b/tests/test_noise_cut.py
@@ -53,7 +53,7 @@ def test_noise_cutoff_cli_overrides(tmp_path, monkeypatch):
 
     captured = {}
 
-    def fake_fit(ts_dict, t_start, t_end, cfg, weights=None):
+    def fake_fit(ts_dict, t_start, t_end, cfg, weights=None, **kwargs):
         captured["times"] = ts_dict.get("Po214", []).tolist()
         return {"E_Po214": 1.0}
 

--- a/tests/test_noise_cutoff.py
+++ b/tests/test_noise_cutoff.py
@@ -51,7 +51,7 @@ def test_noise_cutoff_filters_events(tmp_path, monkeypatch):
 
     captured = {}
 
-    def fake_fit(ts_dict, t_start, t_end, cfg, weights=None):
+    def fake_fit(ts_dict, t_start, t_end, cfg, weights=None, **kwargs):
         captured["times"] = ts_dict.get("Po214", []).tolist()
         return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
 
@@ -119,7 +119,7 @@ def test_invalid_noise_cutoff_skips_cut(tmp_path, monkeypatch, caplog):
 
     captured = {}
 
-    def fake_fit(ts_dict, t_start, t_end, cfg, weights=None):
+    def fake_fit(ts_dict, t_start, t_end, cfg, weights=None, **kwargs):
         captured["times"] = ts_dict.get("Po214", []).tolist()
         return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
 

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -57,7 +57,7 @@ def test_time_window_filters_events(tmp_path, monkeypatch):
 
     captured = {}
 
-    def fake_fit(ts_dict, t_start, t_end, config):
+    def fake_fit(ts_dict, t_start, t_end, config, **kwargs):
         captured["times"] = ts_dict.get("Po214", []).tolist()
         return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
 
@@ -189,7 +189,7 @@ def test_time_window_filters_events_config(tmp_path, monkeypatch):
 
     captured = {}
 
-    def fake_fit(ts_dict, t_start, t_end, config):
+    def fake_fit(ts_dict, t_start, t_end, config, **kwargs):
         captured["times"] = ts_dict.get("Po214", []).tolist()
         return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
 
@@ -268,7 +268,7 @@ def test_run_period_filters_events(tmp_path, monkeypatch):
 
     captured = {}
 
-    def fake_fit(ts_dict, t_start, t_end, config):
+    def fake_fit(ts_dict, t_start, t_end, config, **kwargs):
         captured["times"] = ts_dict.get("Po214", []).tolist()
         return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
 
@@ -352,7 +352,7 @@ def test_baseline_range_iso_strings(tmp_path, monkeypatch, start, end):
 
     captured = {}
 
-    def fake_fit(ts_dict, t_start, t_end, config):
+    def fake_fit(ts_dict, t_start, t_end, config, **kwargs):
         captured["times"] = ts_dict.get("Po214", []).tolist()
         return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
 


### PR DESCRIPTION
## Summary
- allow strict covariance validity check for fit_spectrum and fit_time_series
- expose the option on the CLI
- document new behaviour in README
- test strict mode errors and update helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851927b6eec832b857ca179f7090b04