### PR TITLE
Update CI to run pytest quietly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,4 @@ jobs:
         run: |
           bash scripts/setup_tests.sh
       - name: Run tests
-        run: pytest -v
+        run: pytest -q


### PR DESCRIPTION
## Summary
- run `pytest -q` in CI

## Testing
- `bash scripts/setup_tests.sh`
- `pytest -q` *(fails: FileExistsError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6853379e7fa8832baaba226b3c5d3587