### PR TITLE
Add help invocation test and allow passing argv to main

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -177,7 +177,8 @@ def get_spike_efficiency(spike_cfg):
     return _spike_eff_cache[key]
 
 
-def parse_args():
+def parse_args(argv=None):
+    """Parse command line arguments."""
     p = argparse.ArgumentParser(description="Full Radon Monitor Analysis Pipeline")
     p.add_argument(
         "--config", "-c", required=True, help="Path to JSON configuration file"
@@ -364,7 +365,7 @@ def parse_args():
         ),
     )
 
-    args = p.parse_args()
+    args = p.parse_args(argv)
 
     if args.time_bin_mode_new is not None and args.time_bin_mode_old is not None:
         if args.time_bin_mode_new != args.time_bin_mode_old:
@@ -383,8 +384,8 @@ def parse_args():
     return args
 
 
-def main():
-    cli_args = sys.argv[:]
+def main(argv=None):
+    cli_args = [sys.argv[0]] + (list(argv) if argv is not None else sys.argv[1:])
     cli_sha256 = hashlib.sha256(" ".join(cli_args).encode("utf-8")).hexdigest()
     try:
         commit = subprocess.check_output(
@@ -400,7 +401,7 @@ def main():
     except Exception:
         requirements_sha256 = "unknown"
 
-    args = parse_args()
+    args = parse_args(argv)
     # Convert CLI paths to Path objects
     args.config = Path(args.config)
     args.input = Path(args.input)

--- a/tests/test_analyze_help.py
+++ b/tests/test_analyze_help.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+
+
+def test_analyze_help_exits(capsys):
+    with pytest.raises(SystemExit) as excinfo:
+        analyze.main(["--help"])
+    assert excinfo.value.code == 0
+    captured = capsys.readouterr()
+    assert "usage" in captured.out.lower()


### PR DESCRIPTION
## Summary
- update `parse_args` and `main` in `analyze.py` to accept optional argv
- add a regression test ensuring `analyze.main(['--help'])` works

## Testing
- `pytest tests/test_analyze_help.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c6d07fb0832bac7f4c568e4b4a5c