### PR TITLE
Update copy_config and order in analyze

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1648,8 +1648,10 @@ def main(argv=None):
     if weights is not None:
         summary["efficiency"]["blue_weights"] = list(weights)
 
-    out_dir = write_summary(args.output_dir, summary, args.job_id or now_str)
-    copy_config(out_dir, cfg)
+    ts_id = args.job_id or now_str
+    results_dir = args.output_dir / ts_id
+    copy_config(results_dir, cfg)
+    out_dir = write_summary(args.output_dir, summary, ts_id)
 
     # Generate plots now that the output directory exists
     if spec_plot_data:

--- a/io_utils.py
+++ b/io_utils.py
@@ -409,14 +409,13 @@ def write_summary(output_dir, summary_dict, timestamp=None):
 
 
 def copy_config(output_dir, config_path):
-    """
-    Copy the used config JSON into the timestamped results folder.
+    """Create ``output_dir`` and save the used config JSON there.
 
     Parameters
     ----------
     output_dir : Path or str
-        Path to the directory returned by :func:`write_summary`.  This
-        directory must contain ``summary.json``.
+        Destination directory to create. ``config_used.json`` will be
+        written inside this folder.
     config_path : Path, str or dict
         Configuration file to copy or configuration dictionary.
 
@@ -427,15 +426,9 @@ def copy_config(output_dir, config_path):
     """
 
     output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=False)
 
-    if not (output_path / "summary.json").is_file():
-        raise RuntimeError(
-            f"{output_dir} does not contain summary.json; provide the timestamped results folder."
-        )
-
-    dest_folder = output_path
-
-    dest_path = dest_folder / "config_used.json"
+    dest_path = output_path / "config_used.json"
     if isinstance(config_path, (str, Path)):
         shutil.copyfile(Path(config_path), dest_path)
         logger.info(f"Copied config {config_path} -> {dest_path}")

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -148,15 +148,15 @@ def test_write_summary_and_copy_config(tmp_path):
     summary = {"a": 1, "b": 2}
     outdir = tmp_path / "out"
     ts = "19700101T000000Z"
-    results = write_summary(outdir, summary, ts)
-    assert (Path(results) / "summary.json").exists()
-    # Create dummy config and copy
     cfg = {"test": 1}
     cp = tmp_path / "cfg.json"
     with open(cp, "w") as f:
         json.dump(cfg, f)
-    dest = copy_config(results, cp)
+    results_dir = outdir / ts
+    dest = copy_config(results_dir, cp)
     assert Path(dest).exists()
+    results = write_summary(outdir, summary, ts)
+    assert (Path(results) / "summary.json").exists()
 
 
 def test_write_summary_with_nullable_integers(tmp_path):


### PR DESCRIPTION
## Summary
- make `copy_config` create results directory and not require summary
- write config before summary in analyze
- adjust unit tests for new order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685333d6f2a0832b8726713bc14d33a5