### PR TITLE
Ensure timestamp column parsed as datetime

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -613,6 +613,8 @@ def main(argv=None):
     # ────────────────────────────────────────────────────────────
     try:
         df_full = load_events(args.input, column_map=cfg.get("columns"))
+        if pd.api.types.is_datetime64_any_dtype(df_full["timestamp"]):
+            df_full["timestamp"] = df_full["timestamp"].view("int64") / 1e9
     except Exception as e:
         print(f"ERROR: Could not load events from '{args.input}': {e}")
         sys.exit(1)
@@ -621,8 +623,8 @@ def main(argv=None):
         print("No events found in the input CSV. Exiting.")
         sys.exit(0)
 
-    # ``load_events()`` enforces that ``events["timestamp"]`` is numeric, so no
-    # additional conversion is performed here.
+    # ``load_events()`` now returns timezone-aware datetimes; convert to epoch
+    # seconds for internal calculations.
 
     # ───────────────────────────────────────────────
     # 2a. Pedestal / electronic-noise cut (integer ADC)

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -82,8 +82,11 @@ def test_load_events(tmp_path, caplog):
     df.to_csv(p, index=False)
     with caplog.at_level(logging.INFO):
         loaded = load_events(p)
-    assert loaded["timestamp"].dtype == float
-    assert np.array_equal(loaded["timestamp"].values, np.array([1000.0, 1005.0, 1010.0]))
+    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
+    assert np.array_equal(
+        loaded["timestamp"].values,
+        pd.to_datetime([1000, 1005, 1010], unit="s", utc=True).values,
+    )
     assert np.array_equal(loaded["adc"].values, np.array([1200, 1300, 1250]))
     assert "0 discarded" in caplog.text
 
@@ -103,8 +106,11 @@ def test_load_events_drop_bad_rows(tmp_path, caplog):
     with caplog.at_level(logging.INFO):
         loaded = load_events(p)
     # Expect rows with NaN/inf removed and duplicate dropped
-    assert loaded["timestamp"].dtype == float
-    assert np.array_equal(loaded["timestamp"].values, np.array([1000.0, 1005.0, 1020.0]))
+    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
+    assert np.array_equal(
+        loaded["timestamp"].values,
+        pd.to_datetime([1000, 1005, 1020], unit="s", utc=True).values,
+    )
     assert "3 discarded" in caplog.text
 
 
@@ -121,8 +127,8 @@ def test_load_events_column_aliases(tmp_path):
     p = tmp_path / "alias.csv"
     df.to_csv(p, index=False)
     loaded = load_events(p)
-    assert loaded["timestamp"].dtype == float
-    assert list(loaded["timestamp"])[0] == 1000.0
+    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
+    assert list(loaded["timestamp"])[0] == pd.to_datetime(1000, unit="s", utc=True)
     assert list(loaded["adc"])[0] == 1250
     assert "time" not in loaded.columns
     assert "adc_ch" not in loaded.columns
@@ -148,7 +154,7 @@ def test_load_events_custom_columns(tmp_path):
         "fchannel": "chan",
     }
     loaded = load_events(p, column_map=column_map)
-    assert list(loaded["timestamp"])[0] == 1000.0
+    assert list(loaded["timestamp"])[0] == pd.to_datetime(1000, unit="s", utc=True)
     assert list(loaded["adc"])[0] == 1250
     assert "ftimestamps" not in loaded.columns
 
@@ -183,7 +189,7 @@ def test_load_events_string_nan(tmp_path):
     df.to_csv(p, index=False)
     loaded = load_events(p)
     assert len(loaded) == 1
-    assert loaded["timestamp"].iloc[0] == 1000.0
+    assert loaded["timestamp"].iloc[0] == pd.to_datetime(1000, unit="s", utc=True)
 
 
 def test_write_summary_and_copy_config(tmp_path):


### PR DESCRIPTION
## Summary
- parse timestamps to timezone-aware datetimes in `load_events`
- convert timestamps to epoch seconds inside `analyze` for backward compatibility
- update tests to expect datetime dtype

## Testing
- `pytest -q tests/test_io_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a11ed88c832bb6679567e7a4d004