### PR TITLE
Add test for duplicate job-id behavior

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -406,6 +406,8 @@ def write_summary(output_dir, summary_dict, timestamp=None):
         timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
     output_path = Path(output_dir)
     results_folder = output_path / timestamp
+    if results_folder.exists():
+        raise FileExistsError(f"Results folder {results_folder} already exists")
     ensure_dir(results_folder)
 
     summary_path = results_folder / "summary.json"

--- a/tests/test_job_id_duplicate.py
+++ b/tests/test_job_id_duplicate.py
@@ -1,0 +1,68 @@
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+from fitting import FitResult
+
+
+def run_once(base, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": True,
+            "window_po214": [0, 10],
+            "hl_po214": [1.0, 0.0],
+            "eff_po214": [1.0, 0.0],
+            "flags": {},
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = base / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1],
+        "fBits": [0],
+        "timestamp": [1.0],
+        "adc": [5],
+        "fchannel": [1],
+    })
+    data_path = base / "data.csv"
+    df.to_csv(data_path, index=False)
+
+    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {}}
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0))
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "apply_burst_filter", lambda df, cfg, mode="rate": (df, 0))
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config", str(cfg_path),
+        "--input", str(data_path),
+        "--output_dir", str(base),
+        "--job-id", "JOB123",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+
+def test_job_id_duplicate(tmp_path, monkeypatch):
+    run_once(tmp_path, monkeypatch)
+    with pytest.raises(FileExistsError):
+        run_once(tmp_path, monkeypatch)


### PR DESCRIPTION
## Summary
- raise `FileExistsError` when results folder already exists
- test that running `analyze.main` twice with the same `--job-id` errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853348f71c8832b866ce06b165390f6