### PR TITLE
Expose blue_combine in wrapper

### DIFF
--- a/blue_combine.py
+++ b/blue_combine.py
@@ -4,7 +4,10 @@ from dataclasses import dataclass
 from typing import Sequence, Optional
 import numpy as np
 
-from efficiency import blue_combine
+from efficiency import blue_combine as _efficiency_blue_combine
+
+# Provide a local alias so this module can re-export ``blue_combine``.
+blue_combine = _efficiency_blue_combine
 
 CovarianceMatrix = np.ndarray
 
@@ -19,4 +22,4 @@ def BLUE(measurements: Measurements):
     """Return BLUE combination of the given measurements."""
     return blue_combine(measurements.values, measurements.errors, measurements.corr)
 
-__all__ = ["BLUE", "Measurements", "CovarianceMatrix"]
+__all__ = ["blue_combine", "BLUE", "Measurements", "CovarianceMatrix"]

--- a/tests/test_blue_combine_module.py
+++ b/tests/test_blue_combine_module.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from blue_combine import blue_combine
+
+
+def test_blue_combine_module_runs():
+    vals = np.array([1.0, 2.0])
+    errs = np.array([0.1, 0.2])
+    combined, sigma, weights = blue_combine(vals, errs)
+    expected = np.average(vals, weights=1 / errs**2)
+    expected_sigma = (1 / np.sum(1 / errs**2)) ** 0.5
+    assert combined == pytest.approx(expected)
+    assert sigma == pytest.approx(expected_sigma)
+    assert len(weights) == 2


### PR DESCRIPTION
## Summary
- export `blue_combine` from the compatibility module
- add a test for importing `blue_combine` from `blue_combine.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851a99edefc832bbfd3289d09fb3ad7