### PR TITLE
Add apply_palette utility for color cycles

### DIFF
--- a/color_schemes.py
+++ b/color_schemes.py
@@ -1,6 +1,9 @@
 # Color palettes for plotting
 # Each scheme maps element names to matplotlib color names.
 
+import matplotlib.pyplot as plt
+from matplotlib import cycler
+
 COLOR_SCHEMES = {
     "default": {
         "Po214": "tab:red",
@@ -33,3 +36,29 @@ COLOR_SCHEMES = {
         "hist": "lightgray",
     },
 }
+
+
+def apply_palette(name: str = "default") -> dict:
+    """Apply the color palette ``name`` to Matplotlib.
+
+    This sets :data:`matplotlib.pyplot.rcParams['axes.prop_cycle']` so that
+    subsequent plots use the palette's colors in order.
+
+    Parameters
+    ----------
+    name : str, optional
+        Name of the palette in :data:`COLOR_SCHEMES`.  Defaults to
+        ``"default"``.
+
+    Returns
+    -------
+    dict
+        The palette dictionary that was applied.
+    """
+
+    palette = COLOR_SCHEMES.get(str(name), COLOR_SCHEMES["default"])
+    plt.rcParams["axes.prop_cycle"] = cycler("color", list(palette.values()))
+    return palette
+
+
+__all__ = ["COLOR_SCHEMES", "apply_palette"]

--- a/tests/test_color_schemes.py
+++ b/tests/test_color_schemes.py
@@ -1,4 +1,15 @@
 import color_schemes as cs
+import matplotlib.pyplot as plt
 
 def test_po214_color_defined():
     assert hasattr(cs, "COLOR_SCHEMES") and "Po214" in cs.COLOR_SCHEMES["default"]
+
+
+def test_apply_palette_sets_cycle():
+    original = plt.rcParams["axes.prop_cycle"]
+    try:
+        palette = cs.apply_palette("colorblind")
+        cycle_colors = plt.rcParams["axes.prop_cycle"].by_key().get("color", [])
+        assert list(palette.values()) == cycle_colors
+    finally:
+        plt.rcParams["axes.prop_cycle"] = original


### PR DESCRIPTION
## Summary
- add `apply_palette` function to `color_schemes`
- expose palette application in module exports
- test that the color cycle is configured correctly

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685333b0c5a0832ba69e9566ad9f53b0