### PR TITLE
Update CI to run pytest quietly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,4 @@ jobs:
         run: |
           bash scripts/setup_tests.sh
       - name: Run tests
-        run: pytest -v
+        run: pytest -q


### PR DESCRIPTION
## Summary
- run tests with `pytest -q` instead of verbose mode

## Testing
- `bash scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685333ad3af8832b8abb051205069747