### PR TITLE
Document non-uniform bin edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,10 @@ the bin edges are internally converted to energy using the calibration
 `slope_MeV_per_ch` (MeV per channel) and intercept before plotting.  This ensures `spectrum.png`
 reflects the calibrated energy scale regardless of binning mode.
 
+Custom `bin_edges` arrays may be supplied when calling the spectral fitting or
+plotting routines. The edges can have variable widths but must be strictly
+increasing.
+
 The `spectral_fit` section provides priors for the unbinned likelihood
 fit.  Important keys include:
 

--- a/fitting.py
+++ b/fitting.py
@@ -101,8 +101,9 @@ def fit_spectrum(
         energies.  Ignored if ``bin_edges`` is provided.  If both ``bins``
         and ``bin_edges`` are ``None``, the Freedman--Diaconis rule is used.
     bin_edges : array-like, optional
-        Explicit bin edges for histogramming the energies.  Takes precedence
-        over ``bins`` when given.
+        Explicit, strictly increasing bin edges for histogramming the
+        energies. Non-uniform spacing is supported and takes precedence over
+        ``bins`` when given.
     bounds : dict, optional
         Mapping of parameter name to ``(lower, upper)`` tuples overriding the
         default ±5σ range derived from the priors.  ``None`` values disable a

--- a/plot_utils.py
+++ b/plot_utils.py
@@ -386,7 +386,8 @@ def plot_spectrum(
     bins : int, optional
         Number of bins if ``bin_edges`` is not supplied.
     bin_edges : array-like, optional
-        Explicit bin edges in MeV.  Overrides ``bins``.
+        Explicit, strictly increasing bin edges in MeV.  Non-uniform widths
+        are supported and override ``bins``.
     config : dict, optional
         Plotting configuration dictionary.
     """


### PR DESCRIPTION
## Summary
- clarify that fit_spectrum and plot_spectrum accept non-uniform bin edges
- note this in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852d1ed9138832bb7f47e501f964466