### PR TITLE
Fix energy shift units

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,8 +320,10 @@ additional parameters as documented in `systematics.apply_linear_adc_shift`.
 `sigma_E_frac`, `tail_fraction` and `energy_shift_keV` provide the
 magnitude of systematic shifts applied during the scan.  The first two
 are interpreted fractionally relative to the current parameter values,
-while `energy_shift_keV` is an absolute shift.  Each entry is optional
-and only affects the scan when present.
+while `energy_shift_keV` gives an absolute shift.  Values for
+`energy_shift_keV` should be specified in keV and are converted to MeV
+automatically.  Each entry is optional and only affects the scan when
+present.
 
 `plot_time_style` chooses how the histogram is drawn in the time-series
 plot.  Use `"steps"` (default) for a stepped histogram or `"lines"` to

--- a/systematics.py
+++ b/systematics.py
@@ -89,8 +89,9 @@ def scan_systematics(
     sigma_dict : dict
         Dictionary of parameter shift magnitudes.  Keys may be suffixed
         with ``_frac`` to indicate a fractional shift or ``_keV`` for an
-        absolute shift in the same units as the parameter.  Keys without a
-        suffix are interpreted as absolute shifts.
+        absolute shift supplied in keV.  Values with ``_keV`` are divided
+        by ``1000.0`` to convert to MeV.  Keys without a suffix are
+        interpreted as absolute shifts.
 
     Returns
     -------
@@ -116,7 +117,7 @@ def scan_systematics(
             delta = val * priors[key][0]
         elif full_key.endswith("_keV"):
             key = full_key[:-4]
-            delta = val
+            delta = val / 1000.0  # convert keV → MeV
         else:
             key = full_key
             delta = val

--- a/tests/test_systematics.py
+++ b/tests/test_systematics.py
@@ -103,8 +103,9 @@ def test_scan_systematics_fractional_and_absolute():
     shifts = {"sigma_E_frac": 0.1, "mu_keV": 2.0}
     deltas, tot = scan_systematics(fit_func, priors, shifts)
     assert deltas["sigma_E"] == pytest.approx(0.2)
-    assert deltas["mu"] == pytest.approx(2.0)
-    expected = math.sqrt(0.2 ** 2 + 2.0 ** 2)
+    # _keV suffix should convert the shift from keV to MeV
+    assert deltas["mu"] == pytest.approx(0.002)
+    expected = math.sqrt(0.2 ** 2 + 0.002 ** 2)
     assert tot == pytest.approx(expected)
 
 


### PR DESCRIPTION
## Summary
- handle `_keV` keys in `scan_systematics`
- document the conversion from keV to MeV
- clarify README about automatic conversion
- update unit test for the new behaviour

## Testing
- `pytest -k systematics -q`

------
https://chatgpt.com/codex/tasks/task_e_68521d6039d0832b9741318641056ea5