### PR TITLE
Normalize isotope key case

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ overlaying multiple isotopes so one does not obscure the other.
 when invoking `plot_time_series`.  When set to `true` the analysis does
 not clear the other window, allowing Po‑214 and Po‑218 to be plotted
 together on a single overlay.
-Specifying `window_po210` (and optional `eff_Po210`) adds a Po‑210
+Specifying `window_po210` (and optional `eff_po210`) adds a Po‑210
 histogram to the time-series plots. The model curve appears only when
 fit results for Po‑210 are available.
 
@@ -365,7 +365,7 @@ The same values are used in the `time_fit` routine itself, so changing
 them to the radon half-life (~3.8 days) to match the slowly varying
 radon activity.
 
-`sig_N0_Po214` and `sig_N0_Po218` set the uncertainty on the prior for the
+`sig_N0_po214` and `sig_N0_po218` set the uncertainty on the prior for the
 initial activity `N0` when no baseline range is provided.  Without a baseline,
 the fit applies a Gaussian prior `(0, sig_N0_{iso})` so `N0` may vary rather
 than being fixed to zero.  The default width is `1.0` if not specified in the
@@ -391,8 +391,8 @@ Example snippet:
     "hl_po214": [328320, 0.0],
     "hl_po218": [328320, 0.0],
     "hl_po210": [11923200, 0.0],
