### PR TITLE
Update baseline tests for new summaries

### DIFF
--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -80,6 +80,15 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
     assert summary["baseline"]["n_events"] == 2
     assert summary["baseline"]["dilution_factor"] == pytest.approx(1.0)
     assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(0.8)
+    assert summary["time_fit"]["Po214"]["dE_corrected"] == pytest.approx(
+        0.1414, rel=1e-3
+    )
+    assert summary["baseline"]["scales"] == {
+        "Po214": pytest.approx(1.0),
+        "Po218": pytest.approx(1.0),
+        "Po210": pytest.approx(1.0),
+        "noise": pytest.approx(1.0),
+    }
     assert summary["baseline"].get("noise_level") == 5.0
     times = list(captured.get("times", []))
     assert times == [20]
@@ -155,6 +164,15 @@ def test_baseline_scaling_factor(tmp_path, monkeypatch):
     assert rate == pytest.approx(0.2, rel=1e-3)
     assert dilution == pytest.approx(0.5)
     assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(0.9)
+    assert summary["time_fit"]["Po214"]["dE_corrected"] == pytest.approx(
+        0.0707, rel=1e-3
+    )
+    assert summary["baseline"]["scales"] == {
+        "Po214": pytest.approx(0.5),
+        "Po218": pytest.approx(0.5),
+        "Po210": pytest.approx(1.0),
+        "noise": pytest.approx(1.0),
+    }
 
 
 def test_n0_prior_from_baseline(tmp_path, monkeypatch):
@@ -305,4 +323,5 @@ def test_isotopes_to_subtract_control(tmp_path, monkeypatch):
     summary = captured["summary"]
     assert "rate_Bq" not in summary.get("baseline", {})
     assert "E_corrected" not in summary["time_fit"]["Po214"]
+    assert "dE_corrected" not in summary["time_fit"]["Po214"]
 

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -90,6 +90,12 @@ def test_time_window_filters_events(tmp_path, monkeypatch):
 
     summary = captured.get("summary", {})
     assert summary["baseline"]["n_events"] == 1
+    assert summary["baseline"]["scales"] == {
+        "Po214": pytest.approx(1.0),
+        "Po218": pytest.approx(1.0),
+        "Po210": pytest.approx(1.0),
+        "noise": pytest.approx(1.0),
+    }
     assert captured.get("times") == [6.0]
 
 
@@ -218,6 +224,12 @@ def test_time_window_filters_events_config(tmp_path, monkeypatch):
 
     summary = captured.get("summary", {})
     assert summary["baseline"]["n_events"] == 1
+    assert summary["baseline"]["scales"] == {
+        "Po214": pytest.approx(1.0),
+        "Po218": pytest.approx(1.0),
+        "Po210": pytest.approx(1.0),
+        "noise": pytest.approx(1.0),
+    }
     assert captured.get("times") == [6.0]
 
 
@@ -381,5 +393,11 @@ def test_baseline_range_iso_strings(tmp_path, monkeypatch, start, end):
 
     summary = captured.get("summary", {})
     assert summary["baseline"]["n_events"] == 1
+    assert summary["baseline"]["scales"] == {
+        "Po214": pytest.approx(1.0),
+        "Po218": pytest.approx(1.0),
+        "Po210": pytest.approx(1.0),
+        "noise": pytest.approx(1.0),
+    }
     assert captured.get("times") == [6.0]
 


### PR DESCRIPTION
## Summary
- adjust `test_baseline.py` to expect `scales` and `dE_corrected`
- check `scales` in `test_time_window.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851a9a9e00c832b8f1bca37c95a3e5e