### PR TITLE
Fix results directory creation

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1648,9 +1648,8 @@ def main(argv=None):
     if weights is not None:
         summary["efficiency"]["blue_weights"] = list(weights)
 
-    results_dir = args.output_dir / (args.job_id or now_str)
-    copy_config(results_dir, cfg)
     out_dir = write_summary(args.output_dir, summary, args.job_id or now_str)
+    copy_config(Path(out_dir), cfg)
 
     # Generate plots now that the output directory exists
     if spec_plot_data:

--- a/io_utils.py
+++ b/io_utils.py
@@ -408,7 +408,7 @@ def write_summary(output_dir, summary_dict, timestamp=None):
     results_folder = output_path / timestamp
     if results_folder.exists():
         raise FileExistsError(f"Results folder already exists: {results_folder}")
-    ensure_dir(results_folder)
+    results_folder.mkdir(parents=True, exist_ok=False)
 
     summary_path = results_folder / "summary.json"
 
@@ -441,9 +441,10 @@ def copy_config(output_dir, config_path):
     """
 
     output_path = Path(output_dir)
-    # Create the destination folder. "exist_ok=False" ensures we do not
-    # accidentally overwrite an existing results directory.
-    output_path.mkdir(parents=True, exist_ok=False)
+    # Create the destination folder if needed. "exist_ok=True" ensures this
+    # function can be called after :func:`write_summary` which already created
+    # the directory.
+    output_path.mkdir(parents=True, exist_ok=True)
 
     dest_path = output_path / "config_used.json"
     if isinstance(config_path, (str, Path)):

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -165,14 +165,13 @@ def test_write_summary_and_copy_config(tmp_path):
     summary = {"a": 1, "b": 2}
     outdir = tmp_path / "out"
     ts = "19700101T000000Z"
-    results_dir = outdir / ts
     cfg = {"test": 1}
     cp = tmp_path / "cfg.json"
     with open(cp, "w") as f:
         json.dump(cfg, f)
-    dest = copy_config(results_dir, cp)
-    assert Path(dest).exists()
     results = write_summary(outdir, summary, ts)
+    dest = copy_config(Path(results), cp)
+    assert Path(dest).exists()
     assert (Path(results) / "summary.json").exists()
 
 


### PR DESCRIPTION
## Summary
- avoid accidentally overwriting analysis results folders
- call `write_summary` before `copy_config`
- adjust copy logic and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853376f0eec832bbc09d2cca1563787