### PR TITLE
Raise error when _cov_entry missing parameters

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -105,11 +105,11 @@ def _cov_entry(fit: FitResult | dict, p1: str, p2: str) -> float:
         ordered = [
             k for k in fit.params.keys() if k != "fit_valid" and not k.startswith("d")
         ]
-        try:
-            i1 = ordered.index(p1)
-            i2 = ordered.index(p2)
-        except ValueError:
-            return 0.0
+        if p1 not in ordered or p2 not in ordered:
+            missing = p1 if p1 not in ordered else p2
+            raise KeyError(f"Parameter {missing!r} not found in FitResult")
+        i1 = ordered.index(p1)
+        i2 = ordered.index(p2)
         cov = np.asarray(fit.cov, dtype=float)
         if cov.ndim >= 2 and i1 < cov.shape[0] and i2 < cov.shape[1]:
             return float(cov[i1, i2])

--- a/tests/test_cov_entry.py
+++ b/tests/test_cov_entry.py
@@ -33,6 +33,7 @@ def test_cov_entry_missing_or_none():
     params = {"A": 1.0, "B": 2.0}
     cov = np.eye(2)
     fr = FitResult(params, cov, 0)
-    assert analyze._cov_entry(fr, "A", "C") == 0.0
+    with pytest.raises(KeyError):
+        analyze._cov_entry(fr, "A", "C")
     fr_none = FitResult(params, None, 0)
     assert analyze._cov_entry(fr_none, "A", "B") == 0.0


### PR DESCRIPTION
## Summary
- tweak `_cov_entry` to raise a `KeyError` if either parameter is missing
- update tests for the new behavior

## Testing
- `pytest tests/test_cov_entry.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685202723210832b95498ecd8fc34373