### PR TITLE
Add radon baseline utilities

### DIFF
--- a/radon/__init__.py
+++ b/radon/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for radon-related calculations."""
+
+from .baseline import subtract_baseline
+
+__all__ = ["subtract_baseline"]

--- a/radon/baseline.py
+++ b/radon/baseline.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+__all__ = ["subtract_baseline"]
+
+
+def subtract_baseline(counts, efficiency, live_time, baseline_counts, baseline_live_time):
+    rate = counts / live_time / efficiency
+    sigma_sq = counts / live_time**2 / efficiency**2
+    baseline_rate = baseline_counts / baseline_live_time / efficiency
+    baseline_sigma_sq = baseline_counts / baseline_live_time**2 / efficiency**2
+    corrected_rate = rate - baseline_rate
+    corrected_sigma = np.sqrt(sigma_sq + baseline_sigma_sq)
+    return corrected_rate, corrected_sigma


### PR DESCRIPTION
## Summary
- add new `radon` package
- implement `subtract_baseline` utility
- expose `subtract_baseline` via `radon.__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a10bd420832b80197bb2d3467690