### PR TITLE
Add baseline-mode CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,8 @@ scale factors for Po-214, Po-218, Po-210 and electronic noise are stored in
 option `--baseline_range` overrides `baseline.range` from the
 configuration when provided. When you specify this option the
 configuration's interval is ignored in favour of the CLI value.
+The `--baseline-mode` option selects the background removal strategy.
+Valid modes are `none`, `electronics`, `radon` and `all` (default).
 
 
 Example snippet:

--- a/analyze.py
+++ b/analyze.py
@@ -216,6 +216,12 @@ def parse_args(argv=None):
         ),
     )
     p.add_argument(
+        "--baseline-mode",
+        choices=["none", "electronics", "radon", "all"],
+        default="all",
+        help="Background removal strategy (default: all)",
+    )
+    p.add_argument(
         "--burst-mode",
         choices=["none", "micro", "rate", "both"],
         help="Burst filtering mode to pass to apply_burst_filter. Providing this option overrides `burst_filter.burst_mode` in config.json",


### PR DESCRIPTION
## Summary
- add `--baseline-mode` argument to CLI parser
- document baseline mode behaviour in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68535b2146b8832b8b373952b1e6d5ff