### PR TITLE
Fix alias for time bin width option

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -315,15 +315,10 @@ def parse_args():
     )
     p.add_argument(
         "--plot-time-bin-width",
-        dest="time_bin_width",
-        type=float,
-        help="Fixed time bin width in seconds. Providing this option overrides `plotting.plot_time_bin_width_s` in config.json",
-    )
-    p.add_argument(
         "--time-bin-width",
         dest="time_bin_width",
         type=float,
-        help=argparse.SUPPRESS,
+        help="Fixed time bin width in seconds. Providing this option overrides `plotting.plot_time_bin_width_s` in config.json",
     )
     p.add_argument(
         "--dump-ts-json",


### PR DESCRIPTION
## Summary
- remove duplicate argument definition for `--time-bin-width`
- allow `--plot-time-bin-width` and `--time-bin-width` to share one parser entry

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c893c004832ba76f8e402ddd3e6a