### PR TITLE
Fix config copy order

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1648,9 +1648,8 @@ def main(argv=None):
     if weights is not None:
         summary["efficiency"]["blue_weights"] = list(weights)
 
-    results_dir = args.output_dir / (args.job_id or now_str)
-    copy_config(results_dir, cfg)
     out_dir = write_summary(args.output_dir, summary, args.job_id or now_str)
+    copy_config(out_dir, cfg)
 
     # Generate plots now that the output directory exists
     if spec_plot_data:

--- a/io_utils.py
+++ b/io_utils.py
@@ -441,9 +441,10 @@ def copy_config(output_dir, config_path):
     """
 
     output_path = Path(output_dir)
-    # Create the destination folder. "exist_ok=False" ensures we do not
-    # accidentally overwrite an existing results directory.
-    output_path.mkdir(parents=True, exist_ok=False)
+    # Create the destination folder if needed. Allow existing directories
+    # so that this function can be called after ``write_summary`` has
+    # already created the results directory.
+    output_path.mkdir(parents=True, exist_ok=True)
 
     dest_path = output_path / "config_used.json"
     if isinstance(config_path, (str, Path)):

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -165,15 +165,14 @@ def test_write_summary_and_copy_config(tmp_path):
     summary = {"a": 1, "b": 2}
     outdir = tmp_path / "out"
     ts = "19700101T000000Z"
-    results_dir = outdir / ts
     cfg = {"test": 1}
     cp = tmp_path / "cfg.json"
     with open(cp, "w") as f:
         json.dump(cfg, f)
-    dest = copy_config(results_dir, cp)
-    assert Path(dest).exists()
     results = write_summary(outdir, summary, ts)
     assert (Path(results) / "summary.json").exists()
+    dest = copy_config(results, cp)
+    assert Path(dest).exists()
 
 
 def test_write_summary_with_nullable_integers(tmp_path):


### PR DESCRIPTION
## Summary
- call `write_summary` before `copy_config`
- allow `copy_config` to run when the results folder already exists
- update test for new order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68533c4a0134832ba842de0ef0fdc9ea