### PR TITLE
Update weighting in time fit

### DIFF
--- a/fitting.py
+++ b/fitting.py
@@ -443,13 +443,14 @@ def _neg_log_likelihood_time(
         N0_iso = 0.0 if fix_n0_map[iso] else p[f"N0_{iso}"]
 
         # 1) Integral term. When per-event weights are supplied we
-        # scale the integral by the total weight so that a uniform
+        # scale the integral by the mean weight so that a uniform
         # scaling of all weights cancels between the log and integral
         # contributions.
         integral = _integral_model(E_iso, N0_iso, B_iso, lam, eff, T_rel)
         weights = weights_dict.get(iso)
         if weights is not None and len(weights) > 0:
-            integral *= float(np.sum(weights))
+            weight_mean = np.mean(weights)
+            integral *= float(weight_mean)
 
         # 2) Sum of log[r(t_i)] for each event t_i in times_dict[iso]:
         times_iso = times_dict.get(iso, np.empty(0))

--- a/tests/test_nll_weight_sum.py
+++ b/tests/test_nll_weight_sum.py
@@ -49,7 +49,8 @@ def test_weighted_nll_analytic_matches_numeric():
     def rate(t):
         return eff * (E * (1 - np.exp(-lam * t)) + lam * N0 * np.exp(-lam * t)) + B
 
-    integral_num = quad(rate, 0.0, t_end - t_start)[0] * np.sum(weights)
+    weight_mean = np.mean(weights)
+    integral_num = quad(rate, 0.0, t_end - t_start)[0] * weight_mean
     rate_vals = rate(times - t_start)
     numeric_nll = integral_num - np.sum(weights * np.log(rate_vals))
 

--- a/tests/test_time_series_weights.py
+++ b/tests/test_time_series_weights.py
@@ -90,8 +90,21 @@ def test_weighted_nll_matches_numeric_integration():
     def rate(t):
         return eff * (E * (1 - np.exp(-lam * t)) + lam * N0 * np.exp(-lam * t)) + B
 
-    integral_num = quad(rate, 0.0, t_end - t_start)[0] * np.sum(weights)
+    weight_mean = np.mean(weights)
+    integral_num = quad(rate, 0.0, t_end - t_start)[0] * weight_mean
     rate_vals = rate(times - t_start)
     numeric_nll = integral_num - np.sum(weights * np.log(rate_vals))
 
     assert analytic_nll == pytest.approx(numeric_nll, rel=1e-6)
+
+
+def test_weights_none_equivalent_to_ones():
+    times = simulate_times(40, 15, seed=4)
+    cfg = base_config(15)
+    res_none = fit_time_series({"Po214": times}, 0.0, 15, cfg, weights=None)
+    res_one = fit_time_series(
+        {"Po214": times}, 0.0, 15, cfg, weights={"Po214": np.ones_like(times)}
+    )
+    assert res_none.params["E_Po214"] == pytest.approx(
+        res_one.params["E_Po214"], rel=1e-6
+    )


### PR DESCRIPTION
## Summary
- compute mean weight when scaling likelihood integral
- keep log term the same
- update unit tests for new weighting behavior
- ensure weights=None behaves like unity weights

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685352e562d4832bb9b0bf403c3d94de