### PR TITLE
Fix documentation units

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ filtering.  Events falling outside all provided periods are discarded.
 activity between them.
 
 `ambient_concentration` may also be specified here to record the ambient
-radon concentration in Bq/m³ used for the equivalent air plot.  The
+radon concentration in Bq/L used for the equivalent air plot.  The
 command-line option `--ambient-concentration` overrides this value.  The
 default configuration sets this key to `null`.  The template
 `config.json` therefore includes


### PR DESCRIPTION
## Summary
- correct radon concentration units in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pymc')*

------
https://chatgpt.com/codex/tasks/task_e_68522c5855bc832b9e0ff8888cb16f87