### PR TITLE
Fix division by zero in baseline rate_histogram

### DIFF
--- a/baseline.py
+++ b/baseline.py
@@ -10,6 +10,8 @@ def rate_histogram(df, bins):
         return np.zeros(len(bins) - 1, dtype=float), 0.0
     live = float(df["timestamp"].iloc[-1] - df["timestamp"].iloc[0])
     hist, _ = np.histogram(df["adc"].to_numpy(), bins=bins)
+    if live <= 0:
+        return np.zeros_like(hist, dtype=float), live
     return hist / live, live
 
 

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -7,6 +7,7 @@ import numpy as np
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
+import baseline
 from fitting import FitResult
 
 
@@ -502,3 +503,11 @@ def test_noise_level_none_not_recorded(tmp_path, monkeypatch):
 
     summary = captured.get("summary", {})
     assert "noise_level" not in summary.get("baseline", {})
+
+
+def test_rate_histogram_single_event():
+    df = pd.DataFrame({"timestamp": [1.0], "adc": [10.0]})
+    bins = np.array([0, 20])
+    rate, live = baseline.rate_histogram(df, bins)
+    assert live == 0.0
+    assert np.all(rate == 0.0)


### PR DESCRIPTION
## Summary
- avoid dividing by zero for single-event baseline slices
- test baseline rate histogram with one event

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68537414699c832b8822a6d09507afa8