### PR TITLE
Enable quadratic calibration

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -73,7 +73,11 @@ from io_utils import (
     write_summary,
     apply_burst_filter,
 )
-from calibration import derive_calibration_constants, derive_calibration_constants_auto
+from calibration import (
+    derive_calibration_constants,
+    derive_calibration_constants_auto,
+    apply_calibration,
+)
 
 from fitting import fit_spectrum, fit_time_series, FitResult
 
@@ -808,15 +812,24 @@ def main(argv=None):
 
     # Save “a, c, sigma_E” so we can reconstruct energies
     a, a_sig = cal_params["a"]
+    a2, a2_sig = cal_params.get("a2", (0.0, 0.0))
     c, c_sig = cal_params["c"]
     sigE_mean, sigE_sigma = cal_params["sigma_E"]
     cov_mat = np.asarray(cal_params.get("ac_covariance", [[0.0, 0.0], [0.0, 0.0]]), dtype=float)
     cov_ac = float(cov_mat[0, 1])
+    cov_a_a2 = float(cal_params.get("cov_a_a2", 0.0))
 
-    # Apply linear calibration -> new column “energy_MeV” and its uncertainty
-    events["energy_MeV"] = events["adc"] * a + c
+    # Apply calibration -> new column “energy_MeV” and its uncertainty
+    events["energy_MeV"] = apply_calibration(events["adc"], a, c, quadratic_coeff=a2)
 
-    var_energy = (events["adc"] * a_sig) ** 2 + c_sig ** 2 + 2 * events["adc"] * cov_ac
+    adc_vals = events["adc"].astype(float)
+    var_energy = (
+        (adc_vals * a_sig) ** 2
+        + (adc_vals ** 2 * a2_sig) ** 2
+        + c_sig ** 2
+        + 2 * adc_vals * cov_ac
+        + 2 * adc_vals ** 3 * cov_a_a2
+    )
     events["denergy_MeV"] = np.sqrt(np.clip(var_energy, 0, None))
 
     # ────────────────────────────────────────────────────────────
@@ -877,8 +890,17 @@ def main(argv=None):
         base_events = events_full[mask_base_full].copy()
         # Apply calibration to the baseline events
         if not base_events.empty:
-            base_events["energy_MeV"] = base_events["adc"] * a + c
-            var_base = (base_events["adc"] * a_sig) ** 2 + c_sig ** 2 + 2 * base_events["adc"] * cov_ac
+            base_events["energy_MeV"] = apply_calibration(
+                base_events["adc"], a, c, quadratic_coeff=a2
+            )
+            adc_b = base_events["adc"].astype(float)
+            var_base = (
+                (adc_b * a_sig) ** 2
+                + (adc_b ** 2 * a2_sig) ** 2
+                + c_sig ** 2
+                + 2 * adc_b * cov_ac
+                + 2 * adc_b ** 3 * cov_a_a2
+            )
             base_events["denergy_MeV"] = np.sqrt(np.clip(var_base, 0, None))
         if len(base_events) == 0:
             raise ValueError("baseline_range yielded zero events")
@@ -988,7 +1010,7 @@ def main(argv=None):
 
             # Build edges in ADC units then convert to energy for plotting
             bin_edges_adc = np.arange(adc_min, adc_min + bins * width + 1, width)
-            bin_edges = bin_edges_adc * a + c
+            bin_edges = apply_calibration(bin_edges_adc, a, c, quadratic_coeff=a2)
 
         # Find approximate ADC centroids for Po‐210, Po‐218, Po‐214
 
@@ -1014,7 +1036,7 @@ def main(argv=None):
         )
 
         for peak, centroid_adc in adc_peaks.items():
-            mu = centroid_adc * a + c  # convert to MeV
+            mu = apply_calibration(centroid_adc, a, c, quadratic_coeff=a2)
             bounds_cfg = cfg["spectral_fit"].get("mu_bounds", {})
             bounds = bounds_cfg.get(peak)
             if bounds is not None:

--- a/calibration.py
+++ b/calibration.py
@@ -210,15 +210,9 @@ def calibrate_run(adc_values, config, hist_bins=None):
     E214 = energies["Po214"]
     E218 = energies["Po218"]
 
-    user_requested_quadratic = bool(
+    quadratic = bool(
         config.get("calibration", {}).get("quadratic", False)
     )
-    if user_requested_quadratic:
-        logging.warning(
-            "Quadratic calibration is currently disabled. Using linear calibration instead."
-        )
-
-    quadratic = False
 
     if quadratic:
         # Solve for quadratic coefficients a2, a, c using all three peaks
@@ -331,6 +325,7 @@ def derive_calibration_constants(adc_values, config):
         "sigma_E": (float(res["sigma_E"]), sigE_err),
         "peaks": res.get("peaks", {}),
         "ac_covariance": cov.tolist(),
+        "cov_a_a2": float(res.get("cov_a_a2", 0.0)),
     }
     return out
 
@@ -403,6 +398,7 @@ def derive_calibration_constants_auto(
         "sigma_E": (float(res["sigma_E"]), sigE_err),
         "peaks": res.get("peaks", {}),
         "ac_covariance": cov.tolist(),
+        "cov_a_a2": float(res.get("cov_a_a2", 0.0)),
     }
     return out
 


### PR DESCRIPTION
## Summary
- support optional quadratic term in `calibrate_run`
- use `apply_calibration` for energy conversion
- propagate `a2` and its covariance to uncertainty calculations
- adapt tests for quadratic calibration

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68535069966c832ba485cae54b0efc3a