### PR TITLE
Unify time types & baseline handling

### DIFF
--- a/baseline.py
+++ b/baseline.py
@@ -8,7 +8,12 @@ def rate_histogram(df, bins):
     """Return (histogram in counts/s, live_time_s)"""
     if df.empty:
         return np.zeros(len(bins) - 1, dtype=float), 0.0
-    live = float(df["timestamp"].iloc[-1] - df["timestamp"].iloc[0])
+    t_end = df["timestamp"].iloc[-1]
+    t_start = df["timestamp"].iloc[0]
+    if isinstance(t_end, np.datetime64):
+        live = float((t_end - t_start) / np.timedelta64(1, "s"))
+    else:
+        live = float(t_end - t_start)
     hist_src = df.get("subtracted_adc_hist", df["adc"]).to_numpy()
     hist, _ = np.histogram(hist_src, bins=bins)
     if live <= 0:

--- a/tests/test_baseline_flow.py
+++ b/tests/test_baseline_flow.py
@@ -1,0 +1,69 @@
+import json
+import sys
+from pathlib import Path
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+import baseline_noise
+from fitting import FitResult
+
+
+def test_baseline_flow(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "baseline": {"range": [0, 10], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "calibration": {"noise_cutoff": 5},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": False
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1, 2, 3],
+        "fBits": [0, 0, 0],
+        "timestamp": [1, 2, 20],
+        "adc": [2, 8, 8],
+        "fchannel": [1, 1, 1],
+    })
+    data_path = tmp_path / "data.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "apply_burst_filter", lambda df, cfg, mode="rate": (df, 0))
+    monkeypatch.setattr(baseline_noise, "estimate_baseline_noise", lambda *a, **k: (None, {}))
+
+    captured = {}
+
+    def fake_write(out_dir, summary, timestamp=None):
+        captured["summary"] = summary
+        d = Path(out_dir) / (timestamp or "x")
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+
+    args = [
+        "analyze.py",
+        "--config", str(cfg_path),
+        "--input", str(data_path),
+        "--output_dir", str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+
+    analyze.main()
+
+    summary = captured.get("summary", {})
+    assert summary.get("baseline", {}).get("n_events") == 2

--- a/tests/test_time_parsing.py
+++ b/tests/test_time_parsing.py
@@ -1,0 +1,12 @@
+import pytest
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+
+@pytest.mark.parametrize("spec", ["0", "1970-01-01T00:00:00Z", "1970-01-01T00:00:00+00:00"])
+def test_parse_time_arg_equivalent(spec):
+    dt = analyze.parse_time_arg(spec)
+    assert dt == datetime(1970, 1, 1, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
- keep timestamps as UTC datetimes in io_utils
- add `parse_time_arg` for CLI and use it
- take baseline from raw events and handle datetimes
- update baseline subtraction logic
- tests for time parsing and baseline flow

## Testing
- `pytest tests/test_time_parsing.py tests/test_baseline_flow.py tests/test_io_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6854979e2d20832b91e76ec65c7bc119