### PR TITLE
Link noise threshold to baseline estimation

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -593,10 +593,12 @@ def main(argv=None):
     # 2a. Pedestal / electronic-noise cut (integer ADC)
     # ───────────────────────────────────────────────
     noise_thr = cfg.get("calibration", {}).get("noise_cutoff")
+    noise_thr_val = None
     n_removed_noise = 0
     if noise_thr is not None:
         try:
             thr_val = int(noise_thr)
+            noise_thr_val = thr_val
         except (ValueError, TypeError):
             logging.warning(f"Invalid noise_cutoff '{noise_thr}' - skipping noise cut")
         else:
@@ -898,6 +900,7 @@ def main(argv=None):
                     base_events["adc"].values,
                     peak_adc=peak_adc,
                     return_mask=True,
+                    pedestal_cut=noise_thr_val,
                 )
                 if isinstance(result, tuple) and len(result) == 3:
                     noise_level, _, mask_noise = result

--- a/baseline_noise.py
+++ b/baseline_noise.py
@@ -15,7 +15,13 @@ def _exponential(x, A, k):
 
 
 def estimate_baseline_noise(
-    adc_values, peak_adc=None, nbins=50, model="constant", return_mask=False
+    adc_values,
+    peak_adc=None,
+    nbins=50,
+    model="constant",
+    return_mask=False,
+    *,
+    pedestal_cut=None,
 ):
     """Estimate electronic noise level from baseline ADC values.
 
@@ -29,6 +35,9 @@ def estimate_baseline_noise(
         Number of histogram bins.
     model : {"constant", "exponential"}
         Functional form used for the fit.
+    pedestal_cut : float, optional
+        Lower ADC threshold for the noise pedestal. Values below this
+        are ignored.
 
     Returns
     -------
@@ -43,6 +52,8 @@ def estimate_baseline_noise(
     """
     adc_arr = np.asarray(adc_values, dtype=float)
     mask = np.ones_like(adc_arr, dtype=bool)
+    if pedestal_cut is not None:
+        mask &= adc_arr > pedestal_cut
     if peak_adc is not None:
         mask &= adc_arr < peak_adc
     adc = adc_arr[mask]

--- a/tests/test_baseline_noise.py
+++ b/tests/test_baseline_noise.py
@@ -47,3 +47,21 @@ def test_unknown_model_raises():
     adc = rng.uniform(0, 200, 100)
     with pytest.raises(ValueError):
         estimate_baseline_noise(adc, peak_adc=250, nbins=20, model="unknown")
+
+
+def test_pedestal_cut_applied():
+    rng = np.random.default_rng(3)
+    adc = rng.uniform(50, 150, 500)
+    level, params, mask = estimate_baseline_noise(
+        adc,
+        peak_adc=140,
+        pedestal_cut=100,
+        nbins=20,
+        model="constant",
+        return_mask=True,
+    )
+    assert mask.dtype == bool
+    assert mask.shape == adc.shape
+    if mask.any():
+        assert np.all((adc[mask] > 100) & (adc[mask] < 140))
+    assert not mask.all()


### PR DESCRIPTION
## Summary
- keep numeric noise cutoff value for baseline use
- pass `pedestal_cut` when estimating baseline noise
- allow pedestal filter in `estimate_baseline_noise`
- test that pedestal cut is applied

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685333f07ee4832b91b5d71bb80009b3