### PR TITLE
Clarify time-series window keys

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -20,7 +20,11 @@ def extract_time_series_events(events, cfg):
     events : pandas.DataFrame
         Event data with ``timestamp`` and ``energy_MeV`` columns.
     cfg : dict
-        Configuration containing ``time_fit`` settings.
+        Configuration containing ``time_fit`` settings. The
+        window definitions should use lowercase keys
+        (``window_po214`` etc.). Mixed-case keys such as
+        ``window_Po214`` are still recognized for backward
+        compatibility.
 
     Returns
     -------
@@ -33,6 +37,7 @@ def extract_time_series_events(events, cfg):
     for iso in ("Po214", "Po218", "Po210"):
         win = ts_cfg.get(f"window_{iso.lower()}")
         if win is None:
+            # mixed-case lookup retained for backward compatibility
             win = ts_cfg.get(f"window_{iso}")
         if win is None:
             continue


### PR DESCRIPTION
## Summary
- document that time-series windows should use lowercase keys (`window_po214` etc.)
- retain mixed-case fallback for backward compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685210c476a8832bb1a94d7e7803e711