### PR TITLE
Add baseline uncertainty test

### DIFF
--- a/radon/__init__.py
+++ b/radon/__init__.py
@@ -1,0 +1,3 @@
+"""Simple radon utilities."""
+from .baseline import subtract_baseline
+__all__ = ["subtract_baseline"]

--- a/radon/baseline.py
+++ b/radon/baseline.py
@@ -1,0 +1,41 @@
+"""Utilities for baseline subtraction."""
+import math
+from typing import Tuple
+
+def subtract_baseline(counts: float, baseline_counts: float, efficiency: float,
+                       live_time: float, baseline_live_time: float) -> Tuple[float, float]:
+    """Return background corrected rate and propagated uncertainty.
+
+    Parameters
+    ----------
+    counts : float
+        Total event counts in the analysis window.
+    baseline_counts : float
+        Counts observed in the baseline period.
+    efficiency : float
+        Detection efficiency for the isotope.
+    live_time : float
+        Live time of the analysis measurement in seconds.
+    baseline_live_time : float
+        Live time of the baseline period in seconds.
+
+    Returns
+    -------
+    corrected_rate : float
+        Baseline corrected decay rate in Bq.
+    corrected_sigma : float
+        Propagated 1-sigma uncertainty on the corrected rate.
+    """
+    if efficiency <= 0 or live_time <= 0:
+        return 0.0, 0.0
+    rate = counts / (live_time * efficiency)
+    sigma_rate = math.sqrt(counts) / (live_time * efficiency)
+    if baseline_live_time > 0:
+        baseline_rate = baseline_counts / (baseline_live_time * efficiency)
+        sigma_baseline = math.sqrt(baseline_counts) / (baseline_live_time * efficiency)
+    else:
+        baseline_rate = 0.0
+        sigma_baseline = 0.0
+    corrected_rate = rate - baseline_rate
+    corrected_sigma = math.hypot(sigma_rate, sigma_baseline)
+    return corrected_rate, corrected_sigma

--- a/tests/test_baseline_uncertainty.py
+++ b/tests/test_baseline_uncertainty.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from radon.baseline import subtract_baseline
+
+
+def test_baseline_uncertainty():
+    counts = 100
+    baseline_counts = 25
+    efficiency = 0.5
+    live_time = 3600.0
+    baseline_live_time = 7200.0
+
+    corrected_rate, corrected_sigma = subtract_baseline(
+        counts=counts,
+        baseline_counts=baseline_counts,
+        efficiency=efficiency,
+        live_time=live_time,
+        baseline_live_time=baseline_live_time,
+    )
+
+    expected_rate = counts / (live_time * efficiency) - baseline_counts / (
+        baseline_live_time * efficiency
+    )
+    sigma_rate = np.sqrt(counts) / (live_time * efficiency)
+    sigma_baseline = np.sqrt(baseline_counts) / (baseline_live_time * efficiency)
+    expected_sigma = np.hypot(sigma_rate, sigma_baseline)
+
+    assert corrected_rate == pytest.approx(expected_rate)
+    assert corrected_sigma == pytest.approx(expected_sigma)


### PR DESCRIPTION
## Summary
- implement simple radon.baseline.subtract_baseline utility
- add test verifying baseline subtraction with uncertainties

## Testing
- `pytest tests/test_baseline_uncertainty.py::test_baseline_uncertainty -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a10ecd58832bbde48b5ce0468070