### PR TITLE
Fix half-life config handling

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1132,13 +1132,10 @@ def main():
         )
         priors_time["eff"] = tuple(eff_val)
 
-        # Half-life prior (user must supply [T₁/₂, σ(T₁/₂)] in seconds)
+        # Half-life prior using key `hl_{iso.lower()}` (values in seconds)
         hl_key = f"hl_{iso.lower()}"
         if hl_key in cfg["time_fit"]:
             T12, T12sig = cfg["time_fit"][hl_key]
-            priors_time["tau"] = (T12 / np.log(2), T12sig / np.log(2))
-        elif f"hl_{iso}" in cfg["time_fit"]:
-            T12, T12sig = cfg["time_fit"][f"hl_{iso}"]
             priors_time["tau"] = (T12 / np.log(2), T12sig / np.log(2))
 
         # Background‐rate prior
@@ -1191,7 +1188,7 @@ def main():
             "isotopes": {
                 iso: {
                     "half_life_s": cfg["time_fit"].get(
-                        f"hl_{iso.lower()}", cfg["time_fit"].get(f"hl_{iso}", [np.nan])
+                        f"hl_{iso.lower()}", [np.nan]
                     )[0],
                     "efficiency": cfg["time_fit"].get(
                         f"eff_{iso.lower()}", cfg["time_fit"].get(f"eff_{iso}", [1.0])
@@ -1294,7 +1291,9 @@ def main():
                 cfg_fit = {
                     "isotopes": {
                         iso: {
-                            "half_life_s": cfg["time_fit"].get(f"hl_{iso.lower()}", cfg["time_fit"].get(f"hl_{iso}", [np.nan]))[0],
+                            "half_life_s": cfg["time_fit"].get(
+                                f"hl_{iso.lower()}", [np.nan]
+                            )[0],
                             "efficiency": priors_mod["eff"][0],
                         }
                     },


### PR DESCRIPTION
## Summary
- remove uppercase fallback for half-life priors
- lookup half-life using only lowercase `hl_{iso.lower()}`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68521bca1654832b9a520b89026010b2