### PR TITLE
Handle zero uncertainties in radon activity

### DIFF
--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -63,14 +63,14 @@ def test_compute_radon_activity_only_218_error_eff_not_one():
 
 def test_compute_radon_activity_only_214_error_zero_218_error():
     a, s = compute_radon_activity(10.0, 0.0, 1.0, 12.0, 2.0, 1.0)
-    assert a == pytest.approx((10.0 + 12.0) / 2)
-    assert s == pytest.approx(1.0)
+    assert a == pytest.approx(10.0)
+    assert s == pytest.approx(0.0)
 
 
 def test_compute_radon_activity_only_218_error_zero_214_error():
     a, s = compute_radon_activity(10.0, 1.0, 1.0, 12.0, 0.0, 1.0)
-    assert a == pytest.approx((10.0 + 12.0) / 2)
-    assert s == pytest.approx(0.5)
+    assert a == pytest.approx(12.0)
+    assert s == pytest.approx(0.0)
 
 
 def test_compute_radon_activity_mixed_error_sign():


### PR DESCRIPTION
## Summary
- handle non-negative errors in `compute_radon_activity`
- treat zero uncertainties as exact measurements
- document handling of negative and zero uncertainties
- update unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685334978bc0832b808bff6f20f11e7d