### PR TITLE
Fix warnings during test run

### DIFF
--- a/plot_utils.py
+++ b/plot_utils.py
@@ -290,7 +290,9 @@ def plot_time_series(
     plt.ylabel("Counts / s" if normalise_rate else "Counts per bin")
     title_isos = " & ".join(iso_list)
     plt.title(f"{title_isos} Time Series Fit")
-    plt.legend(fontsize="small")
+    handles, labels = plt.gca().get_legend_handles_labels()
+    if handles:
+        plt.legend(fontsize="small")
 
     ax = plt.gca()
     locator = mdates.AutoDateLocator()


### PR DESCRIPTION
## Summary
- ignore scipy OptimizeWarning in fit_spectrum
- clip covariance diagonal when computing errors
- show legend only when handles exist
- silence pandas DeprecationWarning in apply_burst_filter
- avoid dtype mismatch in burst veto

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68520ee83c2c832b8a3a42fdc460ab13