-    "sig_N0_Po214": 1.0,
-    "sig_N0_Po218": 1.0
+    "sig_N0_po214": 1.0,
+    "sig_N0_po218": 1.0
 }
 ```
 

--- a/analyze.py
+++ b/analyze.py
@@ -1127,9 +1127,7 @@ def main():
         priors_time = {}
 
         # Efficiency prior per isotope
-        eff_val = cfg["time_fit"].get(
-            f"eff_{iso.lower()}", cfg["time_fit"].get(f"eff_{iso}", [1.0, 0.0])
-        )
+        eff_val = cfg["time_fit"].get(f"eff_{iso.lower()}", [1.0, 0.0])
         priors_time["eff"] = tuple(eff_val)
 
         # Half-life prior (user must supply [T₁/₂, σ(T₁/₂)] in seconds)
@@ -1139,8 +1137,8 @@ def main():
             priors_time["tau"] = (T12 / np.log(2), T12sig / np.log(2))
 
         # Background‐rate prior
-        if f"bkg_{iso}" in cfg["time_fit"]:
-            priors_time["B0"] = tuple(cfg["time_fit"][f"bkg_{iso}"])
+        if f"bkg_{iso.lower()}" in cfg["time_fit"]:
+            priors_time["B0"] = tuple(cfg["time_fit"][f"bkg_{iso.lower()}"])
 
         # Initial N₀ from baseline (if provided)
         if baseline_range:
@@ -1155,9 +1153,7 @@ def main():
             if iso in isotopes_to_subtract:
                 baseline_counts[iso] = n0_count
 
-            eff = cfg["time_fit"].get(
-                f"eff_{iso.lower()}", cfg["time_fit"].get(f"eff_{iso}", [1.0])
-            )[0]
+            eff = cfg["time_fit"].get(f"eff_{iso.lower()}", [1.0])[0]
             if baseline_live_time > 0 and eff > 0:
                 n0_activity = n0_count / (baseline_live_time * eff)
                 n0_sigma = np.sqrt(n0_count) / (baseline_live_time * eff)
@@ -1167,12 +1163,12 @@ def main():
 
             priors_time["N0"] = (
                 n0_activity,
-                cfg["time_fit"].get(f"sig_N0_{iso}", n0_sigma),
+                cfg["time_fit"].get(f"sig_N0_{iso.lower()}", n0_sigma),
             )
         else:
             priors_time["N0"] = (
                 0.0,
-                cfg["time_fit"].get(f"sig_N0_{iso}", 1.0),
+                cfg["time_fit"].get(f"sig_N0_{iso.lower()}", 1.0),
             )
 
         # Store priors for use in systematics scanning
@@ -1191,14 +1187,14 @@ def main():
                         f"hl_{iso.lower()}", [np.nan]
                     )[0],
                     "efficiency": cfg["time_fit"].get(
-                        f"eff_{iso.lower()}", cfg["time_fit"].get(f"eff_{iso}", [1.0])
+                        f"eff_{iso.lower()}", [1.0]
                     )[0],
                 }
             },
             "fit_background": not cfg["time_fit"]["flags"].get(
                 "fix_background_b", False
             ),
-            "fit_initial": not cfg["time_fit"]["flags"].get(f"fix_N0_{iso}", False),
+            "fit_initial": not cfg["time_fit"]["flags"].get(f"fix_N0_{iso.lower()}", False),
             "background_guess": cfg["time_fit"].get("background_guess", 0.0),
             "n0_guess_fraction": cfg["time_fit"].get("n0_guess_fraction", 0.1),
         }
@@ -1299,7 +1295,7 @@ def main():
                         "fix_background_b", False
                     ),
                     "fit_initial": not cfg["time_fit"]["flags"].get(
-                        f"fix_N0_{iso}", False
+                        f"fix_N0_{iso.lower()}", False
                     ),
                     "background_guess": cfg["time_fit"].get("background_guess", 0.0),
                     "n0_guess_fraction": cfg["time_fit"].get("n0_guess_fraction", 0.1),
@@ -1414,9 +1410,7 @@ def main():
     baseline_unc = {}
     if baseline_live_time > 0:
         for iso, count in baseline_counts.items():
-            eff = cfg["time_fit"].get(
-                f"eff_{iso.lower()}", cfg["time_fit"].get(f"eff_{iso}", [1.0])
-            )[0]
+            eff = cfg["time_fit"].get(f"eff_{iso.lower()}", [1.0])[0]
             if eff > 0:
                 rate = count / (baseline_live_time * eff)
                 err = np.sqrt(count) / (baseline_live_time * eff)
@@ -1448,9 +1442,7 @@ def main():
             sigma_rate = 0.0
             if baseline_live_time > 0:
                 count = baseline_counts.get(iso, 0.0)
-                eff = cfg["time_fit"].get(
-                    f"eff_{iso.lower()}", cfg["time_fit"].get(f"eff_{iso}", [1.0])
-                )[0]
+                eff = cfg["time_fit"].get(f"eff_{iso.lower()}", [1.0])[0]
                 if eff > 0:
                     sigma_rate = math.sqrt(count) / (baseline_live_time * eff)
             params["dE_corrected"] = float(math.hypot(err_fit, sigma_rate * s))

--- a/config.json
+++ b/config.json
@@ -82,20 +82,20 @@
         "window_po214": [7.4, 7.9],
         "window_po218": [5.8, 6.3],
         "window_po210": [5.2, 5.4],
-        "eff_Po214": [0.40, 0.0],
-        "eff_Po218": [0.20, 0.0],
-        "eff_Po210": [0.10, 0.0],
+        "eff_po214": [0.40, 0.0],
+        "eff_po218": [0.20, 0.0],
+        "eff_po210": [0.10, 0.0],
         "hl_po214": [328320, 0.0],
         "hl_po218": [328320, 0.0],
-        "bkg_Po214": [0.0, 0.0],
-        "bkg_Po218": [0.0, 0.0],
-        "sig_N0_Po214": 1.0,
-        "sig_N0_Po218": 1.0,
+        "bkg_po214": [0.0, 0.0],
+        "bkg_po218": [0.0, 0.0],
+        "sig_N0_po214": 1.0,
+        "sig_N0_po218": 1.0,
         "background_guess": 0.0,
         "n0_guess_fraction": 0.1,
         "flags": {
             "fix_background_b": false,
-            "fix_N0_Po218": false
+            "fix_N0_po218": false
         }
     },
     "systematics": {


### PR DESCRIPTION
## Summary
- ensure isotope keys always use lowercase names
- normalize config.json to use lowercase keys
- document lowercase keys in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68521ed7d9d4832bb32e2b8f365face3