### PR TITLE
Include error in spike efficiency cache key

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -157,11 +157,12 @@ def get_spike_efficiency(spike_cfg):
         spike_cfg.get("counts"),
         spike_cfg.get("activity_bq"),
         spike_cfg.get("live_time_s"),
+        spike_cfg.get("error"),
     )
     if key not in _spike_eff_cache:
         from efficiency import calc_spike_efficiency
 
-        _spike_eff_cache[key] = calc_spike_efficiency(*key)
+        _spike_eff_cache[key] = calc_spike_efficiency(key[0], key[1], key[2])
     return _spike_eff_cache[key]
 
 

--- a/tests/test_spike_efficiency_cache.py
+++ b/tests/test_spike_efficiency_cache.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import analyze
+import efficiency
+
+
+def test_spike_efficiency_cache_separate_by_error(monkeypatch):
+    calls = []
+
+    def fake_calc(counts, act, live):
+        calls.append((counts, act, live))
+        return 0.1
+
+    monkeypatch.setattr(efficiency, "calc_spike_efficiency", fake_calc)
+
+    analyze._spike_eff_cache.clear()
+    cfg1 = {"counts": 10, "activity_bq": 5, "live_time_s": 100, "error": 0.1}
+    cfg2 = {"counts": 10, "activity_bq": 5, "live_time_s": 100, "error": 0.2}
+
+    analyze.get_spike_efficiency(cfg1)
+    analyze.get_spike_efficiency(cfg2)
+
+    assert len(calls) == 2
+    assert len(analyze._spike_eff_cache) == 2


### PR DESCRIPTION
## Summary
- extend spike efficiency cache key with the error value
- update spike efficiency caching logic
- add regression test for caching by error value

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851f3c29758832ba08d2d7d8144ecdf