### PR TITLE
Add alias for plot-time-bin-width and tests

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -316,6 +316,7 @@ def parse_args(argv=None):
     )
     p.add_argument(
         "--plot-time-bin-width",
+        "--time-bin-width",
         dest="time_bin_width",
         type=float,
         help="Fixed time bin width in seconds. Providing this option overrides `plotting.plot_time_bin_width_s` in config.json",

--- a/tests/test_analyze_time_bin_width_alias.py
+++ b/tests/test_analyze_time_bin_width_alias.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+
+
+def test_time_bin_width_aliases():
+    args_long = analyze.parse_args([
+        "--config",
+        "cfg.json",
+        "--input",
+        "data.csv",
+        "--output_dir",
+        "out",
+        "--plot-time-bin-width",
+        "5",
+    ])
+    args_short = analyze.parse_args([
+        "--config",
+        "cfg.json",
+        "--input",
+        "data.csv",
+        "--output_dir",
+        "out",
+        "--time-bin-width",
+        "5",
+    ])
+    assert args_long.time_bin_width == args_short.time_bin_width == 5.0


### PR DESCRIPTION
## Summary
- allow `--time-bin-width` as an alias for `--plot-time-bin-width`
- test that both CLI flags populate `time_bin_width`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853330438a0832b887144ff4a6821a4