### PR TITLE
Clarify time-series window key doc

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -17,8 +17,9 @@ def extract_time_series_events(events, cfg):
     """Slice events for time-series fits based on isotope windows.
 
     Configuration keys **must** use lowercase isotope names, for example
-    ``window_po214``.  Mixed‑case keys used by older versions are no
-    longer supported.
+    (``window_po214`` etc.). Mixed-case keys such as
+    ``window_Po214`` are still recognized for backward
+    compatibility.
 
     Parameters
     ----------


### PR DESCRIPTION
## Summary
- clarify docstring about lowercase keys for time-series extraction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68522051a66c832b8d794fef8267cbc2