### PR TITLE
normalize isotope config keys

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -26,7 +26,7 @@ def extract_time_series_events(events, cfg):
         Configuration containing ``time_fit`` settings. The
         window definitions should use lowercase keys
         (``window_po214`` etc.). Mixed-case keys such as
-        ``window_Po214`` are still recognized for backward
+        ``window_po214`` are still recognized for backward
         compatibility.
 
     Returns

--- a/plot_utils.py
+++ b/plot_utils.py
@@ -117,12 +117,12 @@ def plot_time_series(
     po214_hl = (
         float(hl_Po214)
         if hl_Po214 is not None
-        else float(_cfg_get(config, "hl_Po214", [default214])[0])
+        else float(_cfg_get(config, "hl_po214", [default214])[0])
     )
     po218_hl = (
         float(hl_Po218)
         if hl_Po218 is not None
-        else float(_cfg_get(config, "hl_Po218", [default218])[0])
+        else float(_cfg_get(config, "hl_po218", [default218])[0])
     )
 
     if po214_hl <= 0:
@@ -150,7 +150,7 @@ def plot_time_series(
             "half_life": float(
                 _cfg_get(
                     config,
-                    "hl_Po210",
+                    "hl_po210",
                     [default_const.get("Po210", PO210).half_life_s],
                 )[0]
             ),

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -22,7 +22,7 @@ def test_plot_time_series_receives_merged_config(tmp_path, monkeypatch):
             "do_time_fit": True,
             "window_po214": [7.5, 8.0],
             "window_po218": None,
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },
@@ -96,7 +96,7 @@ def test_analysis_start_time_applied(tmp_path, monkeypatch):
             "do_time_fit": True,
             "window_po214": [7.5, 8.0],
             "window_po218": None,
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },
@@ -163,7 +163,7 @@ def test_job_id_overrides_results_folder(tmp_path, monkeypatch):
             "do_time_fit": True,
             "window_po214": [7.5, 8.0],
             "window_po218": None,
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },
@@ -228,7 +228,7 @@ def test_efficiency_json_cli(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [7.5, 8.0],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },
@@ -287,7 +287,7 @@ def test_systematics_json_cli(tmp_path, monkeypatch):
         "pipeline": {"log_level": "INFO"},
         "calibration": {},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
-        "time_fit": {"do_time_fit": True, "window_po214": [7.4,7.9], "hl_Po214": [1.0,0.0], "eff_Po214": [1.0,0.0], "flags": {}},
+        "time_fit": {"do_time_fit": True, "window_po214": [7.4,7.9], "hl_po214": [1.0,0.0], "eff_Po214": [1.0,0.0], "flags": {}},
         "systematics": {"enable": False},
         "plotting": {"plot_save_formats": ["png"]},
     }
@@ -345,7 +345,7 @@ def test_time_bin_cli(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [7.5, 8.0],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },
@@ -450,7 +450,7 @@ def test_po210_time_series_plot_generated(tmp_path, monkeypatch):
             "window_po214": [7.5, 8.0],
             "window_po218": None,
             "window_po210": [5.2, 5.4],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "eff_Po210": [1.0, 0.0],
             "flags": {},
@@ -836,7 +836,7 @@ def test_settle_s_cli(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [0.0, 20.0],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },
@@ -948,7 +948,7 @@ def test_analysis_end_time_cli(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [0.0, 20.0],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },
@@ -1007,7 +1007,7 @@ def test_spike_end_time_cli(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [0.0, 20.0],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },
@@ -1066,7 +1066,7 @@ def test_spike_period_cli(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [0.0, 20.0],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },
@@ -1772,7 +1772,7 @@ def test_spike_periods_null_config(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [0.0, 20.0],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },
@@ -1830,8 +1830,8 @@ def test_hl_po214_cli_overrides(tmp_path, monkeypatch):
             "do_time_fit": True,
             "window_po214": [0.0, 20.0],
             "window_po218": [0.0, 20.0],
