### PR TITLE
Remove deprecated time-bin-width alias

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -320,12 +320,6 @@ def parse_args():
         help="Fixed time bin width in seconds. Providing this option overrides `plotting.plot_time_bin_width_s` in config.json",
     )
     p.add_argument(
-        "--time-bin-width",
-        dest="time_bin_width",
-        type=float,
-        help=argparse.SUPPRESS,
-    )
-    p.add_argument(
         "--dump-ts-json",
         "--dump-time-series-json",
         dest="dump_ts_json",


### PR DESCRIPTION
## Summary
- clean up CLI argument handling in `analyze.py`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c8fe91a8832bb9306a767412b567