### PR TITLE
Update efficiency docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ which will be combined.  When the configuration file provides an
     ]
 }
 ```
+Here `activity_bq` is the spike activity expressed in decays per second (Bq).
 
 `analyze.py` stores the calculated values and their BLUE combination in
 `summary.json` under the `efficiency` key.


### PR DESCRIPTION
## Summary
- clarify the `activity_bq` field in the efficiency example

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685333df4ccc832ba5114908bbd79cea