### PR TITLE
Add time bin width alias

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -316,6 +316,7 @@ def parse_args(argv=None):
     )
     p.add_argument(
         "--plot-time-bin-width",
+        "--time-bin-width",
         dest="time_bin_width",
         type=float,
         help="Fixed time bin width in seconds. Providing this option overrides `plotting.plot_time_bin_width_s` in config.json",

--- a/tests/test_time_bin_width_alias.py
+++ b/tests/test_time_bin_width_alias.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+
+
+def test_time_bin_width_alias():
+    base = ["--config", "c", "--input", "i", "--output_dir", "o"]
+    args1 = analyze.parse_args(base + ["--plot-time-bin-width", "5"])
+    args2 = analyze.parse_args(base + ["--time-bin-width", "5"])
+    assert args1.time_bin_width == 5.0
+    assert args2.time_bin_width == 5.0
+
+


### PR DESCRIPTION
## Summary
- add `--time-bin-width` as alias for `--plot-time-bin-width`
- test alias recognition by `analyze.parse_args`

## Testing
- `pytest -q tests/test_time_bin_width_alias.py`

------
https://chatgpt.com/codex/tasks/task_e_685337a5c75c832b9fd90b0b55b2ad90