### PR TITLE
Implement pedestal cut masking before peak threshold

### DIFF
--- a/baseline_noise.py
+++ b/baseline_noise.py
@@ -50,10 +50,10 @@ def estimate_baseline_noise(
     """
     adc_arr = np.asarray(adc_values, dtype=float)
     mask = np.ones_like(adc_arr, dtype=bool)
-    if peak_adc is not None:
-        mask &= adc_arr < peak_adc
     if pedestal_cut is not None:
         mask &= adc_arr > pedestal_cut
+    if peak_adc is not None:
+        mask &= adc_arr < peak_adc
     adc = adc_arr[mask]
     if adc.size == 0:
         if return_mask:


### PR DESCRIPTION
## Summary
- update baseline noise function to apply pedestal cut masking before peak threshold
- keep documentation current and behavior unchanged when the cut is not provided

## Testing
- `pytest tests/test_baseline_noise.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6853377603d0832b9d834fbe4dd0bbfe