### PR TITLE
Update baseline subtraction to use datetime ranges

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -989,8 +989,12 @@ def main(argv=None):
     _ensure_events(df_analysis, "baseline subtraction")
 
     if args.baseline_range:
-        t_base0 = _to_epoch(args.baseline_range[0])
-        t_base1 = _to_epoch(args.baseline_range[1])
+        t_base0 = datetime.fromtimestamp(
+            _to_epoch(args.baseline_range[0]), tz=timezone.utc
+        )
+        t_base1 = datetime.fromtimestamp(
+            _to_epoch(args.baseline_range[1]), tz=timezone.utc
+        )
         edges = adc_hist_edges(df_analysis["adc"].values, hist_bins)
         df_analysis = subtract_baseline(
             df_analysis,

--- a/tests/test_baseline_subtract.py
+++ b/tests/test_baseline_subtract.py
@@ -19,8 +19,8 @@ def test_baseline_none():
         df,
         df,
         bins=bins,
-        t_base0=0,
-        t_base1=5,
+        t_base0=pd.Timestamp(0, unit="s", tz="UTC"),
+        t_base1=pd.Timestamp(5, unit="s", tz="UTC"),
         mode="none",
     )
     hist_before, _ = baseline.rate_histogram(df, bins)
@@ -43,8 +43,8 @@ def test_baseline_time_norm():
         df_an,
         df_full,
         bins=bins,
-        t_base0=100,
-        t_base1=140,
+        t_base0=pd.Timestamp(100, unit="s", tz="UTC"),
+        t_base1=pd.Timestamp(140, unit="s", tz="UTC"),
         mode="all",
     )
     integral = out["subtracted_adc_hist"].iloc[0].sum()


### PR DESCRIPTION
## Summary
- support datetime ranges in `baseline.subtract_baseline`
- convert timestamps to seconds internally
- adjust CLI to pass datetimes
- update baseline subtraction tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a1220064832b90592962cf3a921a