### PR TITLE
Update config key lookups to lowercase

### DIFF
--- a/plot_utils.py
+++ b/plot_utils.py
@@ -114,12 +114,24 @@ def plot_time_series(
     po214_hl = (
         float(hl_Po214)
         if hl_Po214 is not None
-        else float(_cfg_get(config, "hl_Po214", [default214])[0])
+        else float(
+            _cfg_get(
+                config,
+                "hl_po214",
+                _cfg_get(config, "hl_Po214", [default214]),
+            )[0]
+        )
     )
     po218_hl = (
         float(hl_Po218)
         if hl_Po218 is not None
-        else float(_cfg_get(config, "hl_Po218", [default218])[0])
+        else float(
+            _cfg_get(
+                config,
+                "hl_po218",
+                _cfg_get(config, "hl_Po218", [default218]),
+            )[0]
+        )
     )
 
     if po214_hl <= 0:
@@ -129,23 +141,27 @@ def plot_time_series(
 
     iso_params = {
         "Po214": {
-            "window": _cfg_get(config, "window_Po214"),
+            "window": _cfg_get(config, "window_po214", _cfg_get(config, "window_Po214")),
             "eff": float(_cfg_get(config, "eff_Po214", [1.0])[0]),
             "half_life": po214_hl,
         },
         "Po218": {
-            "window": _cfg_get(config, "window_Po218"),
+            "window": _cfg_get(config, "window_po218", _cfg_get(config, "window_Po218")),
             "eff": float(_cfg_get(config, "eff_Po218", [1.0])[0]),
             "half_life": po218_hl,
         },
         "Po210": {
-            "window": _cfg_get(config, "window_Po210"),
+            "window": _cfg_get(config, "window_po210", _cfg_get(config, "window_Po210")),
             "eff": float(_cfg_get(config, "eff_Po210", [1.0])[0]),
             "half_life": float(
                 _cfg_get(
                     config,
-                    "hl_Po210",
-                    [default_const.get("Po210", PO210).half_life_s],
+                    "hl_po210",
+                    _cfg_get(
+                        config,
+                        "hl_Po210",
+                        [default_const.get("Po210", PO210).half_life_s],
+                    ),
                 )[0]
             ),
         },
@@ -394,7 +410,7 @@ def plot_spectrum(
     # If an explicit Po-210 window is provided, focus the x-axis on that region
     win_p210 = None
     if config is not None:
-        win_p210 = config.get("window_Po210")
+        win_p210 = config.get("window_po210", config.get("window_Po210"))
     if win_p210 is not None:
         lo, hi = win_p210
         ax_main.set_xlim(lo, hi)


### PR DESCRIPTION
## Summary
- default to lowercase `hl_po214`/`hl_po218`/`hl_po210` lookup keys
- default to lowercase `window_po214`/`window_po218`/`window_po210` lookup keys
- maintain backward compatibility with old mixed-case keys

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685210c6efec832ba838304b803c48bb