### PR TITLE
Modify spike efficiency cache key

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -159,7 +159,6 @@ def get_spike_efficiency(spike_cfg):
         spike_cfg.get("counts"),
         spike_cfg.get("activity_bq"),
         spike_cfg.get("live_time_s"),
-        spike_cfg.get("error"),
     )
     if key not in _spike_eff_cache:
         from efficiency import calc_spike_efficiency

--- a/tests/test_spike_efficiency_cache.py
+++ b/tests/test_spike_efficiency_cache.py
@@ -7,7 +7,7 @@ import analyze
 import efficiency
 
 
-def test_spike_efficiency_cache_separate_by_error(monkeypatch):
+def test_spike_efficiency_cache_same_for_error(monkeypatch):
     calls = []
 
     def fake_calc(counts, act, live):
@@ -23,5 +23,5 @@ def test_spike_efficiency_cache_separate_by_error(monkeypatch):
     analyze.get_spike_efficiency(cfg1)
     analyze.get_spike_efficiency(cfg2)
 
-    assert len(calls) == 2
-    assert len(analyze._spike_eff_cache) == 2
+    assert len(calls) == 1
+    assert len(analyze._spike_eff_cache) == 1


### PR DESCRIPTION
## Summary
- reduce spike eff cache key to counts, activity and live time
- update spike efficiency cache test to expect only one entry when error varies

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68520459e0a0832bb1b4e2910746738f