### PR TITLE
Fix docstring for legacy time series keys

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -16,9 +16,9 @@ import jsonschema
 def extract_time_series_events(events, cfg):
     """Slice events for time-series fits based on isotope windows.
 
-    Configuration keys **must** use lowercase isotope names, for example
-    ``window_po214``.  Mixed‑case keys remain accepted for backward
-    compatibility but should be avoided in new configuration files.
+    Configuration keys **must** use lowercase isotope names
+    (``window_po214`` etc.). Mixed-case keys such as ``window_Po214`` are still
+    recognized for backward compatibility.
 
     Parameters
     ----------


### PR DESCRIPTION
## Summary
- clarify example usage of legacy `window_*` keys in io_utils

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68521d540fdc832bb6f464890a4e3fab