### PR TITLE
Validate non-negative errors in BLUE

### DIFF
--- a/efficiency.py
+++ b/efficiency.py
@@ -122,6 +122,8 @@ def blue_combine(
     """
     vals = np.asarray(values, dtype=float)
     errs = np.asarray(errors, dtype=float)
+    if np.any(errs < 0):
+        raise ValueError("errors cannot be negative")
     if vals.size != errs.size:
         raise ValueError("values and errors must have the same length")
     if vals.size == 0:

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -91,3 +91,18 @@ def test_blue_combine_singular_matrix_error():
     corr = np.array([[1.0, 1.0], [1.0, 1.0]])
     with pytest.raises(ValueError, match="covariance matrix is not invertible"):
         blue_combine(vals, errs, corr)
+
+
+def test_blue_combine_negative_uncertainty():
+    vals = np.array([1.0, 2.0])
+    errs = np.array([0.1, -0.2])
+    with pytest.raises(ValueError, match="errors cannot be negative"):
+        blue_combine(vals, errs)
+
+
+def test_blue_combine_negative_uncertainty_corr():
+    vals = np.array([1.0, 2.0])
+    errs = np.array([0.1, -0.2])
+    corr = np.array([[1.0, 0.5], [0.5, 1.0]])
+    with pytest.raises(ValueError, match="errors cannot be negative"):
+        blue_combine(vals, errs, corr)


### PR DESCRIPTION
## Summary
- prevent `blue_combine` from accepting negative uncertainties
- add corresponding unit tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853547e5b84832b81fb2243afadb747