### PR TITLE
Fix duplicated baseline noise count statement

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -982,10 +982,6 @@ def main(argv=None):
         if "mask_noise" in locals():
             baseline_counts["noise"] = int(np.sum(mask_noise))
 
-        # Record noise counts in ``baseline_counts``
-        if "mask_noise" in locals():
-            baseline_counts["noise"] = int(np.sum(mask_noise))
-
     _ensure_events(df_analysis, "baseline subtraction")
 
     if args.baseline_range:


### PR DESCRIPTION
## Summary
- remove redundant noise count block in `analyze.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685369d14f44832b9535d24d6411b1f4