### PR TITLE
Add repeatability test for scan_systematics

### DIFF
--- a/tests/test_systematics.py
+++ b/tests/test_systematics.py
@@ -185,3 +185,18 @@ def test_analyze_systematics_skip_unknown(tmp_path, monkeypatch):
     analyze.main()
 
     assert captured.get("sigma") == {}
+
+
+def test_scan_systematics_repeatable():
+    priors = {"x": (1.0, 0.1)}
+
+    def fit_func(p):
+        return {"x": p["x"][0] + 1.0}
+
+    shifts = {"x": 0.5}
+
+    d1, unc1 = scan_systematics(fit_func, priors, shifts)
+    d2, unc2 = scan_systematics(fit_func, priors, shifts)
+
+    assert d1 == d2
+    assert unc1 == unc2


### PR DESCRIPTION
## Summary
- ensure scan_systematics gives the same result on repeated calls
- add simple deterministic fit function

## Testing
- `pytest tests/test_systematics.py::test_scan_systematics_repeatable -q`

------
https://chatgpt.com/codex/tasks/task_e_685334a2e944832b9fb72d7e48bafe66