### PR TITLE
Update time-series event window handling

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -31,7 +31,7 @@ def extract_time_series_events(events, cfg):
     ts_cfg = cfg.get("time_fit", {})
     out = {}
     for iso in ("Po214", "Po218", "Po210"):
-        win = ts_cfg.get(f"window_{iso}")
+        win = ts_cfg.get(f"window_{iso.lower()}")
         if win is None:
             continue
         lo, hi = win

--- a/tests/test_time_series_po210_plot.py
+++ b/tests/test_time_series_po210_plot.py
@@ -20,7 +20,7 @@ def test_extract_time_series_po210_count():
             "energy_MeV": [5.1, 5.3, 5.25, 5.5],
         }
     )
-    cfg = {"time_fit": {"window_Po210": [5.2, 5.4]}}
+    cfg = {"time_fit": {"window_po210": [5.2, 5.4]}}
 
     ts = extract_time_series_events(df, cfg)
     assert len(ts.get("Po210", [])) == 2


### PR DESCRIPTION
## Summary
- adjust `extract_time_series_events` to use lowercase window keys
- update Po-210 time-series tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68520661ad90832b838ea7ea6da8cf75