### PR TITLE
Add baseline uncertainty unit test

### DIFF
--- a/tests/test_baseline_uncertainty.py
+++ b/tests/test_baseline_uncertainty.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import pytest
+import numpy as np
+from radon.baseline import subtract_baseline
+
+
+def test_subtract_baseline_uncertainty():
+    counts = 50
+    baseline_counts = 20
+    efficiency = 0.5
+    live_time = 100.0
+    baseline_live_time = 50.0
+
+    expected_rate = counts / live_time / efficiency - baseline_counts / baseline_live_time / efficiency
+    expected_sigma_sq = (
+        counts / live_time**2 / efficiency**2
+        + baseline_counts / baseline_live_time**2 / efficiency**2
+    )
+    expected_sigma = np.sqrt(expected_sigma_sq)
+
+    rate, sigma = subtract_baseline(
+        counts, efficiency, live_time, baseline_counts, baseline_live_time
+    )
+
+    assert rate == pytest.approx(expected_rate)
+    assert sigma == pytest.approx(expected_sigma)
+


### PR DESCRIPTION
## Summary
- add a unit test verifying `radon.baseline.subtract_baseline`

## Testing
- `pytest tests/test_baseline_uncertainty.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a33e6a50832b8b416cf5fb98832e