### PR TITLE
Refactor Po window/half-life keys

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -273,12 +273,12 @@ def parse_args():
     p.add_argument(
         "--hl-po214",
         type=float,
-        help="Half-life to use for Po-214 in seconds. Providing this option overrides `time_fit.hl_Po214` in config.json",
+        help="Half-life to use for Po-214 in seconds. Providing this option overrides `time_fit.hl_po214` in config.json",
     )
     p.add_argument(
         "--hl-po218",
         type=float,
-        help="Half-life to use for Po-218 in seconds. Providing this option overrides `time_fit.hl_Po218` in config.json",
+        help="Half-life to use for Po-218 in seconds. Providing this option overrides `time_fit.hl_po218` in config.json",
     )
     p.add_argument(
         "--debug",
@@ -474,20 +474,20 @@ def main():
     if args.hl_po214 is not None:
         tf = cfg.setdefault("time_fit", {})
         sig = 0.0
-        current = tf.get("hl_Po214")
+        current = tf.get("hl_po214")
         if isinstance(current, list) and len(current) > 1:
             sig = current[1]
-        _log_override("time_fit", "hl_Po214", [float(args.hl_po214), sig])
-        tf["hl_Po214"] = [float(args.hl_po214), sig]
+        _log_override("time_fit", "hl_po214", [float(args.hl_po214), sig])
+        tf["hl_po214"] = [float(args.hl_po214), sig]
 
     if args.hl_po218 is not None:
         tf = cfg.setdefault("time_fit", {})
         sig = 0.0
-        current = tf.get("hl_Po218")
+        current = tf.get("hl_po218")
         if isinstance(current, list) and len(current) > 1:
             sig = current[1]
-        _log_override("time_fit", "hl_Po218", [float(args.hl_po218), sig])
-        tf["hl_Po218"] = [float(args.hl_po218), sig]
+        _log_override("time_fit", "hl_po218", [float(args.hl_po218), sig])
+        tf["hl_po218"] = [float(args.hl_po218), sig]
 
 
     if args.time_bin_mode:
@@ -890,7 +890,7 @@ def main():
             baseline_info["noise_level"] = float(noise_level)
 
         # Record Po-210 and optional noise counts in baseline_counts
-        win_p210 = cfg.get("time_fit", {}).get("window_Po210")
+        win_p210 = cfg.get("time_fit", {}).get("window_po210")
         if win_p210 is not None:
             lo_p210, hi_p210 = win_p210
             probs_p210 = window_prob(
@@ -1101,7 +1101,7 @@ def main():
     time_plot_data = {}
     if cfg.get("time_fit", {}).get("do_time_fit", False):
         for iso in ("Po218", "Po214"):
-            win_key = f"window_{iso}"
+            win_key = f"window_{iso.lower()}"
 
             # Missing energy window for this isotope -> skip gracefully
             win_range = cfg.get("time_fit", {}).get(win_key)
@@ -1130,7 +1130,7 @@ def main():
         priors_time["eff"] = tuple(eff_val)
 
         # Half-life prior (user must supply [T₁/₂, σ(T₁/₂)] in seconds)
-        hl_key = f"hl_{iso}"
+        hl_key = f"hl_{iso.lower()}"
         if hl_key in cfg["time_fit"]:
             T12, T12sig = cfg["time_fit"][hl_key]
             priors_time["tau"] = (T12 / np.log(2), T12sig / np.log(2))
@@ -1182,7 +1182,7 @@ def main():
         fit_cfg = {
             "isotopes": {
                 iso: {
-                    "half_life_s": cfg["time_fit"][f"hl_{iso}"][0],
+                    "half_life_s": cfg["time_fit"][f"hl_{iso.lower()}"][0],
                     "efficiency": cfg["time_fit"][f"eff_{iso}"][0],
                 }
             },
@@ -1229,7 +1229,7 @@ def main():
         }
 
     # Also extract Po-210 events for plotting if a window is provided
-    win_p210 = cfg.get("time_fit", {}).get("window_Po210")
+    win_p210 = cfg.get("time_fit", {}).get("window_po210")
     if win_p210 is not None:
         lo, hi = win_p210
         mask210 = (
@@ -1264,7 +1264,7 @@ def main():
 
             # Build a wrapper to re‐run fit_time_series with modified priors
             def fit_wrapper(priors_mod):
-                win_range = cfg.get("time_fit", {}).get(f"window_{iso}")
+                win_range = cfg.get("time_fit", {}).get(f"window_{iso.lower()}")
                 if win_range is None:
                     raise ValueError(
                         f"Missing window for {iso} during systematics scan"
@@ -1282,7 +1282,7 @@ def main():
                 cfg_fit = {
                     "isotopes": {
                         iso: {
-                            "half_life_s": cfg["time_fit"][f"hl_{iso}"][0],
+                            "half_life_s": cfg["time_fit"][f"hl_{iso.lower()}"][0],
                             "efficiency": priors_mod["eff"][0],
                         }
                     },
@@ -1509,7 +1509,7 @@ def main():
             dN0 = fit.get("dN0_Po214", 0.0)
             default_const = cfg.get("nuclide_constants", {})
             default_hl = default_const.get("Po210", PO210).half_life_s
-            hl = cfg.get("time_fit", {}).get("hl_Po214", [default_hl])[0]
+            hl = cfg.get("time_fit", {}).get("hl_po214", [default_hl])[0]
             cov = _cov_entry(fit_result, "E_Po214", "N0_Po214")
             delta214, err_delta214 = radon_delta(
                 t_start_rel,
@@ -1532,7 +1532,7 @@ def main():
             dN0 = fit.get("dN0_Po218", 0.0)
             default_const = cfg.get("nuclide_constants", {})
             default_hl = default_const.get("Po210", PO210).half_life_s
-            hl = cfg.get("time_fit", {}).get("hl_Po218", [default_hl])[0]
+            hl = cfg.get("time_fit", {}).get("hl_po218", [default_hl])[0]
             cov = _cov_entry(fit_result, "E_Po218", "N0_Po218")
             delta218, err_delta218 = radon_delta(
                 t_start_rel,
@@ -1645,7 +1645,7 @@ def main():
             if not overlay:
                 for other_iso in ("Po214", "Po218", "Po210"):
                     if other_iso != iso:
-                        plot_cfg[f"window_{other_iso}"] = None
+                        plot_cfg[f"window_{other_iso.lower()}"] = None
                 ts_times = pdata["events_times"]
                 ts_energy = pdata["events_energy"]
                 fit_obj = time_fit_results.get(iso)
@@ -1708,7 +1708,7 @@ def main():
             dN0 = fit.get("dN0_Po214", 0.0)
             default_const = cfg.get("nuclide_constants", {})
             default_hl = default_const.get("Po210", PO210).half_life_s
-            hl = cfg.get("time_fit", {}).get("hl_Po214", [default_hl])[0]
+            hl = cfg.get("time_fit", {}).get("hl_po214", [default_hl])[0]
             cov = _cov_entry(fit_result, "E_Po214", "N0_Po214")
             A214, dA214 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl, cov)
             plot_radon_activity(
@@ -1729,7 +1729,7 @@ def main():
             dN0 = fit.get("dN0_Po218", 0.0)
             default_const = cfg.get("nuclide_constants", {})
             default_hl = default_const.get("Po210", PO210).half_life_s
-            hl = cfg.get("time_fit", {}).get("hl_Po218", [default_hl])[0]
+            hl = cfg.get("time_fit", {}).get("hl_po218", [default_hl])[0]
             cov = _cov_entry(fit_result, "E_Po218", "N0_Po218")
             A218, dA218 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl, cov)
 
@@ -1780,7 +1780,7 @@ def main():
                 dN0214 = fit.get("dN0_Po214", 0.0)
                 default_const = cfg.get("nuclide_constants", {})
                 default_hl = default_const.get("Po210", PO210).half_life_s
-                hl214 = cfg.get("time_fit", {}).get("hl_Po214", [default_hl])[0]
+                hl214 = cfg.get("time_fit", {}).get("hl_po214", [default_hl])[0]
                 cov214 = _cov_entry(fit_result, "E_Po214", "N0_Po214")
                 A214_tr, _ = radon_activity_curve(
                     rel_trend, E214, dE214, N0214, dN0214, hl214, cov214
@@ -1795,7 +1795,7 @@ def main():
                 dN0218 = fit.get("dN0_Po218", 0.0)
                 default_const = cfg.get("nuclide_constants", {})
                 default_hl = default_const.get("Po210", PO210).half_life_s
-                hl218 = cfg.get("time_fit", {}).get("hl_Po218", [default_hl])[0]
+                hl218 = cfg.get("time_fit", {}).get("hl_po218", [default_hl])[0]
                 cov218 = _cov_entry(fit_result, "E_Po218", "N0_Po218")
                 A218_tr, _ = radon_activity_curve(
                     rel_trend, E218, dE218, N0218, dN0218, hl218, cov218


### PR DESCRIPTION
## Summary
- use lowercase Po keys in analyze.py
- dynamically lowercase isotope names for key lookup

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: UnboundLocalError, SystemExit)*

------
https://chatgpt.com/codex/tasks/task_e_6852066ea968832bb59c429b0059068b