### PR TITLE
Improve baseline noise docs

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -863,6 +863,7 @@ def main():
             print(f"WARNING: Baseline noise estimation failed -> {e}")
 
         if noise_level is not None:
+            # Store estimated noise peak amplitude in counts (not ADC units)
             baseline_info["noise_level"] = float(noise_level)
 
         # Record Po-210 and optional noise counts in baseline_counts

--- a/baseline_noise.py
+++ b/baseline_noise.py
@@ -33,7 +33,8 @@ def estimate_baseline_noise(
     Returns
     -------
     noise_level : float
-        Fitted noise level (constant or amplitude of exponential).
+        Estimated amplitude of the noise peak in counts (histogram
+        height). This is a count estimate, not an ADC value.
     params : dict
         Additional fitted parameters.
     mask : ndarray of bool, optional


### PR DESCRIPTION
## Summary
- clarify `estimate_baseline_noise` docstring that the noise level is a count amplitude
- annotate assignment of `baseline_info["noise_level"]` with a note that it is in counts

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685204664a4c832b9818cfc59d25c2f4