### PR TITLE
Enforce unique output directories

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1648,7 +1648,13 @@ def main(argv=None):
     if weights is not None:
         summary["efficiency"]["blue_weights"] = list(weights)
 
-    out_dir = write_summary(args.output_dir, summary, args.job_id or now_str)
+    try:
+        out_dir = write_summary(args.output_dir, summary, args.job_id or now_str)
+    except FileExistsError:
+        print(
+            f"ERROR: Output directory already exists: {Path(args.output_dir) / (args.job_id or now_str)}"
+        )
+        sys.exit(1)
     copy_config(out_dir, cfg)
 
     # Generate plots now that the output directory exists

--- a/io_utils.py
+++ b/io_utils.py
@@ -394,7 +394,7 @@ def write_summary(output_dir, summary_dict, timestamp=None):
         timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
     output_path = Path(output_dir)
     results_folder = output_path / timestamp
-    ensure_dir(results_folder)
+    results_folder.mkdir(parents=True, exist_ok=False)
 
     summary_path = results_folder / "summary.json"
 

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -188,6 +188,16 @@ def test_write_summary_with_nan_values(tmp_path):
     assert loaded["list"] == [None, 1.0]
 
 
+def test_write_summary_existing_folder(tmp_path):
+    summary = {"a": 1}
+    outdir = tmp_path / "out_exists"
+    ts = "19700101T000003Z"
+    existing = outdir / ts
+    existing.mkdir(parents=True)
+    with pytest.raises(FileExistsError):
+        write_summary(outdir, summary, ts)
+
+
 def test_apply_burst_filter_no_removal():
     df = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- make `write_summary` raise `FileExistsError` if results folder already exists
- handle that error in `analyze.py`
- add regression test for the new behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685333d6e5fc832ba1f18435352b9bd7