### PR TITLE
Improve burst filter

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -276,7 +276,7 @@ def load_events(csv_path):
     return df
 
 
-def apply_burst_filter(df, cfg, mode="rate"):
+def apply_burst_filter(df, cfg=None, mode="rate"):
     """Remove events occurring during high-rate bursts.
 
     ``mode`` selects the filtering strategy:
@@ -290,8 +290,8 @@ def apply_burst_filter(df, cfg, mode="rate"):
     ----------
     df : pandas.DataFrame
         Event data containing a ``timestamp`` column in seconds.
-    cfg : dict
-        Configuration dictionary.  Expected keys under ``burst_filter`` are
+    cfg : dict, optional
+        Configuration dictionary. Expected keys under ``burst_filter`` are
         ``burst_window_size_s``, ``rolling_median_window`` and
         ``burst_multiplier``.
 
@@ -303,6 +303,7 @@ def apply_burst_filter(df, cfg, mode="rate"):
         Number of events removed.
     """
 
+    cfg = cfg or {}
     bcfg = cfg.get("burst_filter", {})
     warnings.filterwarnings(
         "ignore",
@@ -325,18 +326,26 @@ def apply_burst_filter(df, cfg, mode="rate"):
             times = out_df["timestamp"].values.astype(float)
             if len(times) == 0:
                 return out_df, removed_total
-            window_end = times + float(micro_win)
-            j = np.searchsorted(times, window_end, side="right")
-            counts = j - np.arange(len(times))
-            starts = np.nonzero(counts >= int(micro_thr))[0]
 
-            if len(starts) > 0:
-                diff = np.zeros(len(times) + 1, dtype=int)
-                diff[starts] += 1
-                diff[j[starts]] -= 1
-                to_remove = np.cumsum(diff[:-1]) > 0
+            t_min = times.min()
+            t_max = times.max()
+            hist, edges = np.histogram(times, bins=np.arange(t_min, t_max + 2))
+            hist = hist.astype(int)
+
+            win = int(micro_win)
+            thr = int(micro_thr)
+            if win > 0:
+                csum = np.concatenate([[0], np.cumsum(hist)])
+                counts = csum[win:] - csum[:-win]
+                burst_bins = np.zeros_like(hist, dtype=bool)
+                for i, c in enumerate(counts):
+                    if c >= thr:
+                        burst_bins[i : i + win] = True
             else:
-                to_remove = np.zeros(len(times), dtype=bool)
+                burst_bins = np.zeros_like(hist, dtype=bool)
+
+            bin_idx = np.searchsorted(edges, times, side="right") - 1
+            to_remove = burst_bins[bin_idx]
 
             removed_total += int(to_remove.sum())
             out_df = out_df[~to_remove].reset_index(drop=True)

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -269,7 +269,7 @@ def test_apply_burst_filter_micro_burst():
     assert len(filtered) == len(times) - 4
 
 
-def test_apply_burst_filter_single_searchsorted(monkeypatch):
+def test_apply_burst_filter_histogram_called(monkeypatch):
     times = np.arange(100)
     df = pd.DataFrame(
         {
@@ -288,15 +288,49 @@ def test_apply_burst_filter_single_searchsorted(monkeypatch):
     }
 
     calls = {"n": 0}
-    orig_ss = np.searchsorted
+    orig_hist = np.histogram
 
     def wrapped(*args, **kwargs):
         calls["n"] += 1
-        return orig_ss(*args, **kwargs)
+        return orig_hist(*args, **kwargs)
 
-    monkeypatch.setattr(np, "searchsorted", wrapped)
+    monkeypatch.setattr(np, "histogram", wrapped)
     apply_burst_filter(df, cfg, mode="micro")
     assert calls["n"] == 1
+
+
+def test_apply_burst_filter_both_matches_sequential():
+    base = np.concatenate([np.arange(120), np.arange(130, 150)])
+    micro = np.full(6, 30)
+    rate = np.concatenate([
+        120 + i + 0.1 * np.arange(4)
+        for i in range(10)
+    ]).ravel()
+    times = np.concatenate([base, micro, rate])
+    df = pd.DataFrame(
+        {
+            "fUniqueID": range(len(times)),
+            "fBits": [0] * len(times),
+            "timestamp": times,
+            "adc": [1000] * len(times),
+            "fchannel": [1] * len(times),
+        }
+    )
+    cfg = {
+        "burst_filter": {
+            "burst_window_size_s": 10,
+            "rolling_median_window": 3,
+            "burst_multiplier": 3,
+            "micro_window_size_s": 1,
+            "micro_count_threshold": 5,
+        }
+    }
+
+    seq, rem1 = apply_burst_filter(df, cfg, mode="micro")
+    seq, rem2 = apply_burst_filter(seq, cfg, mode="rate")
+    both, total = apply_burst_filter(df, cfg, mode="both")
+    assert total == rem1 + rem2
+    assert both.reset_index(drop=True).equals(seq.reset_index(drop=True))
 
 
 def test_load_config_duplicate_keys(tmp_path):


### PR DESCRIPTION
## Summary
- update docs and logic to accept optional config
- rebuild micro-burst filtering using 1‑second histograms
- verify histogram usage and sequential behaviour in tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852e65a4644832b8e3d0b4d48de74f3