### PR TITLE
Fix half-life CLI override handling

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -273,12 +273,12 @@ def parse_args():
     p.add_argument(
         "--hl-po214",
         type=float,
-        help="Half-life to use for Po-214 in seconds. Providing this option overrides `time_fit.hl_Po214` in config.json",
+        help="Half-life to use for Po-214 in seconds. Providing this option overrides `time_fit.hl_po214` in config.json",
     )
     p.add_argument(
         "--hl-po218",
         type=float,
-        help="Half-life to use for Po-218 in seconds. Providing this option overrides `time_fit.hl_Po218` in config.json",
+        help="Half-life to use for Po-218 in seconds. Providing this option overrides `time_fit.hl_po218` in config.json",
     )
     p.add_argument(
         "--debug",
@@ -474,20 +474,20 @@ def main():
     if args.hl_po214 is not None:
         tf = cfg.setdefault("time_fit", {})
         sig = 0.0
-        current = tf.get("hl_Po214")
+        current = tf.get("hl_po214")
         if isinstance(current, list) and len(current) > 1:
             sig = current[1]
-        _log_override("time_fit", "hl_Po214", [float(args.hl_po214), sig])
-        tf["hl_Po214"] = [float(args.hl_po214), sig]
+        _log_override("time_fit", "hl_po214", [float(args.hl_po214), sig])
+        tf["hl_po214"] = [float(args.hl_po214), sig]
 
     if args.hl_po218 is not None:
         tf = cfg.setdefault("time_fit", {})
         sig = 0.0
-        current = tf.get("hl_Po218")
+        current = tf.get("hl_po218")
         if isinstance(current, list) and len(current) > 1:
             sig = current[1]
-        _log_override("time_fit", "hl_Po218", [float(args.hl_po218), sig])
-        tf["hl_Po218"] = [float(args.hl_po218), sig]
+        _log_override("time_fit", "hl_po218", [float(args.hl_po218), sig])
+        tf["hl_po218"] = [float(args.hl_po218), sig]
 
 
     if args.time_bin_mode:
@@ -1120,9 +1120,12 @@ def main():
         priors_time["eff"] = tuple(eff_val)
 
         # Half-life prior (user must supply [T₁/₂, σ(T₁/₂)] in seconds)
-        hl_key = f"hl_{iso}"
+        hl_key = f"hl_{iso.lower()}"
         if hl_key in cfg["time_fit"]:
             T12, T12sig = cfg["time_fit"][hl_key]
+            priors_time["tau"] = (T12 / np.log(2), T12sig / np.log(2))
+        elif f"hl_{iso}" in cfg["time_fit"]:
+            T12, T12sig = cfg["time_fit"][f"hl_{iso}"]
             priors_time["tau"] = (T12 / np.log(2), T12sig / np.log(2))
 
         # Background‐rate prior
@@ -1172,7 +1175,7 @@ def main():
         fit_cfg = {
             "isotopes": {
                 iso: {
-                    "half_life_s": cfg["time_fit"][f"hl_{iso}"][0],
+                    "half_life_s": cfg["time_fit"].get(f"hl_{iso.lower()}", cfg["time_fit"].get(f"hl_{iso}", [np.nan]))[0],
                     "efficiency": cfg["time_fit"][f"eff_{iso}"][0],
                 }
             },
@@ -1272,7 +1275,7 @@ def main():
                 cfg_fit = {
                     "isotopes": {
                         iso: {
-                            "half_life_s": cfg["time_fit"][f"hl_{iso}"][0],
+                            "half_life_s": cfg["time_fit"].get(f"hl_{iso.lower()}", cfg["time_fit"].get(f"hl_{iso}", [np.nan]))[0],
                             "efficiency": priors_mod["eff"][0],
                         }
                     },
@@ -1499,7 +1502,7 @@ def main():
             dN0 = fit.get("dN0_Po214", 0.0)
             default_const = cfg.get("nuclide_constants", {})
             default_hl = default_const.get("Po210", PO210).half_life_s
-            hl = cfg.get("time_fit", {}).get("hl_Po214", [default_hl])[0]
+            hl = cfg.get("time_fit", {}).get("hl_po214", cfg.get("time_fit", {}).get("hl_Po214", [default_hl]))[0]
             cov = _cov_entry(fit_result, "E_Po214", "N0_Po214")
             delta214, err_delta214 = radon_delta(
                 t_start_rel,
@@ -1522,7 +1525,7 @@ def main():
             dN0 = fit.get("dN0_Po218", 0.0)
             default_const = cfg.get("nuclide_constants", {})
             default_hl = default_const.get("Po210", PO210).half_life_s
-            hl = cfg.get("time_fit", {}).get("hl_Po218", [default_hl])[0]
+            hl = cfg.get("time_fit", {}).get("hl_po218", cfg.get("time_fit", {}).get("hl_Po218", [default_hl]))[0]
             cov = _cov_entry(fit_result, "E_Po218", "N0_Po218")
             delta218, err_delta218 = radon_delta(
                 t_start_rel,
@@ -1698,7 +1701,7 @@ def main():
             dN0 = fit.get("dN0_Po214", 0.0)
             default_const = cfg.get("nuclide_constants", {})
             default_hl = default_const.get("Po210", PO210).half_life_s
-            hl = cfg.get("time_fit", {}).get("hl_Po214", [default_hl])[0]
+            hl = cfg.get("time_fit", {}).get("hl_po214", cfg.get("time_fit", {}).get("hl_Po214", [default_hl]))[0]
             cov = _cov_entry(fit_result, "E_Po214", "N0_Po214")
             A214, dA214 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl, cov)
             plot_radon_activity(
@@ -1719,7 +1722,7 @@ def main():
             dN0 = fit.get("dN0_Po218", 0.0)
             default_const = cfg.get("nuclide_constants", {})
             default_hl = default_const.get("Po210", PO210).half_life_s
-            hl = cfg.get("time_fit", {}).get("hl_Po218", [default_hl])[0]
+            hl = cfg.get("time_fit", {}).get("hl_po218", cfg.get("time_fit", {}).get("hl_Po218", [default_hl]))[0]
             cov = _cov_entry(fit_result, "E_Po218", "N0_Po218")
             A218, dA218 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl, cov)
 
@@ -1770,7 +1773,9 @@ def main():
                 dN0214 = fit.get("dN0_Po214", 0.0)
                 default_const = cfg.get("nuclide_constants", {})
                 default_hl = default_const.get("Po210", PO210).half_life_s
-                hl214 = cfg.get("time_fit", {}).get("hl_Po214", [default_hl])[0]
+                hl214 = cfg.get("time_fit", {}).get(
+                    "hl_po214", cfg.get("time_fit", {}).get("hl_Po214", [default_hl])
+                )[0]
                 cov214 = _cov_entry(fit_result, "E_Po214", "N0_Po214")
                 A214_tr, _ = radon_activity_curve(
                     rel_trend, E214, dE214, N0214, dN0214, hl214, cov214
@@ -1785,7 +1790,9 @@ def main():
                 dN0218 = fit.get("dN0_Po218", 0.0)
                 default_const = cfg.get("nuclide_constants", {})
                 default_hl = default_const.get("Po210", PO210).half_life_s
-                hl218 = cfg.get("time_fit", {}).get("hl_Po218", [default_hl])[0]
+                hl218 = cfg.get("time_fit", {}).get(
+                    "hl_po218", cfg.get("time_fit", {}).get("hl_Po218", [default_hl])
+                )[0]
                 cov218 = _cov_entry(fit_result, "E_Po218", "N0_Po218")
                 A218_tr, _ = radon_activity_curve(
                     rel_trend, E218, dE218, N0218, dN0218, hl218, cov218


### PR DESCRIPTION
## Summary
- use `hl_po214` and `hl_po218` keys when overriding half-lives
- support old `hl_Po214` and `hl_Po218` keys for backward compatibility
- update help messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685206700b00832b92e7d173fc4f2276