### PR TITLE
Fix baseline histogram binning

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -99,7 +99,7 @@ from plot_utils import (
 )
 from systematics import scan_systematics, apply_linear_adc_shift
 from visualize import cov_heatmap, efficiency_bar
-from utils import find_adc_bin_peaks, cps_to_bq
+from utils import find_adc_bin_peaks, adc_hist_edges, cps_to_bq
 from radmon.baseline import subtract_baseline
 
 
@@ -991,10 +991,11 @@ def main(argv=None):
     if args.baseline_range:
         t_base0 = _to_epoch(args.baseline_range[0])
         t_base1 = _to_epoch(args.baseline_range[1])
+        edges = adc_hist_edges(df_analysis["adc"].values, hist_bins)
         df_analysis = subtract_baseline(
             df_analysis,
             df_full,
-            bins=hist_bins,
+            bins=edges,
             t_base0=t_base0,
             t_base1=t_base1,
             mode=args.baseline_mode,

--- a/utils.py
+++ b/utils.py
@@ -8,7 +8,15 @@ import argparse
 from datetime import datetime, timezone
 from dateutil import parser as date_parser
 
-__all__ = ["to_native", "find_adc_bin_peaks", "cps_to_cpd", "cps_to_bq", "parse_time", "LITERS_PER_M3"]
+__all__ = [
+    "to_native",
+    "find_adc_bin_peaks",
+    "adc_hist_edges",
+    "cps_to_cpd",
+    "cps_to_bq",
+    "parse_time",
+    "LITERS_PER_M3",
+]
 
 # Conversion factor from cubic meters to liters
 LITERS_PER_M3 = 1000.0
@@ -108,6 +116,38 @@ def find_adc_bin_peaks(adc_values, expected, window=50, prominence=0.0, width=No
             results[name] = float(guess)
 
     return results
+
+
+def adc_hist_edges(adc_values, hist_bins=None):
+    """Return histogram bin edges for raw ADC values.
+
+    Parameters
+    ----------
+    adc_values : array-like
+        Raw ADC values used to define the histogram range.
+    hist_bins : int or None, optional
+        Number of bins to divide the range into. When ``None`` each
+        ADC channel becomes its own bin.
+
+    Returns
+    -------
+    np.ndarray
+        Array of bin edges suitable for :func:`numpy.histogram`.
+    """
+
+    adc_arr = np.asarray(adc_values, dtype=float)
+    if adc_arr.size == 0:
+        return np.asarray([0.0, 1.0], dtype=float)
+
+    min_adc = int(np.min(adc_arr))
+    max_adc = int(np.max(adc_arr))
+
+    if hist_bins is None:
+        edges = np.arange(min_adc, max_adc + 2)
+    else:
+        edges = np.linspace(min_adc, max_adc, int(hist_bins) + 1)
+
+    return edges
 
 
 def cps_to_cpd(rate_cps):


### PR DESCRIPTION
## Summary
- compute ADC histogram edges using new `adc_hist_edges` helper
- use the computed bin edges when performing baseline subtraction

## Testing
- `pytest -q` *(fails: Package 'numpy' is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_685366334f64832b84fb6fcaaf63fbee