### PR TITLE
Remove redundant timestamp conversion

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -549,14 +549,16 @@ def main():
         print("No events found in the input CSV. Exiting.")
         sys.exit(0)
 
-    # Ensure “timestamp” column is float‐seconds since epoch
-    # If user provided ISO‐strings, convert to epoch:
-    if events["timestamp"].dtype == object:
-        events["timestamp"] = (
-            pd.to_datetime(events["timestamp"], utc=True).astype(np.int64) / 1e9
-        )
-
-    events["timestamp"] = events["timestamp"].astype(float)
+    # Ensure “timestamp” handling is centralized in ``load_events()``
+    # Previously this block reconverted the ``timestamp`` column here, but
+    # ``load_events()`` already enforces numeric timestamps.  Removing this
+    # conversion avoids redundant dtype checks.
+    #
+    # if events["timestamp"].dtype == object:
+    #     events["timestamp"] = (
+    #         pd.to_datetime(events["timestamp"], utc=True).astype(np.int64) / 1e9
+    #     )
+    # events["timestamp"] = events["timestamp"].astype(float)
 
     # ───────────────────────────────────────────────
     # 2a. Pedestal / electronic-noise cut (integer ADC)


### PR DESCRIPTION
## Summary
- remove re-conversion of `events['timestamp']` in `analyze.py`
- rely on `load_events()` for timestamp dtype enforcement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852045f4f48832b9e900f04c06e59da