### PR TITLE
Add palette tests

### DIFF
--- a/color_schemes.py
+++ b/color_schemes.py
@@ -33,3 +33,23 @@ COLOR_SCHEMES = {
         "hist": "lightgray",
     },
 }
+
+
+def apply_palette(name: str = "default") -> None:
+    """Apply the given palette to ``matplotlib``.
+
+    Parameters
+    ----------
+    name:
+        Name of the palette to apply. If the palette does not exist the
+        ``default`` palette is used.
+    """
+
+    from cycler import cycler
+    from matplotlib import pyplot as plt
+    from matplotlib.colors import to_hex
+
+    palette = COLOR_SCHEMES.get(name, COLOR_SCHEMES["default"])
+    colors = [to_hex(c) for c in palette.values()]
+    plt.rcParams["axes.prop_cycle"] = cycler(color=colors)
+

--- a/tests/test_color_schemes.py
+++ b/tests/test_color_schemes.py
@@ -1,4 +1,27 @@
+import warnings
+
+import matplotlib.pyplot as plt
+from matplotlib.colors import to_hex
+import pytest
+
 import color_schemes as cs
 
 def test_po214_color_defined():
     assert hasattr(cs, "COLOR_SCHEMES") and "Po214" in cs.COLOR_SCHEMES["default"]
+
+
+@pytest.mark.parametrize("name", cs.COLOR_SCHEMES.keys())
+def test_palette_values_are_hex(name):
+    palette = cs.COLOR_SCHEMES[name]
+    for value in palette.values():
+        color = to_hex(value)
+        assert color.startswith("#") and len(color) == 7
+
+
+def test_apply_palette_no_warnings():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("error")
+        cs.apply_palette("default")
+    assert not w
+    cycle = plt.rcParams["axes.prop_cycle"]
+    assert cycle.keys == {"color"}


### PR DESCRIPTION
## Summary
- validate that all palette colors can be expressed in hex
- provide `apply_palette` helper for matplotlib
- test that no warnings are raised when applying palette

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685333b1ad24832bb473eddff3ad79d4