### PR TITLE
Support variable bin widths in fit_spectrum

### DIFF
--- a/fitting.py
+++ b/fitting.py
@@ -130,14 +130,20 @@ def fit_spectrum(
 
     # Determine bin edges for width/normalisation even in unbinned mode
     if bin_edges is not None:
-        edges = np.asarray(bin_edges)
+        edges = np.asarray(bin_edges, dtype=float)
     elif bins is not None:
         edges = np.histogram_bin_edges(e, bins=bins)
     else:
         edges = np.histogram_bin_edges(e, bins="fd")
 
-    width = edges[1] - edges[0]
+    edges = np.asarray(edges, dtype=float)
+    if not np.all(np.diff(edges) > 0):
+        raise ValueError("bin_edges must be strictly increasing")
+
+    width = np.diff(edges)
     centers = 0.5 * (edges[:-1] + edges[1:])
+    if width.size != centers.size:
+        raise RuntimeError("width and center size mismatch")
     if not unbinned:
         hist, _ = np.histogram(e, bins=edges)
 

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -181,6 +181,28 @@ def test_fit_spectrum_custom_bins_and_edges():
     assert "F" in out_edges.params
 
 
+def test_fit_spectrum_non_monotonic_edges_error():
+    rng = np.random.default_rng(20)
+    energies = rng.normal(5.3, 0.05, 50)
+
+    priors = {
+        "sigma0": (0.05, 0.01),
+        "F": (0.0, 0.01),
+        "mu_Po210": (5.3, 0.1),
+        "S_Po210": (50, 5),
+        "mu_Po218": (6.0, 0.1),
+        "S_Po218": (50, 5),
+        "mu_Po214": (7.7, 0.1),
+        "S_Po214": (50, 5),
+        "b0": (0.0, 1.0),
+        "b1": (0.0, 1.0),
+    }
+
+    edges = [5.0, 6.0, 5.5, 7.0]
+    with pytest.raises(ValueError):
+        fit_spectrum(energies, priors, bin_edges=edges)
+
+
 def test_fit_spectrum_custom_bounds():
     """User-provided parameter bounds should constrain the fit."""
     rng = np.random.default_rng(3)


### PR DESCRIPTION
## Summary
- vectorise bin width handling in `fit_spectrum`
- validate monotonicity of provided bin edges
- test for non-monotonic bin edges raising an error

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852d1ef0e84832bb3031cac7fe4157a