### PR TITLE
Update CI to use setup script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          bash scripts/setup_tests.sh
       - name: Run tests
         run: pytest -v

--- a/README.md
+++ b/README.md
@@ -509,9 +509,10 @@ overrides the `systematics` section.
 
 ## Running Tests
 
-Use the provided setup script to install the required packages:
+Install the required packages from `requirements.txt` before running the tests.
+You can do this directly or via the provided helper script:
 ```bash
-scripts/setup_tests.sh
+pip install -r requirements.txt   # or: bash scripts/setup_tests.sh
 pytest -v
 ```
 


### PR DESCRIPTION
## Summary
- install dependencies in CI using setup_tests.sh
- document installing requirements before running the tests

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68521ed5ae20832b9723febf92876a46