### PR TITLE
Fix keV conversion in scan_systematics

### DIFF
--- a/systematics.py
+++ b/systematics.py
@@ -117,7 +117,7 @@ def scan_systematics(
             delta = val * priors[key][0]
         elif full_key.endswith("_keV"):
             key = full_key[:-4]
-            delta = val / 1000.0  # convert keV → MeV
+            delta = val * 1e-3  # convert keV to MeV
         else:
             key = full_key
             delta = val


### PR DESCRIPTION
## Summary
- adjust the keV conversion to use multiplication

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685334a3b20c832b9b5e9b847bc2e97a