### PR TITLE
Use lowercase time window keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--j
   back to this file in Unix seconds.
 - `spectrum.png` – spectrum plot with fitted peaks.
 - `time_series_Po214.png` and `time_series_Po218.png` – decay time-series plots.
-- `time_series_Po210.png` when `window_Po210` is set.
+- `time_series_Po210.png` when `window_po210` is set.
 - Optional `*_ts.json` files containing binned time series when enabled.
 - `efficiency.png` – bar chart of individual efficiencies and the BLUE result.
 - `eff_cov.png` – heatmap of the efficiency covariance matrix.
@@ -77,7 +77,7 @@ The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--j
    `--ambient-concentration` is provided.
 
 The `time_fit` routine still fits only Po‑214 and Po‑218.
-When `window_Po210` is provided the Po‑210 events are extracted and a
+When `window_po210` is provided the Po‑210 events are extracted and a
 time‑series histogram is produced without a decay fit. The `hl_Po210`
 value controls only the model curve drawn in this plot.
 
@@ -331,7 +331,7 @@ overlaying multiple isotopes so one does not obscure the other.
 when invoking `plot_time_series`.  When set to `true` the analysis does
 not clear the other window, allowing Po‑214 and Po‑218 to be plotted
 together on a single overlay.
-Specifying `window_Po210` (and optional `eff_Po210`) adds a Po‑210
+Specifying `window_po210` (and optional `eff_Po210`) adds a Po‑210
 histogram to the time-series plots. The model curve appears only when
 fit results for Po‑210 are available.
 

--- a/analyze.py
+++ b/analyze.py
@@ -890,7 +890,7 @@ def main():
             baseline_info["noise_level"] = float(noise_level)
 
         # Record Po-210 and optional noise counts in baseline_counts
-        win_p210 = cfg.get("time_fit", {}).get("window_Po210")
+        win_p210 = cfg.get("time_fit", {}).get("window_po210")
         if win_p210 is not None:
             lo_p210, hi_p210 = win_p210
             probs_p210 = window_prob(
@@ -1101,7 +1101,7 @@ def main():
     time_plot_data = {}
     if cfg.get("time_fit", {}).get("do_time_fit", False):
         for iso in ("Po218", "Po214"):
-            win_key = f"window_{iso}"
+            win_key = f"window_{iso.lower()}"
 
             # Missing energy window for this isotope -> skip gracefully
             win_range = cfg.get("time_fit", {}).get(win_key)
@@ -1229,7 +1229,7 @@ def main():
         }
 
     # Also extract Po-210 events for plotting if a window is provided
