### PR TITLE
Fix README prior doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,9 +370,10 @@ radon activity.
 
 `sig_n0_po214` and `sig_n0_po218` set the uncertainty on the prior for the
 initial activity `N0` when no baseline range is provided.  Without a baseline,
-the fit applies a Gaussian prior `(0, sig_N0_{iso})` so `N0` may vary rather
-than being fixed to zero.  The default width is `1.0` if not specified in the
-configuration.
+the fit applies a Gaussian prior `(0, sig_n0_{iso.lower()})` so `N0` may vary
+rather than being fixed to zero.  The legacy key `sig_N0_{iso}` is also
+accepted for backward compatibility.  The default width is `1.0` if not
+specified in the configuration.
 
 
 `settling_time_s` was removed from the `time_fit` section and is no


### PR DESCRIPTION
## Summary
- document correct sig_n0_{iso.lower()} key
- mention sig_N0_{iso} is accepted for backwards compatibility

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68522b432124832baf6322d53ede8812