### PR TITLE
Fix redundant time-bin width arg

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -316,7 +316,6 @@ def parse_args(argv=None):
     )
     p.add_argument(
         "--plot-time-bin-width",
-        "--time-bin-width",
         dest="time_bin_width",
         type=float,
         help="Fixed time bin width in seconds. Providing this option overrides `plotting.plot_time_bin_width_s` in config.json",


### PR DESCRIPTION
## Summary
- remove duplicate `--time-bin-width` flag from CLI parser

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852ca64fe6c832bb58c53da34e46b6c