### PR TITLE
Fix N0 prior width lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,8 +373,8 @@ radon activity.
 `sig_n0_po214` and `sig_n0_po218` set the uncertainty on the prior for the
 initial activity `N0` when no baseline range is provided.  Without a baseline,
 the fit applies a Gaussian prior `(0, sig_n0_{iso.lower()})` so `N0` may vary
-rather than being fixed to zero.  The legacy key `sig_N0_{iso}` is also
-accepted for backward compatibility.  The default width is `1.0` if not
+rather than being fixed to zero.  Use the lower-case `sig_n0_{iso}` keys; the
+legacy `sig_N0_{iso}` form is still accepted for backward compatibility.  The default width is `1.0` if not
 specified in the configuration.
 
 

--- a/analyze.py
+++ b/analyze.py
@@ -1169,10 +1169,7 @@ def main():
                 n0_activity,
                 cfg["time_fit"].get(
                     f"sig_n0_{iso.lower()}",
-                    cfg["time_fit"].get(
-                        f"sig_N0_{iso}",
-                        cfg["time_fit"].get(f"sig_N0_{iso.lower()}", n0_sigma),
-                    ),
+                    cfg["time_fit"].get(f"sig_N0_{iso}", n0_sigma),
                 ),
             )
         else:
@@ -1180,10 +1177,7 @@ def main():
                 0.0,
                 cfg["time_fit"].get(
                     f"sig_n0_{iso.lower()}",
-                    cfg["time_fit"].get(
-                        f"sig_N0_{iso}",
-                        cfg["time_fit"].get(f"sig_N0_{iso.lower()}", 1.0),
-                    ),
+                    cfg["time_fit"].get(f"sig_N0_{iso}", 1.0),
                 ),
             )
 


### PR DESCRIPTION
## Summary
- check new `sig_n0_{iso}` prior width before old mixed-case key
- note new key in docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685230d9b59c832b848132c1a0d9ee54