### PR TITLE
Move known energies constant

### DIFF
--- a/calibration.py
+++ b/calibration.py
@@ -6,21 +6,9 @@ from constants import (
     _TAU_MIN,
     DEFAULT_NOISE_CUTOFF,
     DEFAULT_NOMINAL_ADC,
+    DEFAULT_KNOWN_ENERGIES,
     safe_exp as _safe_exp,
 )
-
-
-
-
-# Known α energies (MeV) from config or central constants:
-# Default alpha energies (MeV) used for calibration when not specified
-# in the configuration file.  Values are Po-210, Po-218 and Po-214
-DEFAULT_KNOWN_ENERGIES = {
-    "Po210": 5.304,  # MeV
-    "Po218": 6.002,  # MeV
-    "Po214": 7.687,  # MeV  (use the SNOLAB‐observed centroids if desired)
-}
-
 
 def emg_left(x, mu, sigma, tau):
     """Exponentially modified Gaussian (left-skewed) PDF.

--- a/constants.py
+++ b/constants.py
@@ -41,6 +41,15 @@ DEFAULT_NOMINAL_ADC = {
 # specify ``spectral_fit.expected_peaks``.
 DEFAULT_ADC_CENTROIDS = DEFAULT_NOMINAL_ADC.copy()
 
+# Default alpha energies (MeV) used when calibration configuration does not
+# specify ``known_energies``.  Values correspond to the Po-210, Po-218 and
+# Po-214 peaks.
+DEFAULT_KNOWN_ENERGIES = {
+    "Po210": 5.304,  # MeV
+    "Po218": 6.002,  # MeV
+    "Po214": 7.687,  # MeV
+}
+
 from dataclasses import dataclass
 
 
@@ -111,6 +120,7 @@ __all__ = [
     "CURVE_FIT_MAX_EVALS",
     "DEFAULT_NOMINAL_ADC",
     "DEFAULT_ADC_CENTROIDS",
+    "DEFAULT_KNOWN_ENERGIES",
     "safe_exp",
     "_safe_exp",
     "NuclideConst",

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -9,9 +9,9 @@ from calibration import (
     apply_calibration,
     emg_left,
     gaussian,
-    DEFAULT_KNOWN_ENERGIES,
     derive_calibration_constants,
 )
+from constants import DEFAULT_KNOWN_ENERGIES
 
 
 def test_two_point_calibration():


### PR DESCRIPTION
## Summary
- centralize default alpha energies in constants
- reference constants.DEFAULT_KNOWN_ENERGIES throughout code

## Testing
- `pip install -r requirements.txt`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_685333b578e8832b948265bd328c2900