### PR TITLE
Enforce lowercase half-life keys

### DIFF
--- a/plot_utils.py
+++ b/plot_utils.py
@@ -105,29 +105,21 @@ def plot_time_series(
         fit_results = {}
 
     def _cfg_get(cfg, key, default=None):
-        """Lookup ``key`` in ``cfg`` case-insensitively.
+        """Lookup ``key`` in ``cfg``.
 
         The search first checks the ``time_fit`` sub-dictionary, then the
-        top level of ``cfg``.  Keys are matched ignoring case so that variations
-        in case are recognised.
+        top level of ``cfg``.  Configuration keys should use lowercase
+        names such as ``hl_po214`` and ``hl_po218``.
         """
 
         if not isinstance(cfg, dict):
             return default
 
-        key_lc = str(key).lower()
-
         sub = cfg.get("time_fit", {})
-        if isinstance(sub, dict):
-            for k, v in sub.items():
-                if k.lower() == key_lc:
-                    return v
+        if isinstance(sub, dict) and key in sub:
+            return sub[key]
 
-        for k, v in cfg.items():
-            if k.lower() == key_lc:
-                return v
-
-        return default
+        return cfg.get(key, default)
 
     default_const = config.get("nuclide_constants", {})
     default214 = default_const.get("Po214", PO214).half_life_s


### PR DESCRIPTION
## Summary
- enforce lowercase key names in `plot_time_series._cfg_get`
- clarify `_cfg_get` docstring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685220d06ba0832ba85bdfc423cd7c6a