### PR TITLE
Add --analysis-start-time CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ python analyze.py --config config.json --input merged_data.csv \
     [--efficiency-json eff.json] [--systematics-json syst.json] \
     [--spike-count N --spike-count-err S] [--slope RATE] \
     [--noise-cutoff N] \
-    [--analysis-end-time ISO --spike-end-time ISO] \
+    [--analysis-start-time ISO --analysis-end-time ISO --spike-end-time ISO] \
     [--spike-period START END] [--run-period START END] \
     [--radon-interval START END] \
     [--hl-po214 SEC] [--hl-po218 SEC] \
@@ -251,7 +251,7 @@ file alongside the plot.
 
 Additional convenience flags include `--spike-count` (with optional
 `--spike-count-err`) to override spike efficiency inputs, `--slope` to
-apply a linear ADC drift correction, `--analysis-end-time` and
+apply a linear ADC drift correction, `--analysis-start-time`, `--analysis-end-time` and
 `--spike-end-time` to clip the dataset, one or more `--spike-period`
 options to exclude specific time windows, `--settle-s` to skip the
 initial settling period in the decay fit, `--seed` to set the random

--- a/analyze.py
+++ b/analyze.py
@@ -227,6 +227,10 @@ def parse_args():
         help="Ignore events occurring after this ISO timestamp. Providing this option overrides `analysis.analysis_end_time` in config.json",
     )
     p.add_argument(
+        "--analysis-start-time",
+        help="Reference start time of the analysis (ISO string or epoch). Overrides `analysis.analysis_start_time` in config.json",
+    )
+    p.add_argument(
         "--spike-end-time",
         help="Discard events before this ISO timestamp. Providing this option overrides `analysis.spike_end_time` in config.json",
     )
@@ -457,6 +461,10 @@ def main():
     if args.analysis_end_time is not None:
         _log_override("analysis", "analysis_end_time", args.analysis_end_time)
         cfg.setdefault("analysis", {})["analysis_end_time"] = args.analysis_end_time
+
+    if args.analysis_start_time is not None:
+        _log_override("analysis", "analysis_start_time", args.analysis_start_time)
+        cfg.setdefault("analysis", {})["analysis_start_time"] = args.analysis_start_time
 
     if args.spike_end_time is not None:
         _log_override("analysis", "spike_end_time", args.spike_end_time)

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -999,6 +999,65 @@ def test_analysis_end_time_cli(tmp_path, monkeypatch):
     assert captured["times"] == [0.0]
 
 
+def test_analysis_start_time_cli(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": True,
+            "window_po214": [0.0, 20.0],
+            "hl_po214": [1.0, 0.0],
+            "eff_po214": [1.0, 0.0],
+            "flags": {},
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1],
+        "fBits": [0],
+        "timestamp": [15.0],
+        "adc": [8.0],
+        "fchannel": [1],
+    })
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+
+    captured = {}
+
+    def fake_fit(ts_dict, t_start, t_end, config, **kwargs):
+        captured["t_start"] = t_start
+        return FitResult({}, np.zeros((0, 0)), 0)
+
+    monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+        "--analysis-start-time",
+        "1970-01-01T00:00:10Z",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert captured["t_start"] == 10.0
+
+
 def test_spike_end_time_cli(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},

--- a/tests/test_override_logging.py
+++ b/tests/test_override_logging.py
@@ -57,3 +57,41 @@ def test_analysis_end_time_override_logs(tmp_path, monkeypatch, caplog):
         analyze.main()
 
     assert "analysis.analysis_end_time" in caplog.text
+
+
+def test_analysis_start_time_override_logs(tmp_path, monkeypatch, caplog):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "analysis": {"analysis_start_time": "1970-01-01T00:00:05Z"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    data_path = tmp_path / "data.csv"
+    df.to_csv(data_path, index=False)
+
+    _minimal_patches(monkeypatch)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+        "--analysis-start-time",
+        "1970-01-01T00:00:06Z",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    with caplog.at_level(logging.INFO):
+        analyze.main()
+
+    assert "analysis.analysis_start_time" in caplog.text


### PR DESCRIPTION
## Summary
- add `--analysis-start-time` command-line flag and wire into config overrides
- document the new flag in README usage and convenience section
- test CLI override and logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685235d58f20832bb3f2040de782ac2e