### PR TITLE
Fix docstring for calc_spike_efficiency

### DIFF
--- a/efficiency.py
+++ b/efficiency.py
@@ -26,7 +26,7 @@ def calc_spike_efficiency(
     counts : float
         Number of counts observed during the spike run.
     activity_bq : float
-        Known spike activity in Bq.
+        Known spike activity in decays/s (Bq).
     live_time_s : float
         Exposure time in seconds.
 


### PR DESCRIPTION
## Summary
- clarify units in `calc_spike_efficiency` docstring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685333e146dc832ba39cf278a33fcdab