### PR TITLE
Normalize Po keys

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -17,9 +17,8 @@ def extract_time_series_events(events, cfg):
     """Slice events for time-series fits based on isotope windows.
 
     Configuration keys **must** use lowercase isotope names, for example
-    ``window_po214``.  Mixed‑case keys such as ``window_Po214`` remain
-    accepted for backward compatibility but should be avoided in new
-    configuration files.
+    ``window_po214``.  Mixed‑case keys used by older versions are no
+    longer supported.
 
     Parameters
     ----------

--- a/plot_utils.py
+++ b/plot_utils.py
@@ -108,8 +108,8 @@ def plot_time_series(
         """Lookup ``key`` in ``cfg`` case-insensitively.
 
         The search first checks the ``time_fit`` sub-dictionary, then the
-        top level of ``cfg``.  Keys are matched ignoring case so that both new
-        ``hl_po214`` and legacy ``hl_Po214`` style names are recognised.
+        top level of ``cfg``.  Keys are matched ignoring case so that variations
+        in case are recognised.
         """
 
         if not isinstance(cfg, dict):
@@ -133,10 +133,10 @@ def plot_time_series(
     default214 = default_const.get("Po214", PO214).half_life_s
     default218 = default_const.get("Po218", PO218).half_life_s
 
-    if hl_po214 is None and "hl_Po214" in _legacy_kwargs:
-        hl_po214 = _legacy_kwargs.pop("hl_Po214")
-    if hl_po218 is None and "hl_Po218" in _legacy_kwargs:
-        hl_po218 = _legacy_kwargs.pop("hl_Po218")
+    if hl_po214 is None and "hl_po214" in _legacy_kwargs:
+        hl_po214 = _legacy_kwargs.pop("hl_po214")
+    if hl_po218 is None and "hl_po218" in _legacy_kwargs:
+        hl_po218 = _legacy_kwargs.pop("hl_po218")
 
     po214_hl = (
         float(hl_po214)


### PR DESCRIPTION
## Summary
- update docstrings to only reference lowercase Po keys
- remove legacy Po key handling in plot utils
- keep CLI overrides in lowercase

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68521dd692f8832b8f4b5c4f0445ac77