### PR TITLE
Fix time-fit config key for N0 sigma

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1165,14 +1165,24 @@ def main():
                 n0_activity = 0.0
                 n0_sigma = 1.0
 
+            sigma_key_lower = f"sig_n0_{iso.lower()}"
+            sigma_key_old = f"sig_N0_{iso}"
             priors_time["N0"] = (
                 n0_activity,
-                cfg["time_fit"].get(f"sig_N0_{iso}", n0_sigma),
+                cfg["time_fit"].get(
+                    sigma_key_lower,
+                    cfg["time_fit"].get(sigma_key_old, n0_sigma),
+                ),
             )
         else:
+            sigma_key_lower = f"sig_n0_{iso.lower()}"
+            sigma_key_old = f"sig_N0_{iso}"
             priors_time["N0"] = (
                 0.0,
-                cfg["time_fit"].get(f"sig_N0_{iso}", 1.0),
+                cfg["time_fit"].get(
+                    sigma_key_lower,
+                    cfg["time_fit"].get(sigma_key_old, 1.0),
+                ),
             )
 
         # Store priors for use in systematics scanning


### PR DESCRIPTION
## Summary
- support lowercase config key `sig_n0_{iso}` when building time priors
- keep backwards compatibility with old `sig_N0_{iso}` key

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685221f09c94832bb6ecdfe31faf857e