### PR TITLE
Define LITERS_PER_M3 constant

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from utils import cps_to_cpd, cps_to_bq, find_adc_bin_peaks, parse_time
+from utils import cps_to_cpd, cps_to_bq, find_adc_bin_peaks, parse_time, LITERS_PER_M3
 
 
 def test_cps_to_cpd():
@@ -12,8 +12,9 @@ def test_cps_to_cpd():
 
 
 def test_cps_to_bq_volume():
-    # 2 cps in 10 L -> 2/(0.01 m^3) = 200 Bq/m^3
-    assert cps_to_bq(2.0, volume_liters=10.0) == pytest.approx(200.0)
+    # 2 cps in 10 L -> 2/(10/LITERS_PER_M3) Bq/m^3
+    expected = 2.0 / (10.0 / LITERS_PER_M3)
+    assert cps_to_bq(2.0, volume_liters=10.0) == pytest.approx(expected)
 
 
 def test_cps_to_bq_simple():

--- a/utils.py
+++ b/utils.py
@@ -8,7 +8,10 @@ import argparse
 from datetime import datetime, timezone
 from dateutil import parser as date_parser
 
-__all__ = ["to_native", "find_adc_bin_peaks", "cps_to_cpd", "cps_to_bq", "parse_time"]
+__all__ = ["to_native", "find_adc_bin_peaks", "cps_to_cpd", "cps_to_bq", "parse_time", "LITERS_PER_M3"]
+
+# Conversion factor from cubic meters to liters
+LITERS_PER_M3 = 1000.0
 
 try:
     import pandas as pd
@@ -116,13 +119,15 @@ def cps_to_bq(rate_cps, volume_liters=None):
     """Convert counts/s to activity in Bq.
 
     If ``volume_liters`` is provided, the result is returned as Bq/m^3
-    assuming ``volume_liters`` describes the detector volume.
+    assuming ``volume_liters`` describes the detector volume. Conversion
+    from liters to cubic meters uses :data:`LITERS_PER_M3`.
     """
 
     if volume_liters is None:
         return float(rate_cps)
 
-    volume_m3 = volume_liters / 1000.0
+    # Convert liters -> m^3 using the LITERS_PER_M3 factor
+    volume_m3 = volume_liters / LITERS_PER_M3
     if volume_m3 <= 0:
         raise ValueError("volume_liters must be positive")
     return float(rate_cps) / volume_m3


### PR DESCRIPTION
## Summary
- define `LITERS_PER_M3` near the top of `utils.py`
- reference the constant in `cps_to_bq`
- update docstring and comments
- adjust unit tests to use the constant

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68522c457020832b92e8d540fc50c825