### PR TITLE
Add baseline subtraction and pipeline calibration tests

### DIFF
--- a/tests/test_baseline_subtract.py
+++ b/tests/test_baseline_subtract.py
@@ -1,0 +1,52 @@
+import pytest
+import numpy as np
+import pandas as pd
+from pathlib import Path
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import baseline  # module with subtract_baseline
+
+
+def test_baseline_none():
+    df = pd.DataFrame({
+        "timestamp": np.linspace(0, 9, 10),
+        "adc": np.arange(10),
+    })
+    bins = np.arange(0, 11)
+    out = baseline.subtract_baseline(
+        df,
+        df,
+        bins=bins,
+        t_base0=0,
+        t_base1=5,
+        mode="none",
+    )
+    hist_before, _ = baseline.rate_histogram(df, bins)
+    hist_after, _ = baseline.rate_histogram(out, bins)
+    assert np.allclose(hist_before, hist_after)
+
+
+def test_baseline_time_norm():
+    df_an = pd.DataFrame({
+        "timestamp": np.linspace(0, 4, 5),
+        "adc": [1, 2, 3, 4, 5],
+    })
+    df_bl = pd.DataFrame({
+        "timestamp": np.linspace(100, 140, 50),
+        "adc": np.tile([1, 2, 3, 4, 5], 10),
+    })
+    df_full = pd.concat([df_an, df_bl], ignore_index=True)
+    bins = np.arange(0, 7)
+    out = baseline.subtract_baseline(
+        df_an,
+        df_full,
+        bins=bins,
+        t_base0=100,
+        t_base1=140,
+        mode="all",
+    )
+    integral = out["subtracted_adc_hist"].iloc[0].sum()
+    assert integral == pytest.approx(0.0, rel=1e-6)
+

--- a/tests/test_pipeline_after_fix.py
+++ b/tests/test_pipeline_after_fix.py
@@ -1,0 +1,73 @@
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import analyze
+
+
+def test_pipeline_calibrates_after_fix(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {
+            "method": "two-point",
+            "peak_prominence": 0.0,
+            "peak_width": 1,
+            "nominal_adc": {"Po210": 1250, "Po218": 1300, "Po214": 1800},
+            "peak_search_radius": 200,
+            "fit_window_adc": 20,
+            "use_emg": False,
+            "init_sigma_adc": 5.0,
+            "init_tau_adc": 1.0,
+            "sanity_tolerance_mev": 1.0,
+        },
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    data_path = Path(__file__).resolve().parents[1] / "example_input.csv"
+
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    captured = {}
+
+    def fake_write(out_dir, summary, timestamp=None):
+        captured["summary"] = summary
+        d = Path(out_dir) / (timestamp or "x")
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+
+    analyze.main()
+
+    summary = captured.get("summary", {})
+    cent = summary.get("calibration", {}).get("peaks", {}).get("Po218", {}).get("centroid_adc")
+    assert cent is not None
+    assert cent == pytest.approx(1300, abs=3)
+


### PR DESCRIPTION
## Summary
- check subtract_baseline 'none' and time-normalised subtraction
- run pipeline on example_input.csv verifying calibration succeeds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685374141864832badb2bbf412aab9fd