### PR TITLE
Rename radon baseline helper

### DIFF
--- a/radon/__init__.py
+++ b/radon/__init__.py
@@ -1,5 +1,5 @@
 """Utilities for radon-related calculations."""
 
-from .baseline import subtract_baseline
+from .baseline import subtract_baseline_counts
 
-__all__ = ["subtract_baseline"]
+__all__ = ["subtract_baseline_counts"]

--- a/radon/baseline.py
+++ b/radon/baseline.py
@@ -1,9 +1,36 @@
 import numpy as np
 
-__all__ = ["subtract_baseline"]
+__all__ = ["subtract_baseline_counts"]
 
 
-def subtract_baseline(counts, efficiency, live_time, baseline_counts, baseline_live_time):
+def subtract_baseline_counts(
+    counts: float,
+    efficiency: float,
+    live_time: float,
+    baseline_counts: float,
+    baseline_live_time: float,
+) -> tuple[float, float]:
+    """Return baseline-corrected rate and uncertainty.
+
+    Parameters
+    ----------
+    counts : float
+        Total counts in the signal region.
+    efficiency : float
+        Detection efficiency of the signal.
+    live_time : float
+        Exposure time for ``counts`` in seconds.
+    baseline_counts : float
+        Counts measured during the baseline interval.
+    baseline_live_time : float
+        Exposure time for the baseline counts in seconds.
+
+    Returns
+    -------
+    tuple of float
+        Corrected rate in counts per second and its one-sigma uncertainty.
+    """
+
     rate = counts / live_time / efficiency
     sigma_sq = counts / live_time**2 / efficiency**2
     baseline_rate = baseline_counts / baseline_live_time / efficiency

--- a/tests/test_baseline_uncertainty.py
+++ b/tests/test_baseline_uncertainty.py
@@ -3,7 +3,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import pytest
 import numpy as np
-from radon.baseline import subtract_baseline
+from radon.baseline import subtract_baseline_counts
 
 
 def test_subtract_baseline_uncertainty():
@@ -20,7 +20,7 @@ def test_subtract_baseline_uncertainty():
     )
     expected_sigma = np.sqrt(expected_sigma_sq)
 
-    rate, sigma = subtract_baseline(
+    rate, sigma = subtract_baseline_counts(
         counts, efficiency, live_time, baseline_counts, baseline_live_time
     )
 


### PR DESCRIPTION
## Summary
- rename `radon.baseline.subtract_baseline` to `subtract_baseline_counts`
- add detailed docstring describing counts-based subtraction
- re-export new helper from `radon.__init__`
- update tests to use the new name

## Testing
- `pytest tests/test_baseline_uncertainty.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854aa4af774832ba8f078008a0848b9