### PR TITLE
Guard zero detection efficiency

### DIFF
--- a/fitting.py
+++ b/fitting.py
@@ -518,7 +518,10 @@ def fit_time_series(times_dict, t_start, t_end, config, weights=None, strict=Fal
         if hl <= 0:
             raise ValueError("half_life_s must be positive")
         lam_map[iso] = np.log(2.0) / hl
-        eff_map[iso] = float(iso_cfg.get("efficiency", 1.0))
+        eff = float(iso_cfg.get("efficiency", 1.0))
+        if eff <= 0:
+            raise ValueError("efficiency must be positive")
+        eff_map[iso] = eff
         fix_b_map[iso] = not bool(config.get("fit_background", False))
         fix_n0_map[iso] = not bool(config.get("fit_initial", False))
 

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -428,3 +428,14 @@ def test_fit_time_series_half_life_negative_raises():
     }
     with pytest.raises(ValueError):
         fit_time_series(times_dict, 0.0, 10.0, cfg)
+
+
+def test_fit_time_series_efficiency_zero_raises():
+    times_dict = {"Po214": np.array([0.0, 1.0])}
+    cfg = {
+        "isotopes": {"Po214": {"half_life_s": 1.0, "efficiency": 0.0}},
+        "fit_background": True,
+        "fit_initial": True,
+    }
+    with pytest.raises(ValueError):
+        fit_time_series(times_dict, 0.0, 10.0, cfg)


### PR DESCRIPTION
## Summary
- validate efficiency in `fit_time_series`
- ensure zero-efficiency raises
- test that zero efficiency rejects the fit

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c71d9a40832bb314527d794c2ed4