### PR TITLE
Fix docs for config key case

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -26,7 +26,7 @@ def extract_time_series_events(events, cfg):
         Configuration containing ``time_fit`` settings. The
         window definitions should use lowercase keys
         (``window_po214`` etc.). Mixed-case keys such as
-        ``window_Po214`` are still recognized for backward
+        ``window_po214`` are still recognized for backward
         compatibility.
 
     Returns

--- a/plot_utils.py
+++ b/plot_utils.py
@@ -92,7 +92,7 @@ def plot_time_series(
     t_start, t_end: floats (absolute UNIX times) for the fit window
     config:         JSON dict or nested configuration
     out_png:        output path for the PNG file
-    hl_Po214, hl_Po218: optional half-life values in seconds. If not
+    hl_po214, hl_po218: optional half-life values in seconds. If not
         provided, these are looked up using the configuration keys
         ``hl_po214`` and ``hl_po218`` under ``time_fit`` and default to
         ``PO214_HALF_LIFE_S`` and ``PO218_HALF_LIFE_S`` respectively.


### PR DESCRIPTION
## Summary
- update function docs to use lowercase `hl_po`/`window_po`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685216518ba0832bad7f814843e4a664