### PR TITLE
Relax expected_peaks schema

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -74,7 +74,7 @@ from calibration import derive_calibration_constants, derive_calibration_constan
 
 from fitting import fit_spectrum, fit_time_series, FitResult
 
-from constants import DEFAULT_NOISE_CUTOFF, PO210
+from constants import DEFAULT_NOISE_CUTOFF, PO210, DEFAULT_ADC_CENTROIDS
 
 from plot_utils import (
     plot_spectrum,
@@ -921,12 +921,9 @@ def main():
 
         # Find approximate ADC centroids for Po‐210, Po‐218, Po‐214
 
-        if "expected_peaks" not in cfg.get("spectral_fit", {}):
-            raise KeyError(
-                "'spectral_fit.expected_peaks' must be provided in the configuration"
-            )
-
-        expected_peaks = cfg["spectral_fit"]["expected_peaks"]
+        expected_peaks = cfg.get("spectral_fit", {}).get("expected_peaks")
+        if expected_peaks is None:
+            expected_peaks = DEFAULT_ADC_CENTROIDS
 
         # `find_adc_bin_peaks` will return a dict: e.g. { "Po210": adc_centroid, … }
         adc_peaks = find_adc_bin_peaks(

--- a/config.json
+++ b/config.json
@@ -71,7 +71,6 @@
         "peak_search_width_adc": 3,
         "use_plot_bins_for_fit": false,
         "unbinned_likelihood": false,
-        "expected_peaks": {"Po210": 1250, "Po218": 1405, "Po214": 1800},
         "mu_bounds": {
             "Po210": null,
             "Po218": [5.9, 6.2],

--- a/constants.py
+++ b/constants.py
@@ -20,6 +20,10 @@ DEFAULT_NOMINAL_ADC = {
     "Po214": 1800,
 }
 
+# Default ADC centroids used when the configuration does not
+# specify ``spectral_fit.expected_peaks``.
+DEFAULT_ADC_CENTROIDS = DEFAULT_NOMINAL_ADC.copy()
+
 from dataclasses import dataclass
 
 
@@ -89,6 +93,7 @@ __all__ = [
     "DEFAULT_NOISE_CUTOFF",
     "CURVE_FIT_MAX_EVALS",
     "DEFAULT_NOMINAL_ADC",
+    "DEFAULT_ADC_CENTROIDS",
     "NuclideConst",
     "PO214",
     "PO218",

--- a/io_utils.py
+++ b/io_utils.py
@@ -53,7 +53,6 @@ CONFIG_SCHEMA = {
         "spectral_fit": {
             "type": "object",
             "properties": {"expected_peaks": {"type": "object"}},
-            "required": ["expected_peaks"],
         },
         "time_fit": {
             "type": "object",

--- a/tests/test_expected_peaks_default.py
+++ b/tests/test_expected_peaks_default.py
@@ -1,0 +1,88 @@
+import sys
+import json
+from pathlib import Path
+
+import pandas as pd
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import analyze
+from constants import DEFAULT_ADC_CENTROIDS
+from io_utils import load_config
+from fitting import FitResult
+
+
+def test_expected_peaks_default(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {
+            "do_spectral_fit": True,
+            "mu_sigma": 0.05,
+            "amp_prior_scale": 1.0,
+            "b0_prior": [0.0, 1.0],
+            "b1_prior": [0.0, 1.0],
+        },
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    # Ensure load_config works without expected_peaks
+    loaded = load_config(cfg_path)
+    assert "expected_peaks" not in loaded.get("spectral_fit", {})
+
+    df = pd.DataFrame({
+        "fUniqueID": [1],
+        "fBits": [0],
+        "timestamp": [0],
+        "adc": [1000],
+        "fchannel": [1],
+    })
+    data_path = tmp_path / "events.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants",
+        lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)},
+    )
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants_auto",
+        lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)},
+    )
+    monkeypatch.setattr(analyze, "fit_spectrum", lambda *a, **k: FitResult({}, np.zeros((0, 0)), 0))
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "apply_burst_filter", lambda df, cfg, mode="rate": (df, 0))
+
+    captured = {}
+
+    def fake_find_adc_bin_peaks(adc_values, expected, **kwargs):
+        captured["expected"] = expected
+        return {k: float(v) for k, v in expected.items()}
+
+    monkeypatch.setattr(analyze, "find_adc_bin_peaks", fake_find_adc_bin_peaks)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+
+    analyze.main()
+
+    assert captured.get("expected") == DEFAULT_ADC_CENTROIDS
+

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -65,8 +65,8 @@ def test_load_config_missing_key(tmp_path):
     p = tmp_path / "cfg.json"
     with open(p, "w") as f:
         json.dump(cfg, f)
-    with pytest.raises(KeyError):
-        load_config(p)
+    cfg_loaded = load_config(p)
+    assert "spectral_fit" in cfg_loaded
 
 
 def test_load_config_missing_section(tmp_path):


### PR DESCRIPTION
## Summary
- make `spectral_fit.expected_peaks` optional in CONFIG_SCHEMA
- use `DEFAULT_ADC_CENTROIDS` when `expected_peaks` missing
- update example configuration
- test that missing key succeeds and default peaks are used

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e86a6150832bafdc44dcaa95aa47