### PR TITLE
Add parse_time_arg helper and time parsing tests

### DIFF
--- a/tests/test_time_parsing.py
+++ b/tests/test_time_parsing.py
@@ -1,0 +1,13 @@
+import pytest
+from datetime import datetime, timezone
+
+from utils import parse_time_arg
+
+@pytest.mark.parametrize("inp", [
+    0,
+    "1970-01-01T00:00:00Z",
+    "1970-01-01T00:00:00+00:00",
+])
+def test_parse_time_arg_variants(inp):
+    dt = parse_time_arg(inp)
+    assert dt == datetime(1970, 1, 1, tzinfo=timezone.utc)

--- a/utils.py
+++ b/utils.py
@@ -14,6 +14,7 @@ __all__ = [
     "adc_hist_edges",
     "cps_to_cpd",
     "cps_to_bq",
+    "parse_time_arg",
     "parse_time",
     "LITERS_PER_M3",
 ]
@@ -195,6 +196,13 @@ def parse_time(s: str) -> float:
         return float(dt.timestamp())
 
     raise argparse.ArgumentTypeError(f"could not parse time: {s!r}")
+
+
+def parse_time_arg(val) -> datetime:
+    """Parse a time argument into a UTC ``datetime`` object."""
+
+    ts = parse_time(val)
+    return datetime.fromtimestamp(ts, tz=timezone.utc)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend utils with `parse_time_arg` returning UTC datetimes
- test multiple input formats parsing to the same datetime

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a1226818832bb67fe729c74a6c79