### PR TITLE
Add pedestal_cut to baseline noise estimation

### DIFF
--- a/baseline_noise.py
+++ b/baseline_noise.py
@@ -15,7 +15,12 @@ def _exponential(x, A, k):
 
 
 def estimate_baseline_noise(
-    adc_values, peak_adc=None, nbins=50, model="constant", return_mask=False
+    adc_values,
+    peak_adc=None,
+    pedestal_cut=None,
+    nbins=50,
+    model="constant",
+    return_mask=False,
 ):
     """Estimate electronic noise level from baseline ADC values.
 
@@ -25,6 +30,9 @@ def estimate_baseline_noise(
         Raw ADC values from the baseline period.
     peak_adc : float, optional
         Location of the Po-210 peak. Values above this are ignored.
+    pedestal_cut : float, optional
+        Minimum ADC value to include in the fit. Values below this are
+        ignored.
     nbins : int, optional
         Number of histogram bins.
     model : {"constant", "exponential"}
@@ -43,6 +51,8 @@ def estimate_baseline_noise(
     """
     adc_arr = np.asarray(adc_values, dtype=float)
     mask = np.ones_like(adc_arr, dtype=bool)
+    if pedestal_cut is not None:
+        mask &= adc_arr > pedestal_cut
     if peak_adc is not None:
         mask &= adc_arr < peak_adc
     adc = adc_arr[mask]


### PR DESCRIPTION
## Summary
- extend `estimate_baseline_noise` to accept optional `pedestal_cut`
- document new parameter in the docstring
- mask ADC values below `pedestal_cut`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685333f0d3d4832b8ee09736b3346f11