### PR TITLE
Handle config copy before summary creation

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1648,8 +1648,9 @@ def main(argv=None):
     if weights is not None:
         summary["efficiency"]["blue_weights"] = list(weights)
 
-    out_dir = write_summary(args.output_dir, summary, args.job_id or now_str)
-    copy_config(Path(out_dir), cfg)
+    results_dir = Path(args.output_dir) / (args.job_id or now_str)
+    copy_config(results_dir, cfg)
+    out_dir = write_summary(results_dir, summary)
 
     # Generate plots now that the output directory exists
     if spec_plot_data:

--- a/io_utils.py
+++ b/io_utils.py
@@ -387,32 +387,22 @@ def apply_burst_filter(df, cfg=None, mode="rate"):
 
 
 def write_summary(output_dir, summary_dict, timestamp=None):
-    """
-    Write out ``summary_dict`` to ``summary.json`` under a timestamped
-    directory and return the path to that directory.
+    """Write ``summary_dict`` to ``summary.json`` and return the results folder."""
 
-    Parameters
-    ----------
-    output_dir : Path or str
-        Parent directory under which the results folder will be created.
-    summary_dict : dict
-        Data to serialise into ``summary.json``.
-    timestamp : str, optional
-        Timestamp string to use for the results folder.  If ``None`` a new
-        UTC timestamp will be generated.
-    """
-    # Create timestamped subfolder
-    if timestamp is None:
-        timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
     output_path = Path(output_dir)
-    results_folder = output_path / timestamp
-    if results_folder.exists():
-        raise FileExistsError(f"Results folder already exists: {results_folder}")
-    results_folder.mkdir(parents=True, exist_ok=False)
+
+    if timestamp is None and output_path.is_dir():
+        results_folder = output_path
+    else:
+        if timestamp is None:
+            timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+        results_folder = output_path / timestamp
+        if results_folder.exists():
+            raise FileExistsError(f"Results folder already exists: {results_folder}")
+        results_folder.mkdir(parents=True, exist_ok=False)
 
     summary_path = results_folder / "summary.json"
 
-    # Convert numpy types to native Python using shared helper
     sanitized = to_native(summary_dict)
 
     with open(summary_path, "w", encoding="utf-8") as f:
@@ -430,7 +420,7 @@ def copy_config(output_dir, config_path):
     ----------
     output_dir : Path or str
         Path to the directory where ``config_used.json`` should be placed.
-        The directory will be created if it does not already exist.
+        The directory must not already exist and will be created.
     config_path : Path, str or dict
         Configuration file to copy or configuration dictionary.
 
@@ -441,10 +431,7 @@ def copy_config(output_dir, config_path):
     """
 
     output_path = Path(output_dir)
-    # Create the destination folder if needed. "exist_ok=True" ensures this
-    # function can be called after :func:`write_summary` which already created
-    # the directory.
-    output_path.mkdir(parents=True, exist_ok=True)
+    output_path.mkdir(parents=True, exist_ok=False)
 
     dest_path = output_path / "config_used.json"
     if isinstance(config_path, (str, Path)):

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -196,7 +196,7 @@ def test_job_id_overrides_results_folder(tmp_path, monkeypatch):
     recorded = {}
 
     def fake_write_summary(out_dir, summary, timestamp=None):
-        recorded["folder"] = Path(out_dir) / timestamp
+        recorded["folder"] = Path(out_dir)
         recorded["folder"].mkdir(parents=True, exist_ok=True)
         return str(recorded["folder"])
 

--- a/tests/test_hierarchical_summary.py
+++ b/tests/test_hierarchical_summary.py
@@ -60,7 +60,7 @@ def test_hierarchical_summary(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_hierarchical_runs", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        d = Path(out_dir) / "new"
+        d = Path(out_dir)
         d.mkdir(parents=True, exist_ok=True)
         with open(d / "summary.json", "w") as f:
             json.dump({

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -169,8 +169,9 @@ def test_write_summary_and_copy_config(tmp_path):
     cp = tmp_path / "cfg.json"
     with open(cp, "w") as f:
         json.dump(cfg, f)
-    results = write_summary(outdir, summary, ts)
-    dest = copy_config(Path(results), cp)
+    results_dir = outdir / ts
+    dest = copy_config(results_dir, cp)
+    results = write_summary(results_dir, summary)
     assert Path(dest).exists()
     assert (Path(results) / "summary.json").exists()
 

--- a/tests/test_job_id_duplicate.py
+++ b/tests/test_job_id_duplicate.py
@@ -45,7 +45,10 @@ def test_duplicate_job_id_raises(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
     monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
     monkeypatch.setattr(analyze, "apply_burst_filter", lambda df, cfg, mode="rate": (df, 0))
-    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+    def fake_copy(path, cfg):
+        Path(path).mkdir(parents=True, exist_ok=False)
+
+    monkeypatch.setattr(analyze, "copy_config", fake_copy)
 
     args = [
         "analyze.py",


### PR DESCRIPTION
## Summary
- allow `write_summary` to write into a pre-created directory
- create the results directory when copying the config
- generate results path before writing summary
- update tests for new ordering

## Testing
- `pytest tests/test_analyze_config_merge.py::test_job_id_overrides_results_folder tests/test_hierarchical_summary.py::test_hierarchical_summary tests/test_job_id_duplicate.py::test_duplicate_job_id_raises -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685344374680832ba0cdf7a84eeb2dcd