### PR TITLE
Centralize safe_exp helper

### DIFF
--- a/calibration.py
+++ b/calibration.py
@@ -4,20 +4,12 @@ from scipy.optimize import curve_fit
 from scipy.stats import exponnorm
 from constants import (
     _TAU_MIN,
-    EXP_OVERFLOW_DOUBLE,
     DEFAULT_NOISE_CUTOFF,
     DEFAULT_NOMINAL_ADC,
+    _safe_exp,
 )
 
-# Limit for stable exponentiation when evaluating the EMG tail. Values
-# beyond ~700 in magnitude overflow in IEEE-754 doubles.  Match the
-# safeguard used in :mod:`fitting`.
-_EXP_LIMIT = EXP_OVERFLOW_DOUBLE
 
-
-def _safe_exp(x: np.ndarray) -> np.ndarray:
-    """Return ``exp(x)`` with the input clipped to ``[-_EXP_LIMIT, _EXP_LIMIT]``."""
-    return np.exp(np.clip(x, -_EXP_LIMIT, _EXP_LIMIT))
 
 
 # Known α energies (MeV) from config or central constants:

--- a/constants.py
+++ b/constants.py
@@ -1,6 +1,8 @@
 # constants.py
 """Shared constants for analysis modules."""
 
+import numpy as np
+
 # Minimum allowed value for the exponential tail constant used in EMG fits.
 _TAU_MIN = 1e-6
 
@@ -11,6 +13,16 @@ EXP_OVERFLOW_DOUBLE = 700.0
 DEFAULT_NOISE_CUTOFF = 400
 # Iteration cap for ``scipy.optimize.curve_fit``
 CURVE_FIT_MAX_EVALS = 10000
+
+# Limit for stable exponentiation when evaluating EMG tails or similar
+# likelihood terms. Values beyond roughly ``±700`` overflow in IEEE-754
+# doubles, so clip the exponent to this range.
+_EXP_LIMIT = EXP_OVERFLOW_DOUBLE
+
+
+def _safe_exp(x: np.ndarray) -> np.ndarray:
+    """Return ``exp(x)`` with the input clipped to ``[-_EXP_LIMIT, _EXP_LIMIT]``."""
+    return np.exp(np.clip(x, -_EXP_LIMIT, _EXP_LIMIT))
 
 # Nominal ADC centroids for the Po-210, Po-218 and Po-214 peaks used
 # when calibration data does not specify otherwise.
@@ -94,6 +106,7 @@ __all__ = [
     "CURVE_FIT_MAX_EVALS",
     "DEFAULT_NOMINAL_ADC",
     "DEFAULT_ADC_CENTROIDS",
+    "_safe_exp",
     "NuclideConst",
     "PO214",
     "PO218",

--- a/fitting.py
+++ b/fitting.py
@@ -10,21 +10,9 @@ import numpy as np
 from iminuit import Minuit
 from scipy.optimize import curve_fit, OptimizeWarning
 from calibration import emg_left, gaussian
-from constants import _TAU_MIN, EXP_OVERFLOW_DOUBLE, CURVE_FIT_MAX_EVALS
+from constants import _TAU_MIN, CURVE_FIT_MAX_EVALS, _safe_exp
 
-# Prevent overflow in exp calculations. Values beyond ~700 in magnitude
-# lead to inf/0 under IEEE-754 doubles.  Clip the exponent to a safe range
-# so the likelihood remains finite during optimization.
-_EXP_LIMIT = EXP_OVERFLOW_DOUBLE
-
-# Minimum allowed value for the exponential tail constant to avoid
-# divide-by-zero overflow when evaluating the EMG component. The
-# value itself lives in :mod:`constants` as ``_TAU_MIN``.
-
-def _safe_exp(x):
-    """Return ``exp(x)`` with the input clipped to ``[-_EXP_LIMIT, _EXP_LIMIT]``."""
-    return np.exp(np.clip(x, -_EXP_LIMIT, _EXP_LIMIT))
-
+# Use shared overflow guard for exponentiation
 __all__ = ["fit_time_series", "fit_decay", "fit_spectrum"]
 
 

--- a/tests/test_safe_exp.py
+++ b/tests/test_safe_exp.py
@@ -1,0 +1,16 @@
+import numpy as np
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from constants import _safe_exp, EXP_OVERFLOW_DOUBLE
+
+
+def test_safe_exp_clipping():
+    values = np.array([-2 * EXP_OVERFLOW_DOUBLE, 0.0, 2 * EXP_OVERFLOW_DOUBLE])
+    out = _safe_exp(values)
+    assert np.all(np.isfinite(out))
+    assert out[0] == pytest.approx(np.exp(-EXP_OVERFLOW_DOUBLE))
+    assert out[-1] == pytest.approx(np.exp(EXP_OVERFLOW_DOUBLE))


### PR DESCRIPTION
## Summary
- move `_safe_exp` to constants for consistent overflow behavior
- use new helper in calibration and fitting modules
- test `_safe_exp` clipping

## Testing
- `pip install -r requirements.txt | head -n 20`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c6d75bd8832bb942e3d205ec41ce