### PR TITLE
Update copy_config behavior and adjust summary creation

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1648,8 +1648,9 @@ def main(argv=None):
     if weights is not None:
         summary["efficiency"]["blue_weights"] = list(weights)
 
+    results_dir = args.output_dir / (args.job_id or now_str)
+    copy_config(results_dir, cfg)
     out_dir = write_summary(args.output_dir, summary, args.job_id or now_str)
-    copy_config(out_dir, cfg)
 
     # Generate plots now that the output directory exists
     if spec_plot_data:

--- a/io_utils.py
+++ b/io_utils.py
@@ -427,8 +427,8 @@ def copy_config(output_dir, config_path):
     Parameters
     ----------
     output_dir : Path or str
-        Path to the directory returned by :func:`write_summary`.  This
-        directory must contain ``summary.json``.
+        Path to the directory where ``config_used.json`` should be placed.
+        The directory will be created if it does not already exist.
     config_path : Path, str or dict
         Configuration file to copy or configuration dictionary.
 
@@ -439,15 +439,11 @@ def copy_config(output_dir, config_path):
     """
 
     output_path = Path(output_dir)
+    # Create the destination folder. "exist_ok=False" ensures we do not
+    # accidentally overwrite an existing results directory.
+    output_path.mkdir(parents=True, exist_ok=False)
 
-    if not (output_path / "summary.json").is_file():
-        raise RuntimeError(
-            f"{output_dir} does not contain summary.json; provide the timestamped results folder."
-        )
-
-    dest_folder = output_path
-
-    dest_path = dest_folder / "config_used.json"
+    dest_path = output_path / "config_used.json"
     if isinstance(config_path, (str, Path)):
         shutil.copyfile(Path(config_path), dest_path)
         logger.info(f"Copied config {config_path} -> {dest_path}")

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -165,15 +165,15 @@ def test_write_summary_and_copy_config(tmp_path):
     summary = {"a": 1, "b": 2}
     outdir = tmp_path / "out"
     ts = "19700101T000000Z"
-    results = write_summary(outdir, summary, ts)
-    assert (Path(results) / "summary.json").exists()
-    # Create dummy config and copy
+    results_dir = outdir / ts
     cfg = {"test": 1}
     cp = tmp_path / "cfg.json"
     with open(cp, "w") as f:
         json.dump(cfg, f)
-    dest = copy_config(results, cp)
+    dest = copy_config(results_dir, cp)
     assert Path(dest).exists()
+    results = write_summary(outdir, summary, ts)
+    assert (Path(results) / "summary.json").exists()
 
 
 def test_write_summary_with_nullable_integers(tmp_path):


### PR DESCRIPTION
## Summary
- allow `copy_config` to create the destination folder and no longer require `summary.json`
- call `copy_config` before `write_summary` in `analyze.main`
- update tests for the new copy sequence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853348eee60832b915e8780fc1b1c94