### PR TITLE
Update baseline noise estimator usage

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -594,14 +594,18 @@ def main(argv=None):
     # ───────────────────────────────────────────────
     noise_thr = cfg.get("calibration", {}).get("noise_cutoff")
     n_removed_noise = 0
+    noise_thr_val = None
     if noise_thr is not None:
         try:
-            thr_val = int(noise_thr)
+            noise_thr_val = int(noise_thr)
         except (ValueError, TypeError):
-            logging.warning(f"Invalid noise_cutoff '{noise_thr}' - skipping noise cut")
+            logging.warning(
+                f"Invalid noise_cutoff '{noise_thr}' - skipping noise cut"
+            )
+            noise_thr_val = None
         else:
             before = len(events)
-            events = events[events["adc"] > thr_val].reset_index(drop=True)
+            events = events[events["adc"] > noise_thr_val].reset_index(drop=True)
             n_removed_noise = before - len(events)
             logging.info(f"Noise cut removed {n_removed_noise} events")
 
@@ -897,6 +901,7 @@ def main(argv=None):
                 result = estimate_baseline_noise(
                     base_events["adc"].values,
                     peak_adc=peak_adc,
+                    pedestal_cut=noise_thr_val,
                     return_mask=True,
                 )
                 if isinstance(result, tuple) and len(result) == 3:


### PR DESCRIPTION
## Summary
- record the numeric noise cutoff to reuse later
- pass noise cutoff when estimating baseline noise

## Testing
- `pytest -q` *(fails: Package 'numpy' is required)*

------
https://chatgpt.com/codex/tasks/task_e_68534435bcb0832ba55fa1a717fbd0fa