-            "hl_Po214": [1.0, 0.0],
-            "hl_Po218": [2.0, 0.0],
+            "hl_po214": [1.0, 0.0],
+            "hl_po218": [2.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "eff_Po218": [1.0, 0.0],
             "flags": {},
@@ -1933,7 +1933,7 @@ def test_hl_po210_default_used(tmp_path, monkeypatch):
 
     analyze.main()
 
-    assert "hl_Po210" not in received["config"]
+    assert "hl_po210" not in received["config"]
 
 
 def test_time_fields_written_back(tmp_path, monkeypatch):

--- a/tests/test_analyze_noise_cutoff.py
+++ b/tests/test_analyze_noise_cutoff.py
@@ -17,7 +17,7 @@ def test_analyze_noise_cutoff(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [0, 200],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },

--- a/tests/test_analyze_systematics.py
+++ b/tests/test_analyze_systematics.py
@@ -17,7 +17,7 @@ def test_analyze_systematics_runs(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [0, 10],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -19,7 +19,7 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [7, 9],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },
@@ -102,7 +102,7 @@ def test_baseline_scaling_factor(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [7, 9],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },
@@ -175,7 +175,7 @@ def test_n0_prior_from_baseline(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [7, 9],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },
@@ -259,7 +259,7 @@ def test_isotopes_to_subtract_control(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [7, 9],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },
@@ -334,8 +334,8 @@ def test_baseline_scaling_multiple_isotopes(tmp_path, monkeypatch):
             "window_po214": [7, 9],
             "window_po218": [5.8, 6.3],
             "window_po210": [5.2, 5.4],
-            "hl_Po214": [1.0, 0.0],
-            "hl_Po218": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
+            "hl_po218": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "eff_Po218": [1.0, 0.0],
             "eff_Po210": [1.0, 0.0],
@@ -451,7 +451,7 @@ def test_noise_level_none_not_recorded(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [7, 9],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },

--- a/tests/test_baseline_range_cli.py
+++ b/tests/test_baseline_range_cli.py
@@ -19,7 +19,7 @@ def test_baseline_range_cli_overrides_config(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [7, 9],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },

--- a/tests/test_cli_baseline_range.py
+++ b/tests/test_cli_baseline_range.py
@@ -19,7 +19,7 @@ def test_cli_baseline_range_overrides_config(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [0, 20],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },

--- a/tests/test_cli_baseline_range_iso.py
+++ b/tests/test_cli_baseline_range_iso.py
@@ -19,7 +19,7 @@ def test_cli_baseline_range_iso_strings(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [0, 20],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },

--- a/tests/test_cli_baseline_range_override2.py
+++ b/tests/test_cli_baseline_range_override2.py
@@ -19,7 +19,7 @@ def test_cli_baseline_range_overrides_config_again(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [0, 20],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -47,7 +47,7 @@ def test_fit_time_series_time_window_config():
     cfg = {
         "time_fit": {
             "window_po214": [7.6, 7.9],
-            "hl_Po214": [1.0],
+            "hl_po214": [1.0],
             "eff_Po214": [1.0],
         }
     }
@@ -55,7 +55,7 @@ def test_fit_time_series_time_window_config():
     mask = (energies >= w[0]) & (energies <= w[1])
     times_dict = {"Po214": times[mask]}
     cfg_full = {
-        "isotopes": {"Po214": {"half_life_s": cfg["time_fit"]["hl_Po214"][0], "efficiency": 1.0}},
+        "isotopes": {"Po214": {"half_life_s": cfg["time_fit"]["hl_po214"][0], "efficiency": 1.0}},
         "fit_background": True,
         "fit_initial": True,
     }
@@ -66,7 +66,7 @@ def test_fit_time_series_time_window_config():
     cfg_narrow = {
         "time_fit": {
             "window_po214": [7.7, 7.8],
-            "hl_Po214": [1.0],
+            "hl_po214": [1.0],
             "eff_Po214": [1.0],
         }
     }
@@ -74,7 +74,7 @@ def test_fit_time_series_time_window_config():
     mask2 = (energies >= w2[0]) & (energies <= w2[1])
     times_dict2 = {"Po214": times[mask2]}
     cfg_n = {
-        "isotopes": {"Po214": {"half_life_s": cfg_narrow["time_fit"]["hl_Po214"][0], "efficiency": 1.0}},
+        "isotopes": {"Po214": {"half_life_s": cfg_narrow["time_fit"]["hl_po214"][0], "efficiency": 1.0}},
         "fit_background": True,
         "fit_initial": True,
     }

--- a/tests/test_noise_cut.py
+++ b/tests/test_noise_cut.py
@@ -16,7 +16,7 @@ def test_noise_cutoff_cli_overrides(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [0, 20],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },

--- a/tests/test_noise_cutoff.py
+++ b/tests/test_noise_cutoff.py
@@ -19,7 +19,7 @@ def test_noise_cutoff_filters_events(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [0, 20],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },
@@ -87,7 +87,7 @@ def test_invalid_noise_cutoff_skips_cut(tmp_path, monkeypatch, caplog):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [0, 20],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -102,7 +102,7 @@ def test_plot_time_series_custom_half_life(tmp_path, monkeypatch):
     times = np.array([1000.1, 1000.2, 1001.1, 1001.8])
     energies = np.array([7.6, 7.7, 7.8, 7.7])
     cfg = basic_config()
-    cfg["hl_Po214"] = [2.0]
+    cfg["hl_po214"] = [2.0]
 
     captured = {}
 
@@ -139,7 +139,7 @@ def test_plot_time_series_custom_half_life_po218(tmp_path, monkeypatch):
     cfg.update({
         "window_po218": [5.8, 6.3],
         "eff_Po218": [1.0],
-        "hl_Po218": [4.0],
+        "hl_po218": [4.0],
     })
 
     captured = {}
@@ -175,7 +175,7 @@ def test_plot_time_series_time_fit_half_lives(tmp_path, monkeypatch):
     cfg.update({
         "window_po218": [5.8, 6.3],
         "eff_Po218": [1.0],
-        "time_fit": {"hl_Po214": [2.0], "hl_Po218": [4.0]},
+        "time_fit": {"hl_po214": [2.0], "hl_po218": [4.0]},
     })
 
     captured = {}
@@ -212,7 +212,7 @@ def test_plot_time_series_time_fit_half_lives(tmp_path, monkeypatch):
 
 def test_plot_time_series_invalid_half_life_po214(tmp_path):
     cfg = basic_config()
-    cfg["hl_Po214"] = [0.0]
+    cfg["hl_po214"] = [0.0]
     with pytest.raises(ValueError):
         plot_time_series(
             np.array([1000.1]),
@@ -227,7 +227,7 @@ def test_plot_time_series_invalid_half_life_po214(tmp_path):
 
 def test_plot_time_series_invalid_half_life_po218(tmp_path):
     cfg = basic_config()
-    cfg.update({"window_po218": [5.8, 6.3], "eff_Po218": [1.0], "hl_Po218": [-2.0]})
+    cfg.update({"window_po218": [5.8, 6.3], "eff_Po218": [1.0], "hl_po218": [-2.0]})
     with pytest.raises(ValueError):
         plot_time_series(
             np.array([1000.1]),

--- a/tests/test_sample_radon.py
+++ b/tests/test_sample_radon.py
@@ -17,7 +17,7 @@ def test_total_radon_uses_sample_volume(tmp_path, monkeypatch):
         "baseline": {"monitor_volume_l": 10.0, "sample_volume_l": 5.0},
         "calibration": {},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
-        "time_fit": {"do_time_fit": True, "window_po214": [7, 9], "hl_Po214": [1.0, 0.0], "eff_Po214": [1.0, 0.0], "flags": {}},
+        "time_fit": {"do_time_fit": True, "window_po214": [7, 9], "hl_po214": [1.0, 0.0], "eff_Po214": [1.0, 0.0], "flags": {}},
         "systematics": {"enable": False},
         "plotting": {"plot_save_formats": ["png"]},
     }

--- a/tests/test_systematics.py
+++ b/tests/test_systematics.py
@@ -116,7 +116,7 @@ def test_analyze_systematics_skip_unknown(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [7.0, 8.0],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -20,7 +20,7 @@ def test_time_window_filters_events(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [7, 9],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },
@@ -152,7 +152,7 @@ def test_time_window_filters_events_config(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [7, 9],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },
@@ -231,7 +231,7 @@ def test_run_period_filters_events(tmp_path, monkeypatch):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [7, 9],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },
@@ -318,7 +318,7 @@ def test_baseline_range_iso_strings(tmp_path, monkeypatch, start, end):
         "time_fit": {
             "do_time_fit": True,
             "window_po214": [7, 9],
-            "hl_Po214": [1.0, 0.0],
+            "hl_po214": [1.0, 0.0],
             "eff_Po214": [1.0, 0.0],
             "flags": {},
         },


### PR DESCRIPTION
## Summary
- use lowercase isotope names with `_cfg_get`
- normalize window names in documentation
- update tests for new keys

## Testing
- `bash scripts/setup_tests.sh`
- `pytest -q` *(fails: SystemExit)*

------
https://chatgpt.com/codex/tasks/task_e_6852164372e8832b98220a0b90eaa479