### PR TITLE
Add uncertainty bands to time-series plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,12 @@ Example snippet:
 }
 ```
 
+`plot_time_series` can also display uncertainty bands around the model
+curves.  Pass arrays of propagated errors via the optional
+`model_errors` argument.  When running `analyze.py` these arrays are
+derived from the fitted parameters (`corrected_sigma`) so shaded ±1σ
+regions appear alongside the dashed model lines.
+
 `plot_time_series` takes its half-life values from the `time_fit` section.
 Specify custom values using the keys `hl_po214`, `hl_po218` and `hl_po210`.
 When these keys are omitted, `hl_po214` and `hl_po218` fall back to their

--- a/analyze.py
+++ b/analyze.py
@@ -201,6 +201,78 @@ def get_spike_efficiency(spike_cfg):
     return _spike_eff_cache[key]
 
 
+def _ts_bin_centers_widths(times, cfg, t_start, t_end):
+    """Return bin centers and widths matching :func:`plot_time_series`."""
+    times_rel = np.asarray(times, dtype=float) - float(t_start)
+    bin_mode = str(
+        cfg.get("plot_time_binning_mode", cfg.get("time_bin_mode", "fixed"))
+    ).lower()
+    if bin_mode in ("fd", "auto"):
+        data = times_rel[(times_rel >= 0) & (times_rel <= (t_end - t_start))]
+        if len(data) < 2:
+            n_bins = 1
+        else:
+            q25, q75 = np.percentile(data, [25, 75])
+            iqr = q75 - q25
+            if iqr <= 0:
+                n_bins = int(cfg.get("time_bins_fallback", 1))
+            else:
+                bin_width = 2 * iqr / (len(data) ** (1.0 / 3.0))
+                if isinstance(bin_width, np.timedelta64):
+                    bin_width = bin_width / np.timedelta64(1, "s")
+                    data_range = (data.max() - data.min()) / np.timedelta64(1, "s")
+                else:
+                    data_range = data.max() - data.min()
+                n_bins = max(1, int(np.ceil(data_range / float(bin_width))))
+    else:
+        dt = int(cfg.get("plot_time_bin_width_s", cfg.get("time_bin_s", 3600)))
+        n_bins = int(np.floor((t_end - t_start) / dt))
+        if n_bins < 1:
+            n_bins = 1
+
+    if bin_mode not in ("fd", "auto"):
+        edges = np.arange(0, (n_bins + 1) * dt, dt, dtype=float)
+    else:
+        edges = np.linspace(0, (t_end - t_start), n_bins + 1)
+    centers = 0.5 * (edges[:-1] + edges[1:])
+    widths = np.diff(edges)
+    return centers, widths
+
+
+def _model_uncertainty(centers, widths, fit_obj, iso, cfg, normalise):
+    """Propagate fit parameter errors to the model curve."""
+    if fit_obj is None:
+        return None
+    params = _fit_params(fit_obj)
+    default_const = cfg.get("nuclide_constants", {})
+    hl_default = {
+        "Po214": default_const.get("Po214", PO214).half_life_s,
+        "Po218": default_const.get("Po218", PO218).half_life_s,
+        "Po210": default_const.get("Po210", PO210).half_life_s,
+    }[iso]
+    hl = cfg.get("time_fit", {}).get(f"hl_{iso.lower()}", [hl_default])[0]
+    eff = cfg.get("time_fit", {}).get(f"eff_{iso.lower()}", [1.0])[0]
+    lam = math.log(2.0) / float(hl)
+    dE = params.get("dE_corrected", params.get(f"dE_{iso}", 0.0))
+    dN0 = params.get(f"dN0_{iso}", 0.0)
+    dB = params.get(f"dB_{iso}", params.get("dB", 0.0))
+    cov = 0.0
+    try:
+        cov = _cov_entry(fit_obj, f"E_{iso}", f"N0_{iso}")
+    except Exception:
+        cov = 0.0
+    t = np.asarray(centers, dtype=float)
+    exp_term = np.exp(-lam * t)
+    dR_dE = eff * (1.0 - exp_term)
+    dR_dN0 = eff * lam * exp_term
+    dR_dB = 1.0
+    var = (dR_dE * dE) ** 2 + (dR_dN0 * dN0) ** 2 + (dR_dB * dB) ** 2
+    if cov:
+        var += 2.0 * dR_dE * dR_dN0 * cov
+    sigma_rate = np.sqrt(var)
+    return sigma_rate if normalise else sigma_rate * widths
+
+
 def parse_args(argv=None):
     """Parse command line arguments."""
     p = argparse.ArgumentParser(description="Full Radon Monitor Analysis Pipeline")
@@ -1778,6 +1850,24 @@ def main(argv=None):
                     obj = time_fit_results.get(k)
                     if obj:
                         fit_dict.update(_fit_params(obj))
+
+            centers, widths = _ts_bin_centers_widths(
+                ts_times, plot_cfg, t0_global, t_end_global
+            )
+            normalise = bool(plot_cfg.get("plot_time_normalise_rate", False))
+            model_errs = {}
+            iso_list_err = [iso] if not overlay else [i for i in ("Po214", "Po218", "Po210") if time_fit_results.get(i)]
+            for iso_key in iso_list_err:
+                sigma_arr = _model_uncertainty(
+                    centers,
+                    widths,
+                    time_fit_results.get(iso_key),
+                    iso_key,
+                    plot_cfg,
+                    normalise,
+                )
+                if sigma_arr is not None:
+                    model_errs[iso_key] = sigma_arr
             _ = plot_time_series(
                 all_timestamps=ts_times,
                 all_energies=ts_energy,
@@ -1786,6 +1876,7 @@ def main(argv=None):
                 t_end=t_end_global,
                 config=plot_cfg,
                 out_png=Path(out_dir) / f"time_series_{iso}.png",
+                model_errors=model_errs,
             )
         except Exception as e:
             print(f"WARNING: Could not create time-series plot for {iso} -> {e}")

--- a/plot_utils.py
+++ b/plot_utils.py
@@ -86,6 +86,8 @@ def plot_time_series(
     out_png,
     hl_po214=None,
     hl_po218=None,
+    *,
+    model_errors=None,
     **_legacy_kwargs,
 ):
     """
@@ -101,6 +103,10 @@ def plot_time_series(
         ``PO214_HALF_LIFE_S`` and ``PO218_HALF_LIFE_S`` respectively.
         When Po-210 is plotted the overlay uses the ``hl_po210``
         configuration value.
+    model_errors : dict[str, array-like], optional
+        Mapping of isotope name to 1D arrays of uncertainties for the
+        model curve. When provided, ``fill_between`` is used to draw
+        ±1σ bands around the corresponding model.
     """
 
     if fit_results is None:
@@ -309,6 +315,20 @@ def plot_time_series(
                 ls="--",
                 label=f"Model {iso}",
             )
+            if model_errors and iso in model_errors:
+                err = np.asarray(model_errors[iso], dtype=float)
+                if err.size == model_counts.size:
+                    kw = {"step": "mid"} if style != "lines" else {}
+                    plt.fill_between(
+                        centers_dt,
+                        model_counts - err,
+                        model_counts + err,
+                        color=colors[iso],
+                        alpha=0.3,
+                        **kw,
+                    )
+                else:
+                    raise ValueError("model_errors array length mismatch")
 
     plt.xlabel("Time")
     plt.ylabel("Counts / s" if normalise_rate else "Counts per bin")

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -773,3 +773,34 @@ def test_plot_radon_activity_axis_labels(tmp_path, monkeypatch):
     assert captured["axis"].get_xlabel() == "Elapsed Time (s)"
 
 
+def test_plot_time_series_uncertainty_band(tmp_path, monkeypatch):
+    times = np.array([1000.1, 1000.6, 1001.2, 1001.8])
+    energies = np.full_like(times, 7.7)
+    cfg = basic_config()
+    cfg.update({"plot_time_bin_width_s": 1.0})
+
+    band_called = {}
+
+    def fake_fill(x, y1, y2, *args, **kwargs):
+        band_called["ok"] = True
+        return type("obj", (), {})()
+
+    monkeypatch.setattr("plot_utils.plt.fill_between", fake_fill)
+    monkeypatch.setattr("plot_utils.plt.savefig", lambda *a, **k: None)
+
+    model_errs = {"Po214": np.full(3, 0.1)}
+
+    plot_time_series(
+        times,
+        energies,
+        {"E": 0.1, "B": 0.0, "N0": 0.0},
+        1000.0,
+        1003.0,
+        cfg,
+        str(tmp_path / "ts_band.png"),
+        model_errors=model_errs,
+    )
+
+    assert band_called.get("ok")
+
+


### PR DESCRIPTION
## Summary
- extend `plot_time_series` with `model_errors` parameter and draw shaded sigma bands
- compute model uncertainties from fit results in `analyze.py`
- document the feature in README
- test new plotting option

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854aa4928a4832bb788951535438b87