### PR TITLE
Add overwrite option to analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pip install -r requirements.txt
 
 ```bash
 python analyze.py --config config.json --input merged_data.csv \
-    [--output_dir results] [--job-id MYRUN] \
+    [--output_dir results] [--job-id MYRUN] [--overwrite] \
     [--efficiency-json eff.json] [--systematics-json syst.json] \
     [--spike-count N --spike-count-err S] [--slope RATE] \
     [--noise-cutoff N] \
@@ -62,7 +62,7 @@ sample layout which also includes typical auxiliary fields such as
 
 ## Output
 
-The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--job-id` is given the folder `<output_dir>/<job-id>/` is used instead. The directory includes:
+The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--job-id` is given the folder `<output_dir>/<job-id>/` is used instead. If the folder already exists run with `--overwrite` to replace it. The directory includes:
 
 - `summary.json` – calibration and fit summary.
 - `config_used.json` – copy of the configuration used.

--- a/analyze.py
+++ b/analyze.py
@@ -55,6 +55,7 @@ import subprocess
 import hashlib
 import json
 from pathlib import Path
+import shutil
 
 import math
 import numpy as np
@@ -211,6 +212,11 @@ def parse_args(argv=None):
     p.add_argument(
         "--job-id",
         help="Optional identifier used for the results folder instead of the timestamp",
+    )
+    p.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite existing results folder if it already exists",
     )
     p.add_argument(
         "--efficiency-json",
@@ -1654,7 +1660,13 @@ def main(argv=None):
         summary["efficiency"]["blue_weights"] = list(weights)
 
     results_dir = Path(args.output_dir) / (args.job_id or now_str)
-    copy_config(results_dir, cfg)
+    if results_dir.exists():
+        if args.overwrite:
+            shutil.rmtree(results_dir)
+        else:
+            raise FileExistsError(f"Results folder already exists: {results_dir}")
+
+    copy_config(results_dir, cfg, exist_ok=args.overwrite)
     out_dir = write_summary(results_dir, summary)
 
     # Generate plots now that the output directory exists

--- a/io_utils.py
+++ b/io_utils.py
@@ -412,7 +412,7 @@ def write_summary(output_dir, summary_dict, timestamp=None):
     return results_folder
 
 
-def copy_config(output_dir, config_path):
+def copy_config(output_dir, config_path, *, exist_ok=False):
     """
     Copy the used config JSON into the timestamped results folder.
 
@@ -420,7 +420,10 @@ def copy_config(output_dir, config_path):
     ----------
     output_dir : Path or str
         Path to the directory where ``config_used.json`` should be placed.
-        The directory must not already exist and will be created.
+        The directory will be created if needed.
+    exist_ok : bool, optional
+        If ``True``, allow ``output_dir`` to already exist.
+        Defaults to ``False``.
     config_path : Path, str or dict
         Configuration file to copy or configuration dictionary.
 
@@ -431,7 +434,7 @@ def copy_config(output_dir, config_path):
     """
 
     output_path = Path(output_dir)
-    output_path.mkdir(parents=True, exist_ok=False)
+    output_path.mkdir(parents=True, exist_ok=exist_ok)
 
     dest_path = output_path / "config_used.json"
     if isinstance(config_path, (str, Path)):

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -2036,7 +2036,7 @@ def test_time_fields_written_back(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "load_config", fake_load)
 
-    def fake_copy(outdir, cfg_in):
+    def fake_copy(outdir, cfg_in, exist_ok=False):
         captured["cfg"] = cfg_in
 
     monkeypatch.setattr(analyze, "copy_config", fake_copy)

--- a/tests/test_job_id_duplicate.py
+++ b/tests/test_job_id_duplicate.py
@@ -45,8 +45,8 @@ def test_duplicate_job_id_raises(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
     monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
     monkeypatch.setattr(analyze, "apply_burst_filter", lambda df, cfg, mode="rate": (df, 0))
-    def fake_copy(path, cfg):
-        Path(path).mkdir(parents=True, exist_ok=False)
+    def fake_copy(path, cfg, exist_ok=False):
+        Path(path).mkdir(parents=True, exist_ok=exist_ok)
 
     monkeypatch.setattr(analyze, "copy_config", fake_copy)
 
@@ -69,4 +69,60 @@ def test_duplicate_job_id_raises(tmp_path, monkeypatch):
     monkeypatch.setattr(sys, "argv", args)
     with pytest.raises(FileExistsError):
         analyze.main()
+
+
+def test_job_id_overwrite_allows_rerun(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1],
+        "fBits": [0],
+        "timestamp": [0],
+        "adc": [1000],
+        "fchannel": [1],
+    })
+    data_path = tmp_path / "data.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0, 0)), 0))
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "apply_burst_filter", lambda df, cfg, mode="rate": (df, 0))
+    def fake_copy(path, cfg, exist_ok=False):
+        Path(path).mkdir(parents=True, exist_ok=exist_ok)
+
+    monkeypatch.setattr(analyze, "copy_config", fake_copy)
+
+    base_args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+        "--job-id",
+        "DUPLICATE",
+    ]
+
+    monkeypatch.setattr(sys, "argv", base_args)
+    analyze.main()
+
+    monkeypatch.setattr(sys, "argv", base_args + ["--overwrite"])
+    analyze.main()
 


### PR DESCRIPTION
## Summary
- add `--overwrite` flag to command line parsing
- remove prior results directory when overwriting
- allow `copy_config` to accept an `exist_ok` argument
- document overwrite flag in README
- test duplicate job id behaviour with and without overwrite

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685350a4e494832b88c832f69b1ef5f9