### PR TITLE
Convert palette to hex colors

### DIFF
--- a/color_schemes.py
+++ b/color_schemes.py
@@ -1,16 +1,16 @@
 # Color palettes for plotting
-# Each scheme maps element names to matplotlib color names.
+# Each scheme maps element names to explicit hex color codes.
 
 COLOR_SCHEMES = {
     "default": {
-        "Po214": "tab:red",
-        "Po218": "tab:blue",
-        "Po210": "tab:green",
-        "radon_activity": "tab:purple",
-        "equivalent_air": "tab:green",
-        "efficiency_bar": "tab:blue",
-        "fit": "red",
-        "hist": "gray",
+        "Po214": "#d62728",
+        "Po218": "#1f77b4",
+        "Po210": "#2ca02c",
+        "radon_activity": "#9467bd",
+        "equivalent_air": "#2ca02c",
+        "efficiency_bar": "#1f77b4",
+        "fit": "#ff0000",
+        "hist": "#808080",
     },
     "colorblind": {
         "Po214": "#D55E00",  # orange-red
@@ -20,16 +20,16 @@ COLOR_SCHEMES = {
         "equivalent_air": "#009E73",
         "efficiency_bar": "#0072B2",
         "fit": "#D55E00",
-        "hist": "gray",
+        "hist": "#808080",
     },
     "grayscale": {
-        "Po214": "black",
-        "Po218": "dimgray",
-        "Po210": "gray",
-        "radon_activity": "black",
-        "equivalent_air": "gray",
-        "efficiency_bar": "dimgray",
-        "fit": "black",
-        "hist": "lightgray",
+        "Po214": "#000000",
+        "Po218": "#696969",
+        "Po210": "#808080",
+        "radon_activity": "#000000",
+        "equivalent_air": "#808080",
+        "efficiency_bar": "#696969",
+        "fit": "#000000",
+        "hist": "#d3d3d3",
     },
 }

--- a/plot_utils.py
+++ b/plot_utils.py
@@ -239,9 +239,9 @@ def plot_time_series(
     palette_name = str(config.get("palette", "default"))
     palette = COLOR_SCHEMES.get(palette_name, COLOR_SCHEMES["default"])
     colors = {
-        "Po214": palette.get("Po214", "tab:red"),
-        "Po218": palette.get("Po218", "tab:blue"),
-        "Po210": palette.get("Po210", "tab:green"),
+        "Po214": palette.get("Po214", "#d62728"),
+        "Po218": palette.get("Po218", "#1f77b4"),
+        "Po210": palette.get("Po210", "#2ca02c"),
     }
 
     for iso in iso_list:
@@ -416,7 +416,7 @@ def plot_spectrum(
 
     palette_name = str(config.get("palette", "default")) if config else "default"
     palette = COLOR_SCHEMES.get(palette_name, COLOR_SCHEMES["default"])
-    hist_color = palette.get("hist", "gray")
+    hist_color = palette.get("hist", "#808080")
     ax_main.bar(centers, hist, width=width, color=hist_color, alpha=0.7, label="Data")
 
     # If an explicit Po-210 window is provided, focus the x-axis on that region
@@ -440,7 +440,7 @@ def plot_spectrum(
                 y += amp / (sigma_E * np.sqrt(2 * np.pi)) * np.exp(-0.5 * ((x - mu) / sigma_E) ** 2)
         palette_name = str(config.get("palette", "default")) if config else "default"
         palette = COLOR_SCHEMES.get(palette_name, COLOR_SCHEMES["default"])
-        fit_color = palette.get("fit", "red")
+        fit_color = palette.get("fit", "#ff0000")
         avg_width = float(np.mean(width))
         ax_main.plot(x, y * avg_width, color=fit_color, lw=2, label="Fit")
 
@@ -464,7 +464,7 @@ def plot_spectrum(
                 color=hist_color,
                 alpha=0.7,
             )
-            ax_res.axhline(0.0, color="black", lw=1)
+            ax_res.axhline(0.0, color="#000000", lw=1)
             ax_res.set_ylabel("Residuals")
 
     ax_main.set_ylabel("Counts per bin")
@@ -507,7 +507,7 @@ def plot_radon_activity(times, activity, errors, out_png, config=None):
     plt.figure(figsize=(8, 4))
     palette_name = str(config.get("palette", "default")) if config else "default"
     palette = COLOR_SCHEMES.get(palette_name, COLOR_SCHEMES["default"])
-    color = palette.get("radon_activity", "tab:purple")
+    color = palette.get("radon_activity", "#9467bd")
     plt.errorbar(times_dt, activity, yerr=errors, fmt="o-", color=color)
     plt.xlabel("Time (UTC)")
     plt.ylabel("Radon Activity (Bq)")
@@ -575,7 +575,7 @@ def plot_equivalent_air(times, volumes, errors, conc, out_png, config=None):
     plt.figure(figsize=(8, 4))
     palette_name = str(config.get("palette", "default")) if config else "default"
     palette = COLOR_SCHEMES.get(palette_name, COLOR_SCHEMES["default"])
-    color = palette.get("equivalent_air", "tab:green")
+    color = palette.get("equivalent_air", "#2ca02c")
     plt.errorbar(times_dt, volumes, yerr=errors, fmt="o-", color=color)
     plt.xlabel("Time")
     plt.ylabel("Equivalent Air Volume")
@@ -635,7 +635,7 @@ def plot_radon_trend(times, activity, out_png, config=None):
     plt.figure(figsize=(8, 4))
     palette_name = str(config.get("palette", "default")) if config else "default"
     palette = COLOR_SCHEMES.get(palette_name, COLOR_SCHEMES["default"])
-    color = palette.get("radon_activity", "tab:purple")
+    color = palette.get("radon_activity", "#9467bd")
     plt.plot(times_dt, activity, "o-", color=color)
     plt.xlabel("Time")
     plt.ylabel("Radon Activity (Bq)")

--- a/visualize.py
+++ b/visualize.py
@@ -27,7 +27,15 @@ def cov_heatmap(cov_matrix, out_png, labels=None):
     plt.yticks(range(n), labels)
     for i in range(n):
         for j in range(n):
-            plt.text(j, i, f"{corr[i,j]:.2f}", ha="center", va="center", color="white" if abs(corr[i,j])>0.5 else "black", fontsize=8)
+            plt.text(
+                j,
+                i,
+                f"{corr[i,j]:.2f}",
+                ha="center",
+                va="center",
+                color="#ffffff" if abs(corr[i,j]) > 0.5 else "#000000",
+                fontsize=8,
+            )
     plt.tight_layout()
     dirpath = os.path.dirname(out_png) or "."
     os.makedirs(dirpath, exist_ok=True)
@@ -53,7 +61,7 @@ def efficiency_bar(eff_dict, out_png, config=None):
     plt.figure(figsize=(6, 4))
     palette_name = str(config.get("palette", "default")) if config else "default"
     palette = COLOR_SCHEMES.get(palette_name, COLOR_SCHEMES["default"])
-    color = palette.get("efficiency_bar", "tab:blue")
+    color = palette.get("efficiency_bar", "#1f77b4")
     plt.bar(x, values, yerr=errors, capsize=4, color=color, alpha=0.7)
     plt.xticks(x, names, rotation=45, ha="right")
     plt.ylabel("Efficiency")


### PR DESCRIPTION
## Summary
- convert color scheme palette entries to explicit hex codes
- adapt plotting functions to use hex-based defaults
- set heatmap text colors with hex codes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685333b286a4832b9d9135ddcc0d44ec