### PR TITLE
Fix parse_time float return

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -52,3 +52,11 @@ def test_parse_time_numeric_str():
 
 def test_parse_time_numeric_str_float():
     assert parse_time("42.5") == pytest.approx(42.5)
+
+
+def test_parse_time_iso_no_fraction():
+    assert parse_time("1970-01-01T00:00:00Z") == pytest.approx(0.0)
+
+
+def test_parse_time_iso_fraction():
+    assert parse_time("1970-01-01T00:00:00.5Z") == pytest.approx(0.5)

--- a/utils.py
+++ b/utils.py
@@ -128,8 +128,8 @@ def cps_to_bq(rate_cps, volume_liters=None):
     return float(rate_cps) / volume_m3
 
 
-def parse_time(s: str) -> int:
-    """Parse a timestamp string or integer into Unix epoch seconds."""
+def parse_time(s: str) -> float:
+    """Parse a timestamp string or integer into Unix epoch seconds as a float."""
     if isinstance(s, (int, float)):
         return float(s)
 
@@ -147,7 +147,7 @@ def parse_time(s: str) -> int:
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=timezone.utc)
 
-        return int(dt.timestamp())
+        return float(dt.timestamp())
 
     raise argparse.ArgumentTypeError(f"could not parse time: {s!r}")
 


### PR DESCRIPTION
## Summary
- change `utils.parse_time` to return float timestamps
- document float return in annotation and docstring
- add parse_time tests for ISO strings with and without fractional seconds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68521d2f4bb4832b85109c803ddf3d67