### PR TITLE
Update baseline tests for new error output

### DIFF
--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -84,6 +84,7 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
     assert summary["baseline"]["scales"]["Po210"] == pytest.approx(1.0)
     assert summary["baseline"]["scales"]["noise"] == pytest.approx(1.0)
     assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(0.8)
+    assert summary["time_fit"]["Po214"]["dE_corrected"] == pytest.approx(0.1414213562373095)
     assert summary["baseline"].get("noise_level") == 5.0
     times = list(captured.get("times", []))
     assert times == [20]
@@ -161,6 +162,7 @@ def test_baseline_scaling_factor(tmp_path, monkeypatch):
     assert summary["baseline"]["scales"]["Po214"] == pytest.approx(0.5)
     assert summary["baseline"]["scales"]["Po218"] == pytest.approx(0.5)
     assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(0.9)
+    assert summary["time_fit"]["Po214"]["dE_corrected"] == pytest.approx(0.07071067811865475)
 
 
 def test_n0_prior_from_baseline(tmp_path, monkeypatch):
@@ -312,5 +314,6 @@ def test_isotopes_to_subtract_control(tmp_path, monkeypatch):
     summary = captured["summary"]
     assert "rate_Bq" not in summary.get("baseline", {})
     assert "E_corrected" not in summary["time_fit"]["Po214"]
+    assert "dE_corrected" not in summary["time_fit"]["Po214"]
     assert summary["baseline"]["scales"]["Po214"] == pytest.approx(1.0)
 


### PR DESCRIPTION
## Summary
- verify dE_corrected entries in baseline subtraction tests
- assert dE_corrected absence when subtraction is disabled

## Testing
- `pytest -q` *(fails: Package 'numpy' is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_6851b51787e8832bb64b2adb3b729f4d