### PR TITLE
Fix README key casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--j
   back to this file in Unix seconds.
 - `spectrum.png` – spectrum plot with fitted peaks.
 - `time_series_Po214.png` and `time_series_Po218.png` – decay time-series plots.
-- `time_series_Po210.png` when `window_Po210` is set.
+- `time_series_Po210.png` when `window_po210` is set.
 - Optional `*_ts.json` files containing binned time series when enabled.
 - `efficiency.png` – bar chart of individual efficiencies and the BLUE result.
 - `eff_cov.png` – heatmap of the efficiency covariance matrix.
@@ -77,8 +77,8 @@ The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--j
    `--ambient-concentration` is provided.
 
 The `time_fit` routine still fits only Po‑214 and Po‑218.
-When `window_Po210` is provided the Po‑210 events are extracted and a
-time‑series histogram is produced without a decay fit. The `hl_Po210`
+When `window_po210` is provided the Po‑210 events are extracted and a
+time‑series histogram is produced without a decay fit. The `hl_po210`
 value controls only the model curve drawn in this plot.
 
 The time‐series model multiplies the decay rate by the detection efficiency
@@ -331,7 +331,7 @@ overlaying multiple isotopes so one does not obscure the other.
 when invoking `plot_time_series`.  When set to `true` the analysis does
 not clear the other window, allowing Po‑214 and Po‑218 to be plotted
 together on a single overlay.
-Specifying `window_Po210` (and optional `eff_Po210`) adds a Po‑210
+Specifying `window_po210` (and optional `eff_Po210`) adds a Po‑210
 histogram to the time-series plots. The model curve appears only when
 fit results for Po‑210 are available.
 
@@ -353,12 +353,12 @@ Example snippet:
 ```
 
 `plot_time_series` takes its half-life values from the `time_fit` section.
-When these keys are omitted, `hl_Po214` and `hl_Po218` fall back to their
-physical half-lives (≈164 µs and ≈183 s). `hl_Po210` defaults to its physical
+When these keys are omitted, `hl_po214` and `hl_po218` fall back to their
+physical half-lives (≈164 µs and ≈183 s). `hl_po210` defaults to its physical
 half-life (≈138 days). Specify them to use other values. These custom
 half-lives control the decay model drawn over the time-series histogram.
 The same values are used in the `time_fit` routine itself, so changing
-`hl_Po214` or `hl_Po218` affects both the unbinned fit and the overlay in
+`hl_po214` or `hl_po218` affects both the unbinned fit and the overlay in
 `plot_time_series`. For monitoring that spans multiple days you may set
 them to the radon half-life (~3.8 days) to match the slowly varying
 radon activity.
@@ -377,8 +377,8 @@ discard the first seconds of data before the decay fit.
 ### Fitting Long Time Scales
 
 When the data covers months or more, the short half-lives of Po‑218 and
-Po‑214 no longer matter.  The defaults therefore set `hl_Po214` and
-`hl_Po218` to the radon half-life (≈3.8 days) so the fit tracks the slowly
+Po‑214 no longer matter.  The defaults therefore set `hl_po214` and
+`hl_po218` to the radon half-life (≈3.8 days) so the fit tracks the slowly
 varying radon concentration.  The configuration values are in seconds;
 3.8 days corresponds to roughly `3.8 * 86400 ≈ 3.3e5` seconds.
 
@@ -386,8 +386,8 @@ Example snippet:
 
 ```json
 "time_fit": {
-    "hl_Po214": [328320, 0.0],
-    "hl_Po218": [328320, 0.0],
+    "hl_po214": [328320, 0.0],
+    "hl_po218": [328320, 0.0],
     "sig_N0_Po214": 1.0,
     "sig_N0_Po218": 1.0
 }


### PR DESCRIPTION
## Summary
- update config key casing to match code

## Testing
- `pytest -q` *(fails: 28 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68520657b3e4832b99ad5a86be51da9c