### PR TITLE
Clip negative energy variance

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -760,9 +760,9 @@ def main():
 
     # Apply linear calibration -> new column “energy_MeV” and its uncertainty
     events["energy_MeV"] = events["adc"] * a + c
-    events["denergy_MeV"] = np.sqrt(
-        (events["adc"] * a_sig) ** 2 + c_sig ** 2 + 2 * events["adc"] * cov_ac
-    )
+
+    var_energy = (events["adc"] * a_sig) ** 2 + c_sig ** 2 + 2 * events["adc"] * cov_ac
+    events["denergy_MeV"] = np.sqrt(np.clip(var_energy, 0, None))
 
     # ────────────────────────────────────────────────────────────
     # 4. Baseline run (optional)

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -190,3 +190,20 @@ def test_calibrate_run_quadratic_option():
     ])
 
     assert np.allclose(energies, expected, rtol=1e-3)
+
+
+def test_energy_uncertainty_clipping():
+    """Negative covariance should not produce NaNs in uncertainty."""
+    import pandas as pd
+
+    events = pd.DataFrame({"adc": [1.0]})
+    a_sig = 0.001
+    c_sig = 0.02
+    cov_ac = -0.1
+
+    var_energy = (events["adc"] * a_sig) ** 2 + c_sig ** 2 + 2 * events["adc"] * cov_ac
+    assert var_energy.iloc[0] < 0
+
+    events["denergy_MeV"] = np.sqrt(np.clip(var_energy, 0, None))
+
+    assert np.isfinite(events["denergy_MeV"]).all()


### PR DESCRIPTION
## Summary
- clip negative energy variance before taking sqrt in analysis
- test calibration uncertainty clipping on negative covariance

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851f17389e8832b947fee68fb1533de