### PR TITLE
Allow column aliases in load_events

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -189,9 +189,9 @@ def load_events(csv_path):
     """
     Read event CSV into a DataFrame with columns:
        ['fUniqueID','fBits','timestamp','adc','fchannel']
-    - Ensures timestamp is int, adc is int.
-    - Sort ascending by timestamp.
-    - Returns DataFrame.
+    Column aliases like ``time`` or ``adc_ch`` are automatically renamed to
+    their canonical form.  Ensures ``timestamp`` and ``adc`` are integers,
+    sorts the result by ``timestamp`` and returns the DataFrame.
     """
     path = Path(csv_path)
     if not path.is_file():
@@ -200,7 +200,18 @@ def load_events(csv_path):
     # Read CSV; assume no header comments, first row is header
     df = pd.read_csv(path)
 
-    # Check required columns
+    # Allow some common alternate column names
+    rename = {
+        "time": "timestamp",
+        "adc_ch": "adc",
+        "adc_channel": "adc",
+        "channel": "fchannel",
+        "unique_id": "fUniqueID",
+        "bits": "fBits",
+    }
+    df = df.rename(columns=rename, errors="ignore")
+
+    # Check required columns after renaming
     required_cols = ["fUniqueID", "fBits", "timestamp", "adc", "fchannel"]
     missing = [c for c in required_cols if c not in df.columns]
     if missing:

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -121,6 +121,41 @@ def test_load_events_drop_bad_rows(tmp_path, caplog):
     assert "3 discarded" in caplog.text
 
 
+def test_load_events_column_aliases(tmp_path):
+    df = pd.DataFrame(
+        {
+            "fUniqueID": [1],
+            "fBits": [0],
+            "time": [1000],
+            "adc_ch": [1250],
+            "fchannel": [1],
+        }
+    )
+    p = tmp_path / "alias.csv"
+    df.to_csv(p, index=False)
+    loaded = load_events(p)
+    assert list(loaded["timestamp"])[0] == 1000
+    assert list(loaded["adc"])[0] == 1250
+    assert "time" not in loaded.columns
+    assert "adc_ch" not in loaded.columns
+
+
+def test_load_events_missing_column(tmp_path):
+    df = pd.DataFrame(
+        {
+            "fUniqueID": [1],
+            "fBits": [0],
+            "timestamp": [1000],
+            # ADC column intentionally missing
+            "fchannel": [1],
+        }
+    )
+    p = tmp_path / "missing.csv"
+    df.to_csv(p, index=False)
+    with pytest.raises(KeyError):
+        load_events(p)
+
+
 def test_write_summary_and_copy_config(tmp_path):
     summary = {"a": 1, "b": 2}
     outdir = tmp_path / "out"


### PR DESCRIPTION
## Summary
- rename common column names in `load_events`
- test alias support and missing columns

## Testing
- `pytest tests/test_io_utils.py::test_load_events_column_aliases -q`
- `pytest tests/test_io_utils.py::test_load_events_missing_column -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851f01d83b4832bbf8dc025eb4482d5