### PR TITLE
Fix headless plotting setup

### DIFF
--- a/plot_utils.py
+++ b/plot_utils.py
@@ -4,8 +4,8 @@
 
 import os
 import numpy as np
-import matplotlib
-matplotlib.use('Agg', force=True)
+import matplotlib as _mpl
+_mpl.use("Agg")
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 import matplotlib.ticker as mticker

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -4,6 +4,7 @@ import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+import plot_utils  # ensure matplotlib backend is set
 from visualize import cov_heatmap, efficiency_bar
 
 

--- a/visualize.py
+++ b/visualize.py
@@ -1,7 +1,5 @@
 import os
 import numpy as np
-import matplotlib
-matplotlib.use('Agg', force=True)
 import matplotlib.pyplot as plt
 from color_schemes import COLOR_SCHEMES
 


### PR DESCRIPTION
## Summary
- set matplotlib backend to Agg in `plot_utils`
- remove duplicate backend configuration in `visualize.py`
- ensure tests importing `visualize.py` load `plot_utils` first

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685332d50e8c832bbd902ef1dcadb89d