### PR TITLE
Improve bare filename support in plotting

### DIFF
--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -31,3 +31,23 @@ def test_efficiency_bar_annotations(tmp_path, monkeypatch):
     efficiency_bar(eff, str(out))
     assert out.exists()
     assert any("0.6" in t for t in texts) and any("0.4" in t for t in texts)
+
+
+def test_cov_heatmap_bare_filename(tmp_path, monkeypatch):
+    cov = np.array([[1.0, 0.5], [0.5, 1.0]])
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("visualize.plt.savefig", lambda p, **k: Path(p).touch())
+
+    cov_heatmap(cov, "foo.png")
+
+    assert Path("foo.png").exists()
+
+
+def test_efficiency_bar_bare_filename(tmp_path, monkeypatch):
+    eff = {"sources": {"A": {"value": 0.5, "error": 0.1}}}
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("visualize.plt.savefig", lambda p, **k: Path(p).touch())
+
+    efficiency_bar(eff, "foo.png")
+
+    assert Path("foo.png").exists()

--- a/visualize.py
+++ b/visualize.py
@@ -29,7 +29,8 @@ def cov_heatmap(cov_matrix, out_png, labels=None):
         for j in range(n):
             plt.text(j, i, f"{corr[i,j]:.2f}", ha="center", va="center", color="white" if abs(corr[i,j])>0.5 else "black", fontsize=8)
     plt.tight_layout()
-    os.makedirs(os.path.dirname(out_png), exist_ok=True)
+    dirpath = os.path.dirname(out_png) or "."
+    os.makedirs(dirpath, exist_ok=True)
     plt.savefig(out_png, dpi=300)
     plt.close()
     return corr
@@ -62,7 +63,8 @@ def efficiency_bar(eff_dict, out_png, config=None):
         for i, w in enumerate(weights):
             plt.text(i, values[i] + errors[i], f"{w:.2f}", ha="center", va="bottom", fontsize=8)
     plt.tight_layout()
-    os.makedirs(os.path.dirname(out_png), exist_ok=True)
+    dirpath = os.path.dirname(out_png) or "."
+    os.makedirs(dirpath, exist_ok=True)
     plt.savefig(out_png, dpi=300)
     plt.close()
     return None


### PR DESCRIPTION
## Summary
- handle bare filenames when saving from `cov_heatmap` and `efficiency_bar`
- test plot helpers using bare filenames

## Testing
- `pytest -k visualize -q`
- `pytest -k bare_filename -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852e5dff6e8832ba1c1283f6afbb8de