### PR TITLE
Store baseline subtraction scales

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,9 @@ isotope windows. The counts for each isotope are converted into a decay
 rate in Bq by dividing by the baseline live time and the corresponding
 detection efficiency.  Each rate is scaled by the dilution factor
 `monitor_volume_l / (monitor_volume_l + sample_volume_l)` before being
-subtracted from the fitted radon decay rate of the assay. The command-line
+subtracted from the fitted radon decay rate of the assay. The multiplicative
+scale factors for Po-214, Po-218, Po-210 and electronic noise are stored in
+`summary.json` under `baseline.scales`. The command-line
 option `--baseline_range` overrides `baseline.range` from the
 configuration when provided. When you specify this option the
 configuration's interval is ignored in favour of the CLI value.

--- a/analyze.py
+++ b/analyze.py
@@ -1355,13 +1355,19 @@ def main():
     if monitor_vol + sample_vol > 0:
         dilution_factor = monitor_vol / (monitor_vol + sample_vol)
 
-    scale = {"Po214": dilution_factor, "Po218": dilution_factor, "Po210": 1.0, "noise": 1.0}
+    scales = {
+        "Po214": dilution_factor,
+        "Po218": dilution_factor,
+        "Po210": 1.0,
+        "noise": 1.0,
+    }
+    baseline_info["scales"] = scales
 
     for iso, rate in baseline_rates.items():
         fit = time_fit_results.get(iso)
         params = _fit_params(fit)
         if params and (f"E_{iso}" in params):
-            s = scale.get(iso, 1.0)
+            s = scales.get(iso, 1.0)
             params["E_corrected"] = params[f"E_{iso}"] - s * rate
             err_fit = params.get(f"dE_{iso}", 0.0)
             err_base = baseline_unc.get(iso, 0.0)
@@ -1371,7 +1377,6 @@ def main():
         baseline_info["rate_Bq"] = baseline_rates
         baseline_info["rate_unc_Bq"] = baseline_unc
         baseline_info["dilution_factor"] = dilution_factor
-        baseline_info["scales"] = scale
 
     # ────────────────────────────────────────────────────────────
     # Radon activity extrapolation

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -79,6 +79,10 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
     assert rate == pytest.approx(0.2, rel=1e-3)
     assert summary["baseline"]["n_events"] == 2
     assert summary["baseline"]["dilution_factor"] == pytest.approx(1.0)
+    assert summary["baseline"]["scales"]["Po214"] == pytest.approx(1.0)
+    assert summary["baseline"]["scales"]["Po218"] == pytest.approx(1.0)
+    assert summary["baseline"]["scales"]["Po210"] == pytest.approx(1.0)
+    assert summary["baseline"]["scales"]["noise"] == pytest.approx(1.0)
     assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(0.8)
     assert summary["baseline"].get("noise_level") == 5.0
     times = list(captured.get("times", []))
@@ -154,6 +158,8 @@ def test_baseline_scaling_factor(tmp_path, monkeypatch):
     dilution = summary["baseline"]["dilution_factor"]
     assert rate == pytest.approx(0.2, rel=1e-3)
     assert dilution == pytest.approx(0.5)
+    assert summary["baseline"]["scales"]["Po214"] == pytest.approx(0.5)
+    assert summary["baseline"]["scales"]["Po218"] == pytest.approx(0.5)
     assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(0.9)
 
 
@@ -238,6 +244,7 @@ def test_n0_prior_from_baseline(tmp_path, monkeypatch):
 
     n0_prior = captured.get("priors", {}).get("N0", (None,))[0]
     assert n0_prior == pytest.approx(0.2, rel=1e-3)
+    assert captured["summary"]["baseline"]["scales"]["Po214"] == pytest.approx(1.0)
 
 
 def test_isotopes_to_subtract_control(tmp_path, monkeypatch):
@@ -305,4 +312,5 @@ def test_isotopes_to_subtract_control(tmp_path, monkeypatch):
     summary = captured["summary"]
     assert "rate_Bq" not in summary.get("baseline", {})
     assert "E_corrected" not in summary["time_fit"]["Po214"]
+    assert summary["baseline"]["scales"]["Po214"] == pytest.approx(1.0)
 


### PR DESCRIPTION
## Summary
- keep per-isotope baseline subtraction scaling factors
- expose these scales in `summary.json`
- document baseline scales
- test new `baseline.scales` output

## Testing
- `scripts/setup_tests.sh` *(fails: ModuleNotFoundError: No module named 'scipy.stats')*
- `pytest -q` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6851a9ab3e78832b8d87b1131e2469c5