### PR TITLE
Handle empty DF in micro burst filter

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -295,6 +295,8 @@ def apply_burst_filter(df, cfg, mode="rate"):
 
         if micro_win is not None and micro_thr is not None:
             times = out_df["timestamp"].values.astype(float)
+            if len(times) == 0:
+                return out_df, removed_total
             window_end = times + float(micro_win)
             j = np.searchsorted(times, window_end, side="right")
             counts = j - np.arange(len(times))


### PR DESCRIPTION
## Summary
- prevent pandas boolean index failure in `apply_burst_filter`

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852026298ec832b8ebf5209bd50424e