### PR TITLE
Disable quadratic calibration

### DIFF
--- a/calibration.py
+++ b/calibration.py
@@ -2,6 +2,7 @@ import numpy as np
 from scipy.signal import find_peaks
 from scipy.optimize import curve_fit
 from scipy.stats import exponnorm
+import logging
 from constants import (
     _TAU_MIN,
     DEFAULT_NOISE_CUTOFF,
@@ -221,7 +222,15 @@ def calibrate_run(adc_values, config, hist_bins=None):
     E214 = energies["Po214"]
     E218 = energies["Po218"]
 
-    quadratic = bool(config.get("calibration", {}).get("quadratic", False))
+    user_requested_quadratic = bool(
+        config.get("calibration", {}).get("quadratic", False)
+    )
+    if user_requested_quadratic:
+        logging.warning(
+            "Quadratic calibration is currently disabled. Using linear calibration instead."
+        )
+
+    quadratic = False
 
     if quadratic:
         # Solve for quadratic coefficients a2, a, c using all three peaks


### PR DESCRIPTION
## Summary
- disable quadratic calibration warning users when requested
- ensure linear calibration is always used
- update tests for the warning and zero quadratic coefficient

## Testing
- `pytest tests/test_calibration.py::test_calibrate_run_quadratic_option -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853337445ec832baa4389778a8a8fae