### PR TITLE
Fix Po-210 key names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--j
 
 The `time_fit` routine still fits only Po‑214 and Po‑218.
 When `window_po210` is provided the Po‑210 events are extracted and a
-time‑series histogram is produced without a decay fit. The `hl_Po210`
+time‑series histogram is produced without a decay fit. The `hl_po210`
 value controls only the model curve drawn in this plot.
 
 The time‐series model multiplies the decay rate by the detection efficiency
@@ -354,7 +354,7 @@ Example snippet:
 
 `plot_time_series` takes its half-life values from the `time_fit` section.
 When these keys are omitted, `hl_po214` and `hl_po218` fall back to their
-physical half-lives (≈164 µs and ≈183 s). `hl_Po210` defaults to its physical
+physical half-lives (≈164 µs and ≈183 s). `hl_po210` defaults to its physical
 half-life (≈138 days). Specify them to use other values. These custom
 half-lives control the decay model drawn over the time-series histogram.
 The same values are used in the `time_fit` routine itself, so changing


### PR DESCRIPTION
## Summary
- rename `hl_Po210` references to `hl_po210`

## Testing
- `pytest -q` *(fails: Package 'numpy' is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68520ccec22c832bb02a4b9ba7bebcb7