### PR TITLE
Add pedestal_cut parameter and test

### DIFF
--- a/baseline_noise.py
+++ b/baseline_noise.py
@@ -15,7 +15,12 @@ def _exponential(x, A, k):
 
 
 def estimate_baseline_noise(
-    adc_values, peak_adc=None, nbins=50, model="constant", return_mask=False
+    adc_values,
+    peak_adc=None,
+    pedestal_cut=None,
+    nbins=50,
+    model="constant",
+    return_mask=False,
 ):
     """Estimate electronic noise level from baseline ADC values.
 
@@ -25,6 +30,8 @@ def estimate_baseline_noise(
         Raw ADC values from the baseline period.
     peak_adc : float, optional
         Location of the Po-210 peak. Values above this are ignored.
+    pedestal_cut : float, optional
+        Lower threshold on ADC values. Values below this are ignored.
     nbins : int, optional
         Number of histogram bins.
     model : {"constant", "exponential"}
@@ -45,6 +52,8 @@ def estimate_baseline_noise(
     mask = np.ones_like(adc_arr, dtype=bool)
     if peak_adc is not None:
         mask &= adc_arr < peak_adc
+    if pedestal_cut is not None:
+        mask &= adc_arr > pedestal_cut
     adc = adc_arr[mask]
     if adc.size == 0:
         if return_mask:

--- a/tests/test_baseline_noise.py
+++ b/tests/test_baseline_noise.py
@@ -47,3 +47,25 @@ def test_unknown_model_raises():
     adc = rng.uniform(0, 200, 100)
     with pytest.raises(ValueError):
         estimate_baseline_noise(adc, peak_adc=250, nbins=20, model="unknown")
+
+
+def test_pedestal_cut_below_peak_no_effect():
+    rng = np.random.default_rng(3)
+    adc = rng.uniform(900, 1100, 1000)
+    level_cut, params_cut, mask_cut = estimate_baseline_noise(
+        adc,
+        peak_adc=1200,
+        pedestal_cut=50,
+        nbins=30,
+        model="constant",
+        return_mask=True,
+    )
+    level_no, params_no, mask_no = estimate_baseline_noise(
+        adc,
+        peak_adc=1200,
+        nbins=30,
+        model="constant",
+        return_mask=True,
+    )
+    assert level_cut == pytest.approx(level_no)
+    assert np.array_equal(mask_cut, mask_no)


### PR DESCRIPTION
## Summary
- extend `estimate_baseline_noise` with `pedestal_cut` option
- add unit test verifying pedestal cut below data range has no effect

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685333ef1498832ba48562f1bab245a2