### PR TITLE
Implement BLUE combine allow_negative kwarg

### DIFF
--- a/blue_combine.py
+++ b/blue_combine.py
@@ -6,8 +6,21 @@ import numpy as np
 
 from efficiency import blue_combine as _efficiency_blue_combine
 
-# Provide a local alias so this module can re-export ``blue_combine``.
-blue_combine = _efficiency_blue_combine
+
+def blue_combine(
+    values: Sequence[float],
+    errors: Sequence[float],
+    corr: Optional[np.ndarray] = None,
+    *,
+    allow_negative: bool = False,
+):
+    """Passthrough to :func:`efficiency.blue_combine` with kwarg support."""
+    return _efficiency_blue_combine(
+        values,
+        errors,
+        corr,
+        allow_negative=allow_negative,
+    )
 
 CovarianceMatrix = np.ndarray
 
@@ -18,8 +31,13 @@ class Measurements:
     corr: Optional[np.ndarray] = None
 
 
-def BLUE(measurements: Measurements):
+def BLUE(measurements: Measurements, *, allow_negative: bool = False):
     """Return BLUE combination of the given measurements."""
-    return blue_combine(measurements.values, measurements.errors, measurements.corr)
+    return blue_combine(
+        measurements.values,
+        measurements.errors,
+        measurements.corr,
+        allow_negative=allow_negative,
+    )
 
 __all__ = ["blue_combine", "BLUE", "Measurements", "CovarianceMatrix"]

--- a/tests/test_blue_combine_module.py
+++ b/tests/test_blue_combine_module.py
@@ -17,6 +17,7 @@ def test_blue_combine_module_runs():
     assert combined == pytest.approx(expected)
     assert sigma == pytest.approx(expected_sigma)
     assert len(weights) == 2
+    assert weights.sum() == pytest.approx(1.0)
 
 
 def test_blue_combine_wrapper_dataclass():

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -51,6 +51,7 @@ def test_blue_combine_uncorrelated():
     assert combined == pytest.approx(expected)
     assert sigma == pytest.approx(expected_sigma)
     assert len(weights) == 3
+    assert weights.sum() == pytest.approx(1.0)
 
 
 def test_blue_combine_correlated():
@@ -72,5 +73,13 @@ def test_blue_combine_negative_weights_warning():
     errs = np.array([0.1, 0.2])
     corr = np.array([[1.0, 0.99], [0.99, 1.0]])
     with pytest.warns(UserWarning):
-        _, _, weights = blue_combine(vals, errs, corr)
+        _, _, weights = blue_combine(vals, errs, corr, allow_negative=True)
     assert np.any(weights < 0)
+
+
+def test_blue_combine_negative_weights_error():
+    vals = np.array([1.0, 2.0])
+    errs = np.array([0.1, 0.2])
+    corr = np.array([[1.0, 0.99], [0.99, 1.0]])
+    with pytest.raises(ValueError):
+        blue_combine(vals, errs, corr)


### PR DESCRIPTION
## Summary
- improve BLUE weight handling
- extend `blue_combine` API with `allow_negative` arg and renormalised weights
- expose new argument through `blue_combine` compat layer
- test for negative weights raising and weight sum normalisation

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852e66d59e4832b9b8e44dcf7536aea