### PR TITLE
Enforce unique results folder creation

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1648,7 +1648,14 @@ def main(argv=None):
     if weights is not None:
         summary["efficiency"]["blue_weights"] = list(weights)
 
-    out_dir = write_summary(args.output_dir, summary, args.job_id or now_str)
+    try:
+        out_dir = write_summary(args.output_dir, summary, args.job_id or now_str)
+    except FileExistsError:
+        print(
+            f"ERROR: Results folder '{Path(args.output_dir)/(args.job_id or now_str)}' already exists"
+        )
+        sys.exit(1)
+
     copy_config(out_dir, cfg)
 
     # Generate plots now that the output directory exists

--- a/io_utils.py
+++ b/io_utils.py
@@ -406,7 +406,7 @@ def write_summary(output_dir, summary_dict, timestamp=None):
         timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
     output_path = Path(output_dir)
     results_folder = output_path / timestamp
-    ensure_dir(results_folder)
+    results_folder.mkdir(parents=True, exist_ok=False)
 
     summary_path = results_folder / "summary.json"
 


### PR DESCRIPTION
## Summary
- ensure write_summary fails if output folder already exists
- propagate FileExistsError handling to CLI

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853348e6fb8832b94ed2ca57255a777