### PR TITLE
Add half-life overrides tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,10 +354,11 @@ Example snippet:
 ```
 
 `plot_time_series` takes its half-life values from the `time_fit` section.
+Specify custom values using the keys `hl_po214`, `hl_po218` and `hl_po210`.
 When these keys are omitted, `hl_po214` and `hl_po218` fall back to their
 physical half-lives (≈164 µs and ≈183 s). `hl_po210` defaults to its physical
-half-life (≈138 days). Specify them to use other values. These custom
-half-lives control the decay model drawn over the time-series histogram.
+half-life (≈138 days). These custom half-lives control the decay model drawn
+over the time-series histogram.
 The same values are used in the `time_fit` routine itself, so changing
 `hl_po214` or `hl_po218` affects both the unbinned fit and the overlay in
 `plot_time_series`. For monitoring that spans multiple days you may set

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -4,7 +4,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from constants import PO210, load_nuclide_overrides, load_half_life_overrides
+from constants import PO210, PO214, PO218, load_nuclide_overrides, load_half_life_overrides
 
 
 def test_po210_default():
@@ -17,4 +17,20 @@ def test_po210_override():
     assert consts["Po210"].half_life_s == 42.0
     hl = load_half_life_overrides(cfg)
     assert hl["Po210"] == 42.0
+
+
+def test_po214_override():
+    cfg = {"time_fit": {"hl_po214": [0.5]}}
+    consts = load_nuclide_overrides(cfg)
+    assert consts["Po214"].half_life_s == 0.5
+    hl = load_half_life_overrides(cfg)
+    assert hl["Po214"] == 0.5
+
+
+def test_po218_override():
+    cfg = {"time_fit": {"hl_po218": [200.0]}}
+    consts = load_nuclide_overrides(cfg)
+    assert consts["Po218"].half_life_s == 200.0
+    hl = load_half_life_overrides(cfg)
+    assert hl["Po218"] == 200.0
 


### PR DESCRIPTION
## Summary
- test that nuclide half-lives can be overridden via `hl_*` keys
- document override keys in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest tests/test_constants.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852121a6c14832baedc50ba550cf424