### PR TITLE
Document baseline noise pedestal cut

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,21 @@ python analyze.py --config assay.json --input run.csv --output_dir results \
     --baseline_range 2023-07-01T00:00:00Z 2023-07-03T00:00:00Z
 ```
 
+### Baseline Noise Cut
+
+The helper `baseline_noise.estimate_baseline_noise` extracts the electronic
+noise level from baseline events. Its optional `pedestal_cut` parameter
+omits ADC values at or below the supplied threshold. When a baseline range
+is specified, `analyze.py` forwards `calibration.noise_cutoff` as this value.
+
+Example configuration to tighten the cut (set it to `null` to disable):
+
+```json
+"calibration": {
+    "noise_cutoff": 300
+}
+```
+
 ## Utility Conversions
 
 `utils.py` provides simple helpers to convert count rates and to search for


### PR DESCRIPTION
## Summary
- add a short section about the `pedestal_cut` parameter of `baseline_noise.estimate_baseline_noise`
- note how `analyze.py` uses `calibration.noise_cutoff` with this argument
- show configuration snippet for adjusting or disabling the cut

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685352dc259c832ba939b192cc96d85e