### PR TITLE
Fix docstring for time-series window keys

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -16,9 +16,9 @@ import jsonschema
 def extract_time_series_events(events, cfg):
     """Slice events for time-series fits based on isotope windows.
 
-    Configuration keys **must** use lowercase isotope names, for example
-    ``window_po214``.  Mixed‑case keys remain accepted for backward
-    compatibility but should be avoided in new configuration files.
+    Configuration keys **must** use lowercase isotope names (``window_po214`` etc.).
+    Mixed-case keys such as ``window_Po214`` are still recognized for backward
+    compatibility.
 
     Parameters
     ----------


### PR DESCRIPTION
## Summary
- clarify usage of lowercase `window_po214` in `extract_time_series_events`
- note that mixed-case keys like `window_Po214` are still supported

## Testing
- `pytest -q` *(fails: Package 'numpy' is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68521bd3104c832b994ca78e76ee2936