### PR TITLE
Use parse_time for timestamp parsing

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -99,7 +99,7 @@ from plot_utils import (
 )
 from systematics import scan_systematics, apply_linear_adc_shift
 from visualize import cov_heatmap, efficiency_bar
-from utils import find_adc_bin_peaks, adc_hist_edges, cps_to_bq
+from utils import find_adc_bin_peaks, adc_hist_edges, cps_to_bq, parse_time
 from radmon.baseline import subtract_baseline
 
 
@@ -683,7 +683,7 @@ def main(argv=None):
     t0_cfg = cfg.get("analysis", {}).get("analysis_start_time")
     if t0_cfg is not None:
         try:
-            t0_global = pd.to_datetime(t0_cfg, utc=True).timestamp()
+            t0_global = parse_time(t0_cfg)
         except Exception:
             logging.warning(
                 f"Invalid analysis_start_time '{t0_cfg}' - using first event"
@@ -693,10 +693,7 @@ def main(argv=None):
         t0_global = df_full["timestamp"].min()
 
     def _to_epoch(val):
-        try:
-            return float(val)
-        except Exception:
-            return pd.to_datetime(val, utc=True).timestamp()
+        return parse_time(val)
 
     t_end_cfg = cfg.get("analysis", {}).get("analysis_end_time")
     t_end_global = None
@@ -916,10 +913,7 @@ def main(argv=None):
     if baseline_range:
 
         def to_epoch(x):
-            try:
-                return float(x)
-            except Exception:
-                return pd.to_datetime(x, utc=True).timestamp()
+            return parse_time(x)
 
         t_start_base = to_epoch(baseline_range[0])
         t_end_base = to_epoch(baseline_range[1])

--- a/baseline.py
+++ b/baseline.py
@@ -1,6 +1,7 @@
 import numpy as np
 import logging
 import pandas as pd
+from utils import parse_time
 
 __all__ = ["rate_histogram", "subtract_baseline"]
 
@@ -57,8 +58,8 @@ def subtract_baseline(df_analysis, df_full, bins, t_base0, t_base1,
         live_time_analysis = live_an
 
     # baseline slice
-    t0 = pd.to_datetime(t_base0, utc=True).timestamp()
-    t1 = pd.to_datetime(t_base1, utc=True).timestamp()
+    t0 = parse_time(t_base0)
+    t1 = parse_time(t_base1)
     ts_full = _seconds(df_full["timestamp"])
     mask = (ts_full >= t0) & (ts_full <= t1)
     if not mask.any():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 import pytest
+from datetime import datetime, timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -61,3 +62,13 @@ def test_parse_time_iso_no_fraction():
 
 def test_parse_time_iso_fraction():
     assert parse_time("1970-01-01T00:00:00.5Z") == pytest.approx(0.5)
+
+
+def test_parse_time_datetime_naive():
+    dt = datetime(1970, 1, 1)
+    assert parse_time(dt) == pytest.approx(0.0)
+
+
+def test_parse_time_datetime_aware():
+    dt = datetime(1970, 1, 1, tzinfo=timezone.utc)
+    assert parse_time(dt) == pytest.approx(0.0)

--- a/utils.py
+++ b/utils.py
@@ -174,10 +174,15 @@ def cps_to_bq(rate_cps, volume_liters=None):
     return float(rate_cps) / volume_m3
 
 
-def parse_time(s: str) -> float:
-    """Parse a timestamp string or integer into Unix epoch seconds as a float."""
+def parse_time(s) -> float:
+    """Parse a timestamp string, ``datetime`` or number into Unix epoch seconds."""
     if isinstance(s, (int, float)):
         return float(s)
+
+    if isinstance(s, datetime):
+        if s.tzinfo is None:
+            s = s.replace(tzinfo=timezone.utc)
+        return float(s.timestamp())
 
     if isinstance(s, str):
         try:


### PR DESCRIPTION
## Summary
- centralize timestamp parsing by using `parse_time`
- extend `parse_time` to handle `datetime` inputs
- adjust baseline and analysis pipelines to use the helper
- test `parse_time` with naive and aware datetimes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a4f8223c832baf36a227e88657ce