### PR TITLE
Update config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ found to be non-positive definite.
 
 ## Configuration
 
+The parser is case sensitive, so all keys in `config.json` should be lowercase. Mixed-case names from older files remain supported for backward compatibility but are deprecated.
+
 `nominal_adc` under the `calibration` section sets the expected raw ADC
 centroids for Po‑210, Po‑218 and Po‑214 when using automatic calibration.
 If omitted, defaults of `{"Po210": 1250, "Po218": 1400, "Po214": 1800}`


### PR DESCRIPTION
## Summary
- clarify that configuration keys must be lowercase
- note backward compatibility for old mixed-case keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685221f1b048832baa0cb48dcc629800