### PR TITLE
Fix half-life option help and errors

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -272,12 +272,18 @@ def parse_args():
     p.add_argument(
         "--hl-po214",
         type=float,
-        help="Half-life to use for Po-214 in seconds. Providing this option overrides `time_fit.hl_po214` in config.json",
+        help=(
+            "Half-life to use for Po-214 in seconds. "
+            "Providing this option overrides `time_fit.hl_po214` in config.json"
+        ),
     )
     p.add_argument(
         "--hl-po218",
         type=float,
-        help="Half-life to use for Po-218 in seconds. Providing this option overrides `time_fit.hl_po218` in config.json",
+        help=(
+            "Half-life to use for Po-218 in seconds. "
+            "Providing this option overrides `time_fit.hl_po218` in config.json"
+        ),
     )
     p.add_argument(
         "--debug",

--- a/plot_utils.py
+++ b/plot_utils.py
@@ -123,9 +123,9 @@ def plot_time_series(
     )
 
     if po214_hl <= 0:
-        raise ValueError("hl_Po214 must be positive")
+        raise ValueError("hl_po214 must be positive")
     if po218_hl <= 0:
-        raise ValueError("hl_Po218 must be positive")
+        raise ValueError("hl_po218 must be positive")
 
     iso_params = {
         "Po214": {


### PR DESCRIPTION
## Summary
- tweak error messages for half-life checks in `plot_utils.py`
- clarify help messages for `--hl-po214` and `--hl-po218`

## Testing
- `scripts/setup_tests.sh`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_68520e536d3c832b9b5488c83ff59f64