-    win_p210 = cfg.get("time_fit", {}).get("window_Po210")
+    win_p210 = cfg.get("time_fit", {}).get("window_po210")
     if win_p210 is not None:
         lo, hi = win_p210
         mask210 = (
@@ -1264,7 +1264,7 @@ def main():
 
             # Build a wrapper to re‐run fit_time_series with modified priors
             def fit_wrapper(priors_mod):
-                win_range = cfg.get("time_fit", {}).get(f"window_{iso}")
+                win_range = cfg.get("time_fit", {}).get(f"window_{iso.lower()}")
                 if win_range is None:
                     raise ValueError(
                         f"Missing window for {iso} during systematics scan"

--- a/config.json
+++ b/config.json
@@ -79,9 +79,9 @@
     },
     "time_fit": {
         "do_time_fit": true,
-        "window_Po214": [7.4, 7.9],
-        "window_Po218": [5.8, 6.3],
-        "window_Po210": [5.2, 5.4],
+        "window_po214": [7.4, 7.9],
+        "window_po218": [5.8, 6.3],
+        "window_po210": [5.2, 5.4],
         "eff_Po214": [0.40, 0.0],
         "eff_Po218": [0.20, 0.0],
         "eff_Po210": [0.10, 0.0],

--- a/io_utils.py
+++ b/io_utils.py
@@ -31,7 +31,7 @@ def extract_time_series_events(events, cfg):
     ts_cfg = cfg.get("time_fit", {})
     out = {}
     for iso in ("Po214", "Po218", "Po210"):
-        win = ts_cfg.get(f"window_{iso}")
+        win = ts_cfg.get(f"window_{iso.lower()}")
         if win is None:
             continue
         lo, hi = win

--- a/plot_utils.py
+++ b/plot_utils.py
@@ -129,17 +129,17 @@ def plot_time_series(
 
     iso_params = {
         "Po214": {
-            "window": _cfg_get(config, "window_Po214"),
+            "window": _cfg_get(config, "window_po214"),
             "eff": float(_cfg_get(config, "eff_Po214", [1.0])[0]),
             "half_life": po214_hl,
         },
         "Po218": {
-            "window": _cfg_get(config, "window_Po218"),
+            "window": _cfg_get(config, "window_po218"),
             "eff": float(_cfg_get(config, "eff_Po218", [1.0])[0]),
             "half_life": po218_hl,
         },
         "Po210": {
-            "window": _cfg_get(config, "window_Po210"),
+            "window": _cfg_get(config, "window_po210"),
             "eff": float(_cfg_get(config, "eff_Po210", [1.0])[0]),
             "half_life": float(
                 _cfg_get(
@@ -394,7 +394,7 @@ def plot_spectrum(
     # If an explicit Po-210 window is provided, focus the x-axis on that region
     win_p210 = None
     if config is not None:
-        win_p210 = config.get("window_Po210")
+        win_p210 = config.get("window_po210")
     if win_p210 is not None:
         lo, hi = win_p210
         ax_main.set_xlim(lo, hi)

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -20,8 +20,8 @@ def test_plot_time_series_receives_merged_config(tmp_path, monkeypatch):
         },
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [7.5, 8.0],
-            "window_Po218": None,
+            "window_po214": [7.5, 8.0],
+            "window_po218": None,
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
@@ -79,7 +79,7 @@ def test_plot_time_series_receives_merged_config(tmp_path, monkeypatch):
     analyze.main()
 
     assert received["config"]["plot_time_binning_mode"] == "fd"
-    assert received["config"]["window_Po214"] == [7.5, 8.0]
+    assert received["config"]["window_po214"] == [7.5, 8.0]
     assert received["config"]["overlay_isotopes"] is True
 
 
@@ -94,8 +94,8 @@ def test_analysis_start_time_applied(tmp_path, monkeypatch):
         },
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [7.5, 8.0],
-            "window_Po218": None,
+            "window_po214": [7.5, 8.0],
+            "window_po218": None,
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
@@ -161,8 +161,8 @@ def test_job_id_overrides_results_folder(tmp_path, monkeypatch):
         },
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [7.5, 8.0],
-            "window_Po218": None,
+            "window_po214": [7.5, 8.0],
+            "window_po218": None,
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
@@ -227,7 +227,7 @@ def test_efficiency_json_cli(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [7.5, 8.0],
+            "window_po214": [7.5, 8.0],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
@@ -287,7 +287,7 @@ def test_systematics_json_cli(tmp_path, monkeypatch):
         "pipeline": {"log_level": "INFO"},
         "calibration": {},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
-        "time_fit": {"do_time_fit": True, "window_Po214": [7.4,7.9], "hl_Po214": [1.0,0.0], "eff_Po214": [1.0,0.0], "flags": {}},
+        "time_fit": {"do_time_fit": True, "window_po214": [7.4,7.9], "hl_Po214": [1.0,0.0], "eff_Po214": [1.0,0.0], "flags": {}},
         "systematics": {"enable": False},
         "plotting": {"plot_save_formats": ["png"]},
     }
@@ -344,7 +344,7 @@ def test_time_bin_cli(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [7.5, 8.0],
+            "window_po214": [7.5, 8.0],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
@@ -447,9 +447,9 @@ def test_po210_time_series_plot_generated(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [7.5, 8.0],
-            "window_Po218": None,
-            "window_Po210": [5.2, 5.4],
+            "window_po214": [7.5, 8.0],
+            "window_po218": None,
+            "window_po210": [5.2, 5.4],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "eff_Po210": [1.0, 0.0],
@@ -835,7 +835,7 @@ def test_settle_s_cli(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [0.0, 20.0],
+            "window_po214": [0.0, 20.0],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
@@ -947,7 +947,7 @@ def test_analysis_end_time_cli(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [0.0, 20.0],
+            "window_po214": [0.0, 20.0],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
@@ -1006,7 +1006,7 @@ def test_spike_end_time_cli(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [0.0, 20.0],
+            "window_po214": [0.0, 20.0],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
@@ -1065,7 +1065,7 @@ def test_spike_period_cli(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [0.0, 20.0],
+            "window_po214": [0.0, 20.0],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
@@ -1771,7 +1771,7 @@ def test_spike_periods_null_config(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [0.0, 20.0],
+            "window_po214": [0.0, 20.0],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
@@ -1828,8 +1828,8 @@ def test_hl_po214_cli_overrides(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [0.0, 20.0],
-            "window_Po218": [0.0, 20.0],
+            "window_po214": [0.0, 20.0],
+            "window_po218": [0.0, 20.0],
             "hl_Po214": [1.0, 0.0],
             "hl_Po218": [2.0, 0.0],
             "eff_Po214": [1.0, 0.0],
@@ -1889,7 +1889,7 @@ def test_hl_po210_default_used(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": False,
-            "window_Po210": [5.2, 5.4],
+            "window_po210": [5.2, 5.4],
             "flags": {},
         },
         "systematics": {"enable": False},

--- a/tests/test_analyze_noise_cutoff.py
+++ b/tests/test_analyze_noise_cutoff.py
@@ -16,7 +16,7 @@ def test_analyze_noise_cutoff(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [0, 200],
+            "window_po214": [0, 200],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},

--- a/tests/test_analyze_systematics.py
+++ b/tests/test_analyze_systematics.py
@@ -16,7 +16,7 @@ def test_analyze_systematics_runs(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [0, 10],
+            "window_po214": [0, 10],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -18,7 +18,7 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [7, 9],
+            "window_po214": [7, 9],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
@@ -101,7 +101,7 @@ def test_baseline_scaling_factor(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [7, 9],
+            "window_po214": [7, 9],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
@@ -174,7 +174,7 @@ def test_n0_prior_from_baseline(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [7, 9],
+            "window_po214": [7, 9],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
@@ -258,7 +258,7 @@ def test_isotopes_to_subtract_control(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [7, 9],
+            "window_po214": [7, 9],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
@@ -331,9 +331,9 @@ def test_baseline_scaling_multiple_isotopes(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [7, 9],
-            "window_Po218": [5.8, 6.3],
-            "window_Po210": [5.2, 5.4],
+            "window_po214": [7, 9],
+            "window_po218": [5.8, 6.3],
+            "window_po210": [5.2, 5.4],
             "hl_Po214": [1.0, 0.0],
             "hl_Po218": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
@@ -450,7 +450,7 @@ def test_noise_level_none_not_recorded(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [7, 9],
+            "window_po214": [7, 9],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},

--- a/tests/test_baseline_range_cli.py
+++ b/tests/test_baseline_range_cli.py
@@ -18,7 +18,7 @@ def test_baseline_range_cli_overrides_config(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [7, 9],
+            "window_po214": [7, 9],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},

--- a/tests/test_cli_baseline_range.py
+++ b/tests/test_cli_baseline_range.py
@@ -18,7 +18,7 @@ def test_cli_baseline_range_overrides_config(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [0, 20],
+            "window_po214": [0, 20],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},

--- a/tests/test_cli_baseline_range_iso.py
+++ b/tests/test_cli_baseline_range_iso.py
@@ -18,7 +18,7 @@ def test_cli_baseline_range_iso_strings(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [0, 20],
+            "window_po214": [0, 20],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},

--- a/tests/test_cli_baseline_range_override2.py
+++ b/tests/test_cli_baseline_range_override2.py
@@ -18,7 +18,7 @@ def test_cli_baseline_range_overrides_config_again(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [0, 20],
+            "window_po214": [0, 20],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -46,12 +46,12 @@ def test_fit_time_series_time_window_config():
     # Config window covering most events
     cfg = {
         "time_fit": {
-            "window_Po214": [7.6, 7.9],
+            "window_po214": [7.6, 7.9],
             "hl_Po214": [1.0],
             "eff_Po214": [1.0],
         }
     }
-    w = cfg["time_fit"]["window_Po214"]
+    w = cfg["time_fit"]["window_po214"]
     mask = (energies >= w[0]) & (energies <= w[1])
     times_dict = {"Po214": times[mask]}
     cfg_full = {
@@ -65,12 +65,12 @@ def test_fit_time_series_time_window_config():
     # Narrower window -> fewer events
     cfg_narrow = {
         "time_fit": {
-            "window_Po214": [7.7, 7.8],
+            "window_po214": [7.7, 7.8],
             "hl_Po214": [1.0],
             "eff_Po214": [1.0],
         }
     }
-    w2 = cfg_narrow["time_fit"]["window_Po214"]
+    w2 = cfg_narrow["time_fit"]["window_po214"]
     mask2 = (energies >= w2[0]) & (energies <= w2[1])
     times_dict2 = {"Po214": times[mask2]}
     cfg_n = {

--- a/tests/test_noise_cut.py
+++ b/tests/test_noise_cut.py
@@ -15,7 +15,7 @@ def test_noise_cutoff_cli_overrides(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [0, 20],
+            "window_po214": [0, 20],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},

--- a/tests/test_noise_cutoff.py
+++ b/tests/test_noise_cutoff.py
@@ -18,7 +18,7 @@ def test_noise_cutoff_filters_events(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [0, 20],
+            "window_po214": [0, 20],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
@@ -86,7 +86,7 @@ def test_invalid_noise_cutoff_skips_cut(tmp_path, monkeypatch, caplog):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [0, 20],
+            "window_po214": [0, 20],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -10,9 +10,9 @@ from plot_utils import plot_time_series, plot_spectrum, extract_time_series
 
 def basic_config():
     return {
-        "window_Po214": [7.5, 8.0],
+        "window_po214": [7.5, 8.0],
         "eff_Po214": [1.0],
-        "window_Po218": None,
+        "window_po218": None,
         "time_bin_mode": "fixed",
         "time_bin_s": 1.0,
         "dump_time_series_json": False,
@@ -93,7 +93,7 @@ def test_plot_spectrum_save_formats(tmp_path):
 
 def test_plot_spectrum_po210_xlim(tmp_path):
     energies = np.linspace(0, 10, 100)
-    cfg = {"window_Po210": [5.2, 5.4]}
+    cfg = {"window_po210": [5.2, 5.4]}
     ax = plot_spectrum(energies, config=cfg, out_png=str(tmp_path / "spec2.png"))
     assert ax.get_xlim() == (5.2, 5.4)
 
@@ -137,7 +137,7 @@ def test_plot_time_series_custom_half_life_po218(tmp_path, monkeypatch):
     energies = np.array([5.9, 6.0, 5.8])
     cfg = basic_config()
     cfg.update({
-        "window_Po218": [5.8, 6.3],
+        "window_po218": [5.8, 6.3],
         "eff_Po218": [1.0],
         "hl_Po218": [4.0],
     })
@@ -173,7 +173,7 @@ def test_plot_time_series_time_fit_half_lives(tmp_path, monkeypatch):
     energies = np.array([7.6, 5.9, 7.8, 6.0])
     cfg = basic_config()
     cfg.update({
-        "window_Po218": [5.8, 6.3],
+        "window_po218": [5.8, 6.3],
         "eff_Po218": [1.0],
         "time_fit": {"hl_Po214": [2.0], "hl_Po218": [4.0]},
     })
@@ -227,7 +227,7 @@ def test_plot_time_series_invalid_half_life_po214(tmp_path):
 
 def test_plot_time_series_invalid_half_life_po218(tmp_path):
     cfg = basic_config()
-    cfg.update({"window_Po218": [5.8, 6.3], "eff_Po218": [1.0], "hl_Po218": [-2.0]})
+    cfg.update({"window_po218": [5.8, 6.3], "eff_Po218": [1.0], "hl_Po218": [-2.0]})
     with pytest.raises(ValueError):
         plot_time_series(
             np.array([1000.1]),
@@ -277,7 +277,7 @@ def test_plot_time_series_po210_no_model(tmp_path, monkeypatch):
     times = np.array([1000.1, 1000.2])
     energies = np.array([5.3, 5.25])
     cfg = basic_config()
-    cfg.update({"window_Po210": [5.2, 5.4], "eff_Po210": [1.0]})
+    cfg.update({"window_po210": [5.2, 5.4], "eff_Po210": [1.0]})
 
     labels = []
 
@@ -308,7 +308,7 @@ def test_plot_time_series_po210_default_half_life(tmp_path, monkeypatch):
     times = np.array([1000.1, 1001.1, 1001.9])
     energies = np.array([5.3, 5.3, 5.3])
     cfg = basic_config()
-    cfg.update({"window_Po210": [5.2, 5.4], "eff_Po210": [1.0]})
+    cfg.update({"window_po210": [5.2, 5.4], "eff_Po210": [1.0]})
 
     captured = {}
 

--- a/tests/test_sample_radon.py
+++ b/tests/test_sample_radon.py
@@ -17,7 +17,7 @@ def test_total_radon_uses_sample_volume(tmp_path, monkeypatch):
         "baseline": {"monitor_volume_l": 10.0, "sample_volume_l": 5.0},
         "calibration": {},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
-        "time_fit": {"do_time_fit": True, "window_Po214": [7, 9], "hl_Po214": [1.0, 0.0], "eff_Po214": [1.0, 0.0], "flags": {}},
+        "time_fit": {"do_time_fit": True, "window_po214": [7, 9], "hl_Po214": [1.0, 0.0], "eff_Po214": [1.0, 0.0], "flags": {}},
         "systematics": {"enable": False},
         "plotting": {"plot_save_formats": ["png"]},
     }

--- a/tests/test_systematics.py
+++ b/tests/test_systematics.py
@@ -115,7 +115,7 @@ def test_analyze_systematics_skip_unknown(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [7.0, 8.0],
+            "window_po214": [7.0, 8.0],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},

--- a/tests/test_time_series_po210_plot.py
+++ b/tests/test_time_series_po210_plot.py
@@ -20,7 +20,7 @@ def test_extract_time_series_po210_count():
             "energy_MeV": [5.1, 5.3, 5.25, 5.5],
         }
     )
-    cfg = {"time_fit": {"window_Po210": [5.2, 5.4]}}
+    cfg = {"time_fit": {"window_po210": [5.2, 5.4]}}
 
     ts = extract_time_series_events(df, cfg)
     assert len(ts.get("Po210", [])) == 2
@@ -29,7 +29,7 @@ def test_extract_time_series_po210_count():
 def test_plot_time_series_po210_png(tmp_path, monkeypatch):
     times = np.array([1000.1, 1000.2, 1000.3])
     energies = np.array([5.3, 5.25, 5.3])
-    cfg = {"window_Po210": [5.2, 5.4], "eff_Po210": [1.0]}
+    cfg = {"window_po210": [5.2, 5.4], "eff_Po210": [1.0]}
 
     labels = []
     orig_plot = plot_utils.plt.plot

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -19,7 +19,7 @@ def test_time_window_filters_events(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [7, 9],
+            "window_po214": [7, 9],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
@@ -151,7 +151,7 @@ def test_time_window_filters_events_config(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [7, 9],
+            "window_po214": [7, 9],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
@@ -230,7 +230,7 @@ def test_run_period_filters_events(tmp_path, monkeypatch):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [7, 9],
+            "window_po214": [7, 9],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
@@ -314,7 +314,7 @@ def test_baseline_range_iso_strings(tmp_path, monkeypatch, start, end):
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
             "do_time_fit": True,
-            "window_Po214": [7, 9],
+            "window_po214": [7, 9],
             "hl_Po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},


### PR DESCRIPTION
## Summary
- rename config keys `window_Po214`, `window_Po218`, `window_Po210` to lowercase
- update code to read the lowercase variants
- adjust tests and docs for new key names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685206637f10832b8354c4b708ba99fd