### PR TITLE
Improve linear background weighting

### DIFF
--- a/background.py
+++ b/background.py
@@ -16,6 +16,7 @@ def estimate_linear_background(energies, centroids, peak_width=0.3, bins="fd"):
         Half-width around each centroid to exclude from the fit.
     bins : int or sequence or str, optional
         Histogram bin specification passed to ``numpy.histogram``.
+        The fit is weighted by ``sqrt(counts)`` assuming Poisson statistics.
 
     Returns
     -------
@@ -29,6 +30,7 @@ def estimate_linear_background(energies, centroids, peak_width=0.3, bins="fd"):
 
     hist, edges = np.histogram(e, bins=bins)
     centers = 0.5 * (edges[:-1] + edges[1:])
+    weights = np.sqrt(np.clip(hist, 1, None))
     mask = np.ones_like(centers, dtype=bool)
     for mu in centroids.values():
         mask &= ~((centers >= mu - peak_width) & (centers <= mu + peak_width))
@@ -36,6 +38,6 @@ def estimate_linear_background(energies, centroids, peak_width=0.3, bins="fd"):
     if mask.sum() < 2:
         return 0.0, 0.0
 
-    coeffs = np.polyfit(centers[mask], hist[mask], 1)
+    coeffs = np.polyfit(centers[mask], hist[mask], 1, w=weights[mask])
     b1, b0 = coeffs
     return float(b0), float(b1)

--- a/tests/test_linear_background.py
+++ b/tests/test_linear_background.py
@@ -40,6 +40,14 @@ def test_estimate_linear_background():
     assert b1 != 0
 
 
+def test_linear_background_slope_unbiased():
+    """Estimated slope should match the true continuum slope."""
+    energies, peaks = generate_spectrum()
+    b0, b1 = estimate_linear_background(energies, peaks, peak_width=0.3)
+    assert b0 == pytest.approx(200.0, rel=0.05)
+    assert b1 == pytest.approx(8.0, rel=0.05)
+
+
 def test_auto_background_priors(monkeypatch, tmp_path):
     energies, peaks = generate_spectrum()
     rng = np.random.default_rng(1)


### PR DESCRIPTION
## Summary
- compute sqrt-count weights for the linear continuum fit
- weight by these in numpy.polyfit
- test slope against toy spectra

## Testing
- `pytest tests/test_linear_background.py::test_estimate_linear_background -q`
- `pytest tests/test_linear_background.py::test_linear_background_slope_unbiased -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852e68e0238832bb92fc825f6077187