### PR TITLE
Handle singular covariance in BLUE

### DIFF
--- a/efficiency.py
+++ b/efficiency.py
@@ -135,7 +135,10 @@ def blue_combine(
             raise ValueError("correlation matrix has wrong shape")
         cov = c * np.outer(errs, errs)
 
-    Vinv = np.linalg.inv(cov)
+    try:
+        Vinv = np.linalg.inv(cov)
+    except np.linalg.LinAlgError as exc:
+        raise ValueError("covariance matrix is not invertible") from exc
     ones = np.ones(vals.size)
     norm = float(ones @ Vinv @ ones)
     weights = (Vinv @ ones) / norm

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -83,3 +83,11 @@ def test_blue_combine_negative_weights_error():
     corr = np.array([[1.0, 0.99], [0.99, 1.0]])
     with pytest.raises(ValueError):
         blue_combine(vals, errs, corr)
+
+
+def test_blue_combine_singular_matrix_error():
+    vals = np.array([1.0, 2.0])
+    errs = np.array([0.1, 0.2])
+    corr = np.array([[1.0, 1.0], [1.0, 1.0]])
+    with pytest.raises(ValueError, match="covariance matrix is not invertible"):
+        blue_combine(vals, errs, corr)


### PR DESCRIPTION
## Summary
- handle singular covariance matrix when inverting
- test BLUE combination with a singular matrix

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685352e14a18832b9d4bf4380d982aa8