### PR TITLE
Add time binning mode conflict detection

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -284,13 +284,13 @@ def parse_args():
     )
     p.add_argument(
         "--plot-time-binning-mode",
-        dest="time_bin_mode",
+        dest="time_bin_mode_new",
         choices=["auto", "fd", "fixed"],
         help="Time-series binning mode. Providing this option overrides `plotting.plot_time_binning_mode` in config.json",
     )
     p.add_argument(
         "--time-bin-mode",
-        dest="time_bin_mode",
+        dest="time_bin_mode_old",
         choices=["auto", "fd", "fixed"],
         help="DEPRECATED alias for --plot-time-binning-mode",
     )
@@ -342,7 +342,24 @@ def parse_args():
             "write a hierarchical fit summary to OUTFILE"
         ),
     )
-    return p.parse_args()
+
+    args = p.parse_args()
+
+    if args.time_bin_mode_new is not None and args.time_bin_mode_old is not None:
+        if args.time_bin_mode_new != args.time_bin_mode_old:
+            p.error(
+                "--plot-time-binning-mode conflicts with deprecated --time-bin-mode"
+            )
+
+    args.time_bin_mode = (
+        args.time_bin_mode_new
+        if args.time_bin_mode_new is not None
+        else args.time_bin_mode_old
+    )
+    del args.time_bin_mode_new
+    del args.time_bin_mode_old
+
+    return args
 
 
 def main():

--- a/tests/test_time_bin_mode_conflict.py
+++ b/tests/test_time_bin_mode_conflict.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+import json
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+
+
+def test_time_bin_mode_conflict(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+
+    args = [
+        "analyze.py",
+        "--config", str(cfg_path),
+        "--input", str(data_path),
+        "--output_dir", str(tmp_path),
+        "--plot-time-binning-mode", "auto",
+        "--time-bin-mode", "fd",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+
+    with pytest.raises(SystemExit):
+        analyze.main()
+


### PR DESCRIPTION
## Summary
- detect conflicting `--time-bin-mode` and `--plot-time-binning-mode` options
- test that passing both with different values errors out

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852027881f4832bbc28c9ff3f779408