### PR TITLE
Use float timestamps when loading event CSVs

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -190,8 +190,8 @@ def load_events(csv_path):
     Read event CSV into a DataFrame with columns:
        ['fUniqueID','fBits','timestamp','adc','fchannel']
     Column aliases like ``time`` or ``adc_ch`` are automatically renamed to
-    their canonical form.  Ensures ``timestamp`` and ``adc`` are integers,
-    sorts the result by ``timestamp`` and returns the DataFrame.
+    their canonical form.  Ensures ``timestamp`` is float seconds and ``adc`` is
+    an integer, sorts the result by ``timestamp`` and returns the DataFrame.
     """
     path = Path(csv_path)
     if not path.is_file():
@@ -217,6 +217,10 @@ def load_events(csv_path):
     if missing:
         raise KeyError(f"Input CSV is missing required columns: {missing}")
 
+    # Convert columns to numeric
+    df["timestamp"] = pd.to_numeric(df["timestamp"], errors="coerce")
+    df["adc"] = pd.to_numeric(df["adc"], errors="coerce")
+
     # Drop rows with non-finite timestamp or adc values
     start_len = len(df)
     mask = np.isfinite(df["timestamp"]) & np.isfinite(df["adc"])
@@ -228,7 +232,7 @@ def load_events(csv_path):
     discarded = start_len - len(df)
 
     # Convert types
-    df["timestamp"] = df["timestamp"].astype(int)
+    df["timestamp"] = df["timestamp"].astype(float)
     df["adc"] = df["adc"].astype(int)
 
     # Sort by timestamp

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -97,7 +97,8 @@ def test_load_events(tmp_path, caplog):
     df.to_csv(p, index=False)
     with caplog.at_level(logging.INFO):
         loaded = load_events(p)
-    assert np.array_equal(loaded["timestamp"].values, np.array([1000, 1005, 1010]))
+    assert loaded["timestamp"].dtype == float
+    assert np.array_equal(loaded["timestamp"].values, np.array([1000.0, 1005.0, 1010.0]))
     assert np.array_equal(loaded["adc"].values, np.array([1200, 1300, 1250]))
     assert "0 discarded" in caplog.text
 
@@ -117,7 +118,8 @@ def test_load_events_drop_bad_rows(tmp_path, caplog):
     with caplog.at_level(logging.INFO):
         loaded = load_events(p)
     # Expect rows with NaN/inf removed and duplicate dropped
-    assert np.array_equal(loaded["timestamp"].values, np.array([1000, 1005, 1020]))
+    assert loaded["timestamp"].dtype == float
+    assert np.array_equal(loaded["timestamp"].values, np.array([1000.0, 1005.0, 1020.0]))
     assert "3 discarded" in caplog.text
 
 
@@ -134,7 +136,8 @@ def test_load_events_column_aliases(tmp_path):
     p = tmp_path / "alias.csv"
     df.to_csv(p, index=False)
     loaded = load_events(p)
-    assert list(loaded["timestamp"])[0] == 1000
+    assert loaded["timestamp"].dtype == float
+    assert list(loaded["timestamp"])[0] == 1000.0
     assert list(loaded["adc"])[0] == 1250
     assert "time" not in loaded.columns
     assert "adc_ch" not in loaded.columns


### PR DESCRIPTION
## Summary
- keep timestamps as floating point seconds in `load_events`
- check for float timestamps in `test_io_utils`

## Testing
- `pytest tests/test_io_utils.py::test_load_events -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851f3d0f4d4832b96b9a8b5864f4e01