### PR TITLE
Fix defaults and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ This repository provides a complete pipeline to analyze electrostatic radon moni
 
 ## Installation
 
+This project requires **Python 3.11** or newer.
+
 ```bash
 pip install -r requirements.txt
 ```

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,15 @@
+"""Radon Monitor analysis package."""
+
+from .efficiency import (
+    calc_spike_efficiency,
+    calc_assay_efficiency,
+    calc_decay_efficiency,
+    blue_combine,
+)
+
+__all__ = [
+    "calc_spike_efficiency",
+    "calc_assay_efficiency",
+    "calc_decay_efficiency",
+    "blue_combine",
+]

--- a/analyze.py
+++ b/analyze.py
@@ -1533,7 +1533,7 @@ def main():
             N0 = fit.get("N0_Po214", 0.0)
             dN0 = fit.get("dN0_Po214", 0.0)
             default_const = cfg.get("nuclide_constants", {})
-            default_hl = default_const.get("Po210", PO210).half_life_s
+            default_hl = default_const.get("Po214", PO214).half_life_s
             hl = cfg.get("time_fit", {}).get("hl_po214", [default_hl])[0]
             cov = _cov_entry(fit_result, "E_Po214", "N0_Po214")
             delta214, err_delta214 = radon_delta(
@@ -1556,7 +1556,7 @@ def main():
             N0 = fit.get("N0_Po218", 0.0)
             dN0 = fit.get("dN0_Po218", 0.0)
             default_const = cfg.get("nuclide_constants", {})
-            default_hl = default_const.get("Po210", PO210).half_life_s
+            default_hl = default_const.get("Po218", PO218).half_life_s
             hl = cfg.get("time_fit", {}).get("hl_po218", [default_hl])[0]
             cov = _cov_entry(fit_result, "E_Po218", "N0_Po218")
             delta218, err_delta218 = radon_delta(
@@ -1732,7 +1732,7 @@ def main():
             N0 = fit.get("N0_Po214", 0.0)
             dN0 = fit.get("dN0_Po214", 0.0)
             default_const = cfg.get("nuclide_constants", {})
-            default_hl = default_const.get("Po210", PO210).half_life_s
+            default_hl = default_const.get("Po214", PO214).half_life_s
             hl = cfg.get("time_fit", {}).get("hl_po214", [default_hl])[0]
             cov = _cov_entry(fit_result, "E_Po214", "N0_Po214")
             A214, dA214 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl, cov)
@@ -1753,7 +1753,7 @@ def main():
             N0 = fit.get("N0_Po218", 0.0)
             dN0 = fit.get("dN0_Po218", 0.0)
             default_const = cfg.get("nuclide_constants", {})
-            default_hl = default_const.get("Po210", PO210).half_life_s
+            default_hl = default_const.get("Po218", PO218).half_life_s
             hl = cfg.get("time_fit", {}).get("hl_po218", [default_hl])[0]
             cov = _cov_entry(fit_result, "E_Po218", "N0_Po218")
             A218, dA218 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl, cov)
@@ -1804,7 +1804,7 @@ def main():
                 N0214 = fit.get("N0_Po214", 0.0)
                 dN0214 = fit.get("dN0_Po214", 0.0)
                 default_const = cfg.get("nuclide_constants", {})
-                default_hl = default_const.get("Po210", PO210).half_life_s
+                default_hl = default_const.get("Po214", PO214).half_life_s
                 hl214 = cfg.get("time_fit", {}).get("hl_po214", [default_hl])[0]
                 cov214 = _cov_entry(fit_result, "E_Po214", "N0_Po214")
                 A214_tr, _ = radon_activity_curve(
@@ -1819,7 +1819,7 @@ def main():
                 N0218 = fit.get("N0_Po218", 0.0)
                 dN0218 = fit.get("dN0_Po218", 0.0)
                 default_const = cfg.get("nuclide_constants", {})
-                default_hl = default_const.get("Po210", PO210).half_life_s
+                default_hl = default_const.get("Po218", PO218).half_life_s
                 hl218 = cfg.get("time_fit", {}).get("hl_po218", [default_hl])[0]
                 cov218 = _cov_entry(fit_result, "E_Po218", "N0_Po218")
                 A218_tr, _ = radon_activity_curve(

--- a/efficiency.py
+++ b/efficiency.py
@@ -37,6 +37,8 @@ def calc_spike_efficiency(
     """
     if activity_bq <= 0 or live_time_s <= 0:
         raise ValueError("activity_bq and live_time_s must be positive")
+    if counts < 0:
+        raise ValueError("counts cannot be negative")
     return float(counts) / (float(activity_bq) * float(live_time_s))
 
 
@@ -57,6 +59,8 @@ def calc_assay_efficiency(rate_cps: float, reference_bq: float) -> float:
     """
     if reference_bq <= 0:
         raise ValueError("reference_bq must be positive")
+    if rate_cps < 0:
+        raise ValueError("rate_cps cannot be negative")
     return float(rate_cps) / float(reference_bq)
 
 

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -17,9 +17,19 @@ def test_calc_spike_efficiency():
     assert eff == pytest.approx(0.05)
 
 
+def test_calc_spike_efficiency_negative_counts():
+    with pytest.raises(ValueError):
+        calc_spike_efficiency(-1, 10.0, 100.0)
+
+
 def test_calc_assay_efficiency():
     eff = calc_assay_efficiency(0.5, 2.0)
     assert eff == pytest.approx(0.25)
+
+
+def test_calc_assay_efficiency_negative_rate():
+    with pytest.raises(ValueError):
+        calc_assay_efficiency(-0.1, 2.0)
 
 
 def test_calc_decay_efficiency():


### PR DESCRIPTION
## Summary
- clarify Python 3.11 requirement in README
- expose key helpers in `__init__`
- validate negative inputs in efficiency helpers
- correct half-life defaults for Po214 and Po218
- test error cases for negative counts and rates

## Testing
- `bash scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685227460a88832ba9643897b30757b1