### PR TITLE
Add isotopes_to_subtract config

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,16 +395,19 @@ These half-life values may also be set on the command line with
 ### Baseline Runs
 
 A baseline run measures the radon background with an empty monitor before
-an assay. Configuration must define three keys under `baseline`:
+an assay. Configuration must define these keys under `baseline`:
 
 - `baseline.range` – list of two ISO‑8601 timestamps selecting the baseline interval.
 - `monitor_volume_l` – internal volume of the radon monitor in liters.
 - `sample_volume_l` – volume of the assay sample in liters.
+- `isotopes_to_subtract` – list of isotopes whose baseline rates are
+  subtracted from the fitted decay rates. The default is
+  `["Po214", "Po218"]`.
 
-Events collected during the baseline period are counted in the Po‑214 and
-Po‑218 windows. The counts are converted directly into a decay rate in
-Bq by dividing by the baseline live time and detection efficiency.  This
-rate is scaled by the dilution factor
+Events collected during the baseline period are counted in the selected
+isotope windows. The counts for each isotope are converted into a decay
+rate in Bq by dividing by the baseline live time and the corresponding
+detection efficiency.  Each rate is scaled by the dilution factor
 `monitor_volume_l / (monitor_volume_l + sample_volume_l)` before being
 subtracted from the fitted radon decay rate of the assay. The command-line
 option `--baseline_range` overrides `baseline.range` from the
@@ -418,7 +421,8 @@ Example snippet:
 "baseline": {
     "range": ["2023-07-01T00:00:00Z", "2023-07-03T00:00:00Z"],
     "monitor_volume_l": 10.0,
-    "sample_volume_l": 5.0
+    "sample_volume_l": 5.0,
+    "isotopes_to_subtract": ["Po214", "Po218"]
 }
 ```
 

--- a/analyze.py
+++ b/analyze.py
@@ -757,6 +757,7 @@ def main():
     # ────────────────────────────────────────────────────────────
     baseline_info = {}
     baseline_cfg = cfg.get("baseline", {})
+    isotopes_to_subtract = baseline_cfg.get("isotopes_to_subtract", ["Po214", "Po218"])
     baseline_range = None
     if args.baseline_range:
         _log_override("baseline", "range", args.baseline_range)
@@ -1070,7 +1071,8 @@ def main():
                 hi,
             )
             n0_count = float(np.sum(probs_base))
-            baseline_counts[iso] = n0_count
+            if iso in isotopes_to_subtract:
+                baseline_counts[iso] = n0_count
 
             eff = cfg["time_fit"].get(f"eff_{iso}", [1.0])[0]
             if baseline_live_time > 0 and eff > 0:

--- a/config.json
+++ b/config.json
@@ -17,7 +17,8 @@
     "baseline": {
         "range": ["1970-01-01T00:00:00Z", "1970-01-01T00:05:00Z"],
         "monitor_volume_l": 605.0,
-        "sample_volume_l": 0.0
+        "sample_volume_l": 0.0,
+        "isotopes_to_subtract": ["Po214", "Po218"]
     },
     "burst_filter": {
         "burst_mode": "rate",

--- a/io_utils.py
+++ b/io_utils.py
@@ -81,6 +81,7 @@ CONFIG_SCHEMA = {
                 "range": {"type": "array", "items": {"type": ["string", "number"]}, "minItems": 2, "maxItems": 2},
                 "monitor_volume_l": {"type": "number", "minimum": 0},
                 "sample_volume_l": {"type": "number", "minimum": 0},
+                "isotopes_to_subtract": {"type": "array", "items": {"type": "string"}},
             },
         },
         "burst_filter": {

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -239,3 +239,70 @@ def test_n0_prior_from_baseline(tmp_path, monkeypatch):
     n0_prior = captured.get("priors", {}).get("N0", (None,))[0]
     assert n0_prior == pytest.approx(0.2, rel=1e-3)
 
+
+def test_isotopes_to_subtract_control(tmp_path, monkeypatch):
+    """No subtraction occurs when the isotope list is empty."""
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "baseline": {"range": [0, 10], "monitor_volume_l": 605.0, "sample_volume_l": 0.0, "isotopes_to_subtract": []},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": True,
+            "window_Po214": [7, 9],
+            "hl_Po214": [1.0, 0.0],
+            "eff_Po214": [1.0, 0.0],
+            "flags": {},
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1, 2, 3],
+        "fBits": [0, 0, 0],
+        "timestamp": [1, 2, 20],
+        "adc": [8, 8, 8],
+        "fchannel": [1, 1, 1],
+    })
+    data_path = tmp_path / "data.csv"
+    df.to_csv(data_path, index=False)
+
+    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({"E_Po214": 1.0}, np.zeros((1,1)), 0))
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(baseline_noise, "estimate_baseline_noise", lambda *a, **k: (None, {}))
+
+    captured = {}
+
+    def fake_write(out_dir, summary, timestamp=None):
+        captured["summary"] = summary
+        d = Path(out_dir) / (timestamp or "x")
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config", str(cfg_path),
+        "--input", str(data_path),
+        "--output_dir", str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+
+    analyze.main()
+
+    summary = captured["summary"]
+    assert "rate_Bq" not in summary.get("baseline", {})
+    assert "E_corrected" not in summary["time_fit"]["Po214"]
+


### PR DESCRIPTION
## Summary
- support `baseline.isotopes_to_subtract` list in default config
- validate the new key in `CONFIG_SCHEMA`
- only subtract baseline for configured isotopes in `analyze.py`
- document baseline subtraction behaviour
- test that disabling subtraction works

## Testing
- `pytest -q tests/test_baseline.py::test_isotopes_to_subtract_control -q` *(fails: Package 'numpy' is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68519bfc209c832b885cd7fd346a751a