### PR TITLE
Ensure baseline uses all events

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -612,16 +612,19 @@ def main(argv=None):
     # 2. Load event data
     # ────────────────────────────────────────────────────────────
     try:
-        df_full = load_events(args.input, column_map=cfg.get("columns"))
-        if pd.api.types.is_datetime64_any_dtype(df_full["timestamp"]):
-            df_full["timestamp"] = df_full["timestamp"].view("int64") / 1e9
+        df_all = load_events(args.input, column_map=cfg.get("columns"))
+        if pd.api.types.is_datetime64_any_dtype(df_all["timestamp"]):
+            df_all["timestamp"] = df_all["timestamp"].view("int64") / 1e9
     except Exception as e:
         print(f"ERROR: Could not load events from '{args.input}': {e}")
         sys.exit(1)
 
-    if df_full.empty:
+    if df_all.empty:
         print("No events found in the input CSV. Exiting.")
         sys.exit(0)
+
+    events_all = df_all.copy()
+    events_filtered = events_all.copy()
 
     # ``load_events()`` now returns timezone-aware datetimes; convert to epoch
     # seconds for internal calculations.
@@ -641,16 +644,16 @@ def main(argv=None):
             )
             noise_thr_val = None
         else:
-            before = len(df_full)
-            df_full = df_full[df_full["adc"] > noise_thr_val].reset_index(drop=True)
-            n_removed_noise = before - len(df_full)
+            before = len(events_filtered)
+            events_filtered = events_filtered[events_filtered["adc"] > noise_thr_val].reset_index(drop=True)
+            n_removed_noise = before - len(events_filtered)
             logging.info(f"Noise cut removed {n_removed_noise} events")
 
-    _ensure_events(df_full, "noise cut")
+    _ensure_events(events_filtered, "noise cut")
 
     # Optional burst filter to remove high-rate clusters
-    total_span = df_full["timestamp"].max() - df_full["timestamp"].min()
-    rate_cps = len(df_full) / max(total_span, 1e-9)
+    total_span = events_filtered["timestamp"].max() - events_filtered["timestamp"].min()
+    rate_cps = len(events_filtered) / max(total_span, 1e-9)
     if args.burst_mode is None:
         current_mode = cfg.get("burst_filter", {}).get("burst_mode", "rate")
         if current_mode == "rate" and rate_cps < 0.1:
@@ -662,8 +665,8 @@ def main(argv=None):
         else cfg.get("burst_filter", {}).get("burst_mode", "rate")
     )
 
-    n_before_burst = len(df_full)
-    df_full, n_removed_burst = apply_burst_filter(df_full, cfg, mode=burst_mode)
+    n_before_burst = len(events_filtered)
+    events_filtered, n_removed_burst = apply_burst_filter(events_filtered, cfg, mode=burst_mode)
     if n_before_burst > 0:
         frac_removed = n_removed_burst / n_before_burst
         logging.info(
@@ -674,12 +677,7 @@ def main(argv=None):
                 f"More than half of events vetoed by burst filter ({frac_removed:.1%})"
             )
 
-    _ensure_events(df_full, "burst filtering")
-
-    # Keep a copy of the data set after noise and burst filtering but before
-    # any time-window selections. This full set is later used to extract
-    # baseline events independent of the analysis time windows.
-    events_full = df_full.copy()
+    _ensure_events(events_filtered, "burst filtering")
 
     # Global t₀ reference
     t0_cfg = cfg.get("analysis", {}).get("analysis_start_time")
@@ -690,9 +688,9 @@ def main(argv=None):
             logging.warning(
                 f"Invalid analysis_start_time '{t0_cfg}' - using first event"
             )
-            t0_global = df_full["timestamp"].min()
+            t0_global = events_filtered["timestamp"].min()
     else:
-        t0_global = df_full["timestamp"].min()
+        t0_global = events_filtered["timestamp"].min()
 
     def _to_epoch(val):
         try:
@@ -776,7 +774,7 @@ def main(argv=None):
             radon_interval = None
 
     # Apply optional time window cuts before any baseline or fit operations
-    df_analysis = df_full.copy()
+    df_analysis = events_filtered.copy()
     if t_spike_end is not None:
         df_analysis = df_analysis[df_analysis["timestamp"] >= t_spike_end].reset_index(drop=True)
     for start_ts, end_ts in spike_periods:
@@ -927,13 +925,13 @@ def main(argv=None):
         t_end_base = to_epoch(baseline_range[1])
         if t_end_base <= t_start_base:
             raise ValueError("baseline_range end time must be greater than start time")
-        mask_base_full = (events_full["timestamp"] >= t_start_base) & (
-            events_full["timestamp"] < t_end_base
+        mask_base_full = (events_all["timestamp"] >= t_start_base) & (
+            events_all["timestamp"] < t_end_base
         )
         mask_base = (df_analysis["timestamp"] >= t_start_base) & (
             df_analysis["timestamp"] < t_end_base
         )
-        base_events = events_full[mask_base_full].copy()
+        base_events = events_all[mask_base_full].copy()
         # Apply calibration to the baseline events
         if not base_events.empty:
             base_events["energy_MeV"] = apply_calibration(
@@ -1007,7 +1005,7 @@ def main(argv=None):
         edges = adc_hist_edges(df_analysis["adc"].values, hist_bins)
         df_analysis = subtract_baseline(
             df_analysis,
-            df_full,
+            events_all,
             bins=edges,
             t_base0=t_base0,
             t_base1=t_base1,

--- a/tests/test_baseline_flow.py
+++ b/tests/test_baseline_flow.py
@@ -1,0 +1,81 @@
+import json
+import sys
+from pathlib import Path
+import pandas as pd
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+import baseline_noise
+from fitting import FitResult
+
+
+def test_baseline_event_survives_noise_cut(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "baseline": {"range": [0, 10], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "calibration": {"noise_cutoff": 10},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": True,
+            "window_po214": [10, 14],
+            "hl_po214": [1.0, 0.0],
+            "eff_po214": [1.0, 0.0],
+            "flags": {},
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1, 2],
+        "fBits": [0, 0],
+        "timestamp": [5.0, 15.0],
+        "adc": [5, 12],
+        "fchannel": [1, 1],
+    })
+    data_path = tmp_path / "data.csv"
+    df.to_csv(data_path, index=False)
+
+    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "apply_burst_filter", lambda df, cfg, mode="rate": (df, 0))
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(baseline_noise, "estimate_baseline_noise", lambda *a, **k: (None, {}))
+
+    captured = {}
+
+    def fake_fit(ts_dict, t_start, t_end, cfg, **kwargs):
+        captured["times"] = ts_dict.get("Po214", []).tolist()
+        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
+
+    monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
+
+    def fake_write(out_dir, summary, timestamp=None):
+        captured["summary"] = summary
+        d = Path(out_dir) / (timestamp or "x")
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config", str(cfg_path),
+        "--input", str(data_path),
+        "--output_dir", str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    summary = captured["summary"]
+    assert summary["baseline"]["n_events"] == 1
+    assert captured.get("times") == [15.0]


### PR DESCRIPTION
## Summary
- keep unfiltered events as `events_all`
- apply noise and burst filters to a separate `events_filtered`
- base the baseline window and subtraction on `events_all`
- add regression test confirming baseline events survive filtering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854aa290620832b9753a7d8edd18aae