### PR TITLE
Validate sigma in window_prob

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -127,6 +127,9 @@ def window_prob(E, sigma, lo, hi):
     E = np.asarray(E, dtype=float)
     sigma = np.asarray(sigma, dtype=float)
     E, sigma = np.broadcast_arrays(E, sigma)
+
+    if np.any(sigma < 0):
+        raise ValueError("negative sigma in window_prob")
     lo_val = float(lo) if np.isscalar(lo) else float(lo)
     hi_val = float(hi) if np.isscalar(hi) else float(hi)
 

--- a/tests/test_window_prob.py
+++ b/tests/test_window_prob.py
@@ -23,3 +23,9 @@ def test_window_prob_mixed_sigma():
 def test_window_prob_scalar_zero_sigma():
     assert analyze.window_prob(5.0, 0.0, 4.0, 6.0) == pytest.approx(1.0)
     assert analyze.window_prob(7.0, 0.0, 4.0, 6.0) == pytest.approx(0.0)
+
+
+def test_window_prob_negative_sigma_raises():
+    with pytest.raises(ValueError):
+        analyze.window_prob(1.0, -0.1, 0.0, 2.0)
+


### PR DESCRIPTION
## Summary
- raise `ValueError` when `window_prob` receives a negative sigma
- test negative sigma handling

## Testing
- `pip install -q numpy scipy matplotlib pandas iminuit pytest pymc jsonschema python-dateutil`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852026d138c832b8c4a9dc5ad51587b