### PR TITLE
Add negative activity check

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -160,7 +160,8 @@ def compute_total_radon(
 
     Both ``monitor_volume`` and ``sample_volume`` must be non-negative.  A
     ``ValueError`` is raised if ``monitor_volume`` is not positive, if
-    ``sample_volume`` is negative, or if ``err_bq`` is negative.
+    ``sample_volume`` is negative, if ``err_bq`` is negative, or if
+    ``activity_bq`` is negative.
 
     Returns
     -------
@@ -184,6 +185,8 @@ def compute_total_radon(
         raise ValueError("sample_volume must be non-negative")
     if err_bq < 0:
         raise ValueError("err_bq must be non-negative")
+    if activity_bq < 0:
+        raise ValueError("activity_bq must be non-negative")
     conc = activity_bq / monitor_volume
     sigma_conc = err_bq / monitor_volume
 

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -189,6 +189,11 @@ def test_compute_total_radon_negative_err_bq():
         compute_total_radon(5.0, -0.1, 10.0, 1.0)
 
 
+def test_compute_total_radon_negative_activity_bq():
+    with pytest.raises(ValueError):
+        compute_total_radon(-1.0, 0.5, 10.0, 1.0)
+
+
 def test_radon_activity_curve():
     times = [0.0, 1.0]
     E = 5.0


### PR DESCRIPTION
## Summary
- validate `activity_bq` in `compute_total_radon`
- test that negative activity triggers an error

## Testing
- `pytest -q tests/test_radon_activity.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685352e045dc832b96a06b35424c3a37