### PR TITLE
Support lowercase sig_n0 prior keys

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1167,12 +1167,18 @@ def main():
 
             priors_time["N0"] = (
                 n0_activity,
-                cfg["time_fit"].get(f"sig_N0_{iso.lower()}", n0_sigma),
+                cfg["time_fit"].get(
+                    f"sig_n0_{iso.lower()}",
+                    cfg["time_fit"].get(f"sig_N0_{iso}", n0_sigma),
+                ),
             )
         else:
             priors_time["N0"] = (
                 0.0,
-                cfg["time_fit"].get(f"sig_N0_{iso.lower()}", 1.0),
+                cfg["time_fit"].get(
+                    f"sig_n0_{iso.lower()}",
+                    cfg["time_fit"].get(f"sig_N0_{iso}", 1.0),
+                ),
             )
 
         # Store priors for use in systematics scanning


### PR DESCRIPTION
## Summary
- allow both `sig_n0_{iso.lower()}` and `sig_N0_{iso}` keys for priors

## Testing
- `pytest -q` *(fails: Package 'numpy' is required)*

------
https://chatgpt.com/codex/tasks/task_e_6852271ad094832bb3c774bb439ff925