### PR TITLE
Add weight normalization test for blue_combine

### DIFF
--- a/tests/test_blue.py
+++ b/tests/test_blue.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from blue_combine import blue_combine
+
+
+def test_blue_weights_normalization():
+    vals = np.array([1.0, 2.0, 3.0])
+    errs = np.array([0.1, 0.2, 0.3])
+    _, _, weights = blue_combine(vals, errs)
+    assert abs(np.sum(weights) - 1) < 1e-9


### PR DESCRIPTION
## Summary
- add a basic test verifying that `blue_combine` weights sum to one

## Testing
- `pytest tests/test_blue.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685333ae9618832ba385861bfeb2a77c