### PR TITLE
Add half-life logging and stricter BLUE weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,9 @@ When these keys are omitted, `hl_po214` and `hl_po218` fall back to their
 physical half-lives (≈164 µs and ≈183 s). `hl_po210` defaults to its physical
 half-life (≈138 days). These custom half-lives control the decay model drawn
 over the time-series histogram.
+When `time_fit.do_time_fit` is `false` and no custom value is given,
+`plot_time_series` still uses these physical half-lives for the overlay and
+logs this fallback choice.
 The same values are used in the `time_fit` routine itself, so changing
 `hl_po214` or `hl_po218` affects both the unbinned fit and the overlay in
 `plot_time_series`. For monitoring that spans multiple days you may set
@@ -506,6 +509,10 @@ which will be combined.  When the configuration file provides an
 
 The helper `blue_combine.py` exposes a small wrapper so the combination
 can be used independently via ``from blue_combine import BLUE``.
+
+Pass ``allow_negative=False`` to ``blue_combine`` (or ``BLUE``) to raise a
+``ValueError`` when any weight is negative.  The default ``True`` merely
+emits a warning and returns the weights unchanged.
 
 The option `--efficiency-json PATH` may be supplied on the command line to
 load the efficiency section from a separate file instead of embedding it

--- a/blue_combine.py
+++ b/blue_combine.py
@@ -18,8 +18,13 @@ class Measurements:
     corr: Optional[np.ndarray] = None
 
 
-def BLUE(measurements: Measurements):
+def BLUE(measurements: Measurements, *, allow_negative: bool = True):
     """Return BLUE combination of the given measurements."""
-    return blue_combine(measurements.values, measurements.errors, measurements.corr)
+    return blue_combine(
+        measurements.values,
+        measurements.errors,
+        measurements.corr,
+        allow_negative=allow_negative,
+    )
 
 __all__ = ["blue_combine", "BLUE", "Measurements", "CovarianceMatrix"]

--- a/plot_utils.py
+++ b/plot_utils.py
@@ -3,6 +3,7 @@
 # -----------------------------------------------------
 
 import os
+import logging
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
@@ -130,16 +131,28 @@ def plot_time_series(
     if hl_po218 is None and "hl_po218" in _legacy_kwargs:
         hl_po218 = _legacy_kwargs.pop("hl_po218")
 
-    po214_hl = (
-        float(hl_po214)
-        if hl_po214 is not None
-        else float(_cfg_get(config, "hl_po214", [default214])[0])
-    )
-    po218_hl = (
-        float(hl_po218)
-        if hl_po218 is not None
-        else float(_cfg_get(config, "hl_po218", [default218])[0])
-    )
+    cfg214 = _cfg_get(config, "hl_po214", None)
+    cfg218 = _cfg_get(config, "hl_po218", None)
+
+    if hl_po214 is not None:
+        po214_hl = float(hl_po214)
+    elif cfg214 is not None:
+        po214_hl = float(cfg214[0]) if isinstance(cfg214, list) else float(cfg214)
+    else:
+        po214_hl = float(default214)
+        logging.info(
+            "hl_po214 not specified; using physical half-life %.5g s", po214_hl
+        )
+
+    if hl_po218 is not None:
+        po218_hl = float(hl_po218)
+    elif cfg218 is not None:
+        po218_hl = float(cfg218[0]) if isinstance(cfg218, list) else float(cfg218)
+    else:
+        po218_hl = float(default218)
+        logging.info(
+            "hl_po218 not specified; using physical half-life %.5g s", po218_hl
+        )
 
     if po214_hl <= 0:
         raise ValueError("hl_po214 must be positive")

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -74,3 +74,11 @@ def test_blue_combine_negative_weights_warning():
     with pytest.warns(UserWarning):
         _, _, weights = blue_combine(vals, errs, corr)
     assert np.any(weights < 0)
+
+
+def test_blue_combine_negative_weights_error():
+    vals = np.array([1.0, 2.0])
+    errs = np.array([0.1, 0.2])
+    corr = np.array([[1.0, 0.99], [0.99, 1.0]])
+    with pytest.raises(ValueError):
+        blue_combine(vals, errs, corr, allow_negative=False)


### PR DESCRIPTION
## Summary
- log when `plot_time_series` falls back to physical half-lives
- allow `efficiency.blue_combine` to reject negative BLUE weights
- expose `allow_negative` in `blue_combine.BLUE`
- document new behavior and flag in README
- test new parameter

## Testing
- `pytest tests/test_plot_utils.py::test_plot_time_series_fallback -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c71fa044832b826901c4f6dad686