### PR TITLE
Clarify lowercase keys in time-series extraction docstring

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -16,19 +16,17 @@ import jsonschema
 def extract_time_series_events(events, cfg):
     """Slice events for time-series fits based on isotope windows.
 
-    Configuration keys should use lowercase isotope names, e.g. ``window_po214``.
+    Configuration keys **must** use lowercase isotope names, for example
+    ``window_po214``.  Mixed‑case keys remain accepted for backward
+    compatibility but should be avoided in new configuration files.
 
     Parameters
     ----------
     events : pandas.DataFrame
         Event data with ``timestamp`` and ``energy_MeV`` columns.
     cfg : dict
-        Configuration containing ``time_fit`` settings. The
-        window definitions should use lowercase keys
-
-        (``window_po214`` etc.). Mixed-case keys such as
-        ``window_po214`` are still recognized for backward
-        compatibility.
+        Configuration containing ``time_fit`` settings. The window
+        definitions should use lowercase keys.
 
     Returns
     -------


### PR DESCRIPTION
## Summary
- emphasize that `extract_time_series_events` expects lowercase config keys
- mention that mixed-case keys are still supported

## Testing
- `pip install -q -r requirements.txt`
- `pytest tests/test_time_series_po210_plot.py::test_extract_time_series_po210_count -q`

------
https://chatgpt.com/codex/tasks/task_e_6852198cf32c832b914983361071f969