### PR TITLE
Allow custom CSV column names

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ sample layout which also includes typical auxiliary fields such as
 `baseline_adc`, `spike_flag`, `valid`, `temperature`, `run_id`,
 `pressure` and `humidity`.
 
+When your CSV uses different header names you can specify them under
+the `columns` section of the configuration.  Provide a mapping from the
+canonical names (`timestamp`, `adc`, etc.) to the actual column names in
+the file:
+
+```json
+"columns": {
+    "timestamp": "ftimestamps",
+    "adc": "fadc_channels"
+}
+```
+
 ## Output
 
 The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--job-id` is given the folder `<output_dir>/<job-id>/` is used instead. If the folder already exists run with `--overwrite` to replace it. The directory includes:

--- a/analyze.py
+++ b/analyze.py
@@ -601,7 +601,7 @@ def main(argv=None):
     # 2. Load event data
     # ────────────────────────────────────────────────────────────
     try:
-        df_full = load_events(args.input)
+        df_full = load_events(args.input, column_map=cfg.get("columns"))
     except Exception as e:
         print(f"ERROR: Could not load events from '{args.input}': {e}")
         sys.exit(1)

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -128,6 +128,31 @@ def test_load_events_column_aliases(tmp_path):
     assert "adc_ch" not in loaded.columns
 
 
+def test_load_events_custom_columns(tmp_path):
+    df = pd.DataFrame(
+        {
+            "uid": [1],
+            "bits": [0],
+            "ftimestamps": [1000],
+            "fadc_channels": [1250],
+            "chan": [1],
+        }
+    )
+    p = tmp_path / "custom.csv"
+    df.to_csv(p, index=False)
+    column_map = {
+        "fUniqueID": "uid",
+        "fBits": "bits",
+        "timestamp": "ftimestamps",
+        "adc": "fadc_channels",
+        "fchannel": "chan",
+    }
+    loaded = load_events(p, column_map=column_map)
+    assert list(loaded["timestamp"])[0] == 1000.0
+    assert list(loaded["adc"])[0] == 1250
+    assert "ftimestamps" not in loaded.columns
+
+
 def test_load_events_missing_column(tmp_path):
     df = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- allow specifying CSV column names via a new `columns` config section
- pass the mapping to `load_events`
- update README documentation
- test loading CSV files with custom column names

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685454ed5018832bafca556a57b4cc4d