### PR TITLE
Fix docs to use lowercase half-life keys

### DIFF
--- a/plot_utils.py
+++ b/plot_utils.py
@@ -92,7 +92,7 @@ def plot_time_series(
     t_start, t_end: floats (absolute UNIX times) for the fit window
     config:         JSON dict or nested configuration
     out_png:        output path for the PNG file
-    hl_Po214, hl_Po218: optional half-life values in seconds. If not
+    hl_po214, hl_po218: optional half-life values in seconds. If not
         provided, these are looked up in ``config`` and default to
         ``PO214_HALF_LIFE_S`` and ``PO218_HALF_LIFE_S`` respectively.
     """


### PR DESCRIPTION
## Summary
- correct half-life option names in time-series plotting docstring

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685210c449a4832b9829428174920725