### PR TITLE
Refine spike efficiency cache key

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -158,11 +158,11 @@ _spike_eff_cache = {}
 def get_spike_efficiency(spike_cfg):
     """Return spike efficiency using :func:`calc_spike_efficiency` with caching."""
 
-    key = (
-        spike_cfg.get("counts"),
-        spike_cfg.get("activity_bq"),
-        spike_cfg.get("live_time_s"),
-    )
+    counts = spike_cfg.get("counts")
+    activity = spike_cfg.get("activity_bq")
+    live_time = spike_cfg.get("live_time_s")
+
+    key = (counts, activity, live_time)
     if key not in _spike_eff_cache:
         from efficiency import calc_spike_efficiency
 


### PR DESCRIPTION
## Summary
- cache spike efficiency using counts, activity, and live time only

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852070ec07c832b8393306f0ae1b5c0