### PR TITLE
Update result writing order

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -406,9 +406,8 @@ def write_summary(output_dir, summary_dict, timestamp=None):
         timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
     output_path = Path(output_dir)
     results_folder = output_path / timestamp
-    if results_folder.exists():
-        raise FileExistsError(f"Results folder already exists: {results_folder}")
-    ensure_dir(results_folder)
+    if not results_folder.exists():
+        ensure_dir(results_folder)
 
     summary_path = results_folder / "summary.json"
 

--- a/tests/test_job_id_duplicate.py
+++ b/tests/test_job_id_duplicate.py
@@ -45,7 +45,8 @@ def test_duplicate_job_id_raises(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
     monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
     monkeypatch.setattr(analyze, "apply_burst_filter", lambda df, cfg, mode="rate": (df, 0))
-    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+    # Use the real copy_config so that an existing job-id triggers an error
+    monkeypatch.setattr(analyze, "copy_config", analyze.copy_config)
 
     args = [
         "analyze.py",


### PR DESCRIPTION
## Summary
- allow `write_summary` to write into an existing result folder
- use real `copy_config` in duplicate-job-id test so `FileExistsError` is raised

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853377bbbac832ba7726abd7dd98a6f