### PR TITLE
Normalize Po config keys

### DIFF
--- a/plot_utils.py
+++ b/plot_utils.py
@@ -82,8 +82,8 @@ def plot_time_series(
     t_end,
     config,
     out_png,
-    hl_Po214=None,
-    hl_Po218=None,
+    hl_po214=None,
+    hl_po218=None,
 ):
     """
     all_timestamps: 1D np.ndarray of absolute UNIX times (s)
@@ -133,13 +133,13 @@ def plot_time_series(
     default218 = default_const.get("Po218", PO218).half_life_s
 
     po214_hl = (
-        float(hl_Po214)
-        if hl_Po214 is not None
+        float(hl_po214)
+        if hl_po214 is not None
         else float(_cfg_get(config, "hl_po214", [default214])[0])
     )
     po218_hl = (
-        float(hl_Po218)
-        if hl_Po218 is not None
+        float(hl_po218)
+        if hl_po218 is not None
         else float(_cfg_get(config, "hl_po218", [default218])[0])
     )
 


### PR DESCRIPTION
## Summary
- keep time-series helper consistent by using lowercase configuration keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68521aa3434c832b808ae1a691ee711c