### PR TITLE
Propagate baseline counting uncertainty

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -56,6 +56,7 @@ import hashlib
 import json
 from pathlib import Path
 
+import math
 import numpy as np
 import pandas as pd
 from scipy.stats import norm
@@ -1382,8 +1383,13 @@ def main():
             s = scales.get(iso, 1.0)
             params["E_corrected"] = params[f"E_{iso}"] - s * rate
             err_fit = params.get(f"dE_{iso}", 0.0)
-            err_base = baseline_unc.get(iso, 0.0)
-            params["dE_corrected"] = float(np.hypot(err_fit, s * err_base))
+            sigma_rate = 0.0
+            if baseline_live_time > 0:
+                count = baseline_counts.get(iso, 0.0)
+                eff = cfg["time_fit"].get(f"eff_{iso}", [1.0])[0]
+                if eff > 0:
+                    sigma_rate = math.sqrt(count) / (baseline_live_time * eff)
+            params["dE_corrected"] = float(math.hypot(err_fit, sigma_rate * s))
 
     if baseline_rates:
         baseline_info["rate_Bq"] = baseline_rates


### PR DESCRIPTION
## Summary
- include `math` for scalar operations
- propagate baseline counting error into the corrected decay rate

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851b50febc4832b8e09ee93467b6a17