### PR TITLE
Fix radon trend import

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -90,6 +90,7 @@ from plot_utils import (
     plot_time_series,
     plot_radon_activity,
     plot_equivalent_air,
+    plot_radon_trend,
 )
 from systematics import scan_systematics, apply_linear_adc_shift
 from visualize import cov_heatmap, efficiency_bar


### PR DESCRIPTION
## Summary
- ensure radon trend plotting is imported in the main pipeline

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_685244a87e04832bbd44ad3c2ddb6b99