### PR TITLE
Expose deprecated time-bin-mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,8 @@ Example snippet:
 bins to use when the automatic [Freedman–Diaconis rule](https://en.wikipedia.org/wiki/Freedman%E2%80%93Diaconis_rule) fails,
 typically due to zero IQR.  The default is `1`.
 
-The CLI options `--plot-time-binning-mode` and `--plot-time-bin-width` override
+The CLI options `--plot-time-binning-mode` (deprecated alias
+`--time-bin-mode`) and `--plot-time-bin-width` override
 `plot_time_binning_mode` and `plot_time_bin_width_s` in the configuration
 to control the time-series histogram. Passing `--dump-ts-json` writes the
 histogram counts to a `*_ts.json` file alongside the plot.

--- a/analyze.py
+++ b/analyze.py
@@ -289,7 +289,7 @@ def parse_args():
         "--time-bin-mode",
         dest="time_bin_mode",
         choices=["auto", "fd", "fixed"],
-        help=argparse.SUPPRESS,
+        help="DEPRECATED alias for --plot-time-binning-mode",
     )
     p.add_argument(
         "--plot-time-bin-width",


### PR DESCRIPTION
## Summary
- document `--time-bin-mode` instead of hiding the option
- mention the deprecated alias in README

## Testing
- `pytest -q`
- `python analyze.py --help | grep -n -A1 -B1 "DEPRECATED" -n`


------
https://chatgpt.com/codex/tasks/task_e_6851f18997d4832b9c70104d15332ee3