### PR TITLE
Enforce lower-case time series windows

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -25,9 +25,7 @@ def extract_time_series_events(events, cfg):
     cfg : dict
         Configuration containing ``time_fit`` settings. The
         window definitions should use lowercase keys
-        (``window_po214`` etc.). Mixed-case keys such as
-        ``window_Po214`` are still recognized for backward
-        compatibility.
+        (``window_po214`` etc.).
 
     Returns
     -------
@@ -40,9 +38,6 @@ def extract_time_series_events(events, cfg):
     for iso in ("Po214", "Po218", "Po210"):
         # Windows are stored using lowercase isotope names
         win = ts_cfg.get(f"window_{iso.lower()}")
-        if win is None:
-            # mixed-case lookup retained for backward compatibility
-            win = ts_cfg.get(f"window_{iso}")
         if win is None:
             continue
         lo, hi = win


### PR DESCRIPTION
## Summary
- remove mixed-case fallback from `extract_time_series_events`
- update docstring accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685216092144832b8713ad58d6173eb6