### PR TITLE
Add negative error validation for BLUE combine

### DIFF
--- a/efficiency.py
+++ b/efficiency.py
@@ -126,6 +126,8 @@ def blue_combine(
         raise ValueError("values and errors must have the same length")
     if vals.size == 0:
         raise ValueError("no values provided")
+    if np.any(errs < 0):
+        raise ValueError("errors cannot contain negative values")
 
     if corr is None:
         cov = np.diag(errs**2)

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -83,3 +83,18 @@ def test_blue_combine_negative_weights_error():
     corr = np.array([[1.0, 0.99], [0.99, 1.0]])
     with pytest.raises(ValueError):
         blue_combine(vals, errs, corr)
+
+
+def test_blue_combine_negative_errors_uncorrelated():
+    vals = np.array([0.4, 0.5])
+    errs = np.array([0.1, -0.2])
+    with pytest.raises(ValueError):
+        blue_combine(vals, errs)
+
+
+def test_blue_combine_negative_errors_correlated():
+    vals = np.array([0.4, 0.5])
+    errs = np.array([0.1, -0.2])
+    corr = np.eye(2)
+    with pytest.raises(ValueError):
+        blue_combine(vals, errs, corr)


### PR DESCRIPTION
## Summary
- validate that uncertainty inputs are non-negative in `blue_combine`
- test that negative uncertainties raise `ValueError`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685352e0a4c8832b85cc8cad0cdfd9b6