### PR TITLE
Add corrected baseline rates to summary

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1538,6 +1538,9 @@ def main(argv=None):
     }
     baseline_info["scales"] = scales
 
+    corrected_rates = {}
+    corrected_unc = {}
+
     for iso, rate in baseline_rates.items():
         fit = time_fit_results.get(iso)
         params = _fit_params(fit)
@@ -1553,12 +1556,19 @@ def main(argv=None):
                 )[0]
                 if eff > 0:
                     sigma_rate = math.sqrt(count) / (baseline_live_time * eff)
-            params["dE_corrected"] = float(math.hypot(err_fit, sigma_rate * s))
+            dE_corr = float(math.hypot(err_fit, sigma_rate * s))
+            params["dE_corrected"] = dE_corr
+            corrected_rates[iso] = params["E_corrected"]
+            corrected_unc[iso] = dE_corr
 
     if baseline_rates:
         baseline_info["rate_Bq"] = baseline_rates
         baseline_info["rate_unc_Bq"] = baseline_unc
         baseline_info["dilution_factor"] = dilution_factor
+    if corrected_rates:
+        baseline_info["corrected_rate_Bq"] = corrected_rates
+    if corrected_unc:
+        baseline_info["corrected_sigma_Bq"] = corrected_unc
 
     # ────────────────────────────────────────────────────────────
     # Radon activity extrapolation

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -84,8 +84,12 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
     assert summary["baseline"]["scales"]["Po218"] == pytest.approx(1.0)
     assert summary["baseline"]["scales"]["Po210"] == pytest.approx(1.0)
     assert summary["baseline"]["scales"]["noise"] == pytest.approx(1.0)
+    corr_rate = summary["baseline"]["corrected_rate_Bq"]["Po214"]
+    corr_sig = summary["baseline"]["corrected_sigma_Bq"]["Po214"]
     assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(0.8)
     assert summary["time_fit"]["Po214"]["dE_corrected"] == pytest.approx(0.1414213562373095)
+    assert corr_rate == pytest.approx(0.8)
+    assert corr_sig == pytest.approx(0.1414213562373095)
     assert summary["baseline"].get("noise_level") == 5.0
     times = list(captured.get("times", []))
     assert times == [1, 2, 20]
@@ -160,8 +164,12 @@ def test_baseline_scaling_factor(tmp_path, monkeypatch):
     assert dilution == pytest.approx(0.5)
     assert summary["baseline"]["scales"]["Po214"] == pytest.approx(0.5)
     assert summary["baseline"]["scales"]["Po218"] == pytest.approx(0.5)
+    corr_rate = summary["baseline"]["corrected_rate_Bq"]["Po214"]
+    corr_sig = summary["baseline"]["corrected_sigma_Bq"]["Po214"]
     assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(0.9)
     assert summary["time_fit"]["Po214"]["dE_corrected"] == pytest.approx(0.07071067811865475)
+    assert corr_rate == pytest.approx(0.9)
+    assert corr_sig == pytest.approx(0.07071067811865475)
 
 
 def test_n0_prior_from_baseline(tmp_path, monkeypatch):
@@ -314,6 +322,8 @@ def test_isotopes_to_subtract_control(tmp_path, monkeypatch):
     assert "rate_Bq" not in summary.get("baseline", {})
     assert "E_corrected" not in summary["time_fit"]["Po214"]
     assert "dE_corrected" not in summary["time_fit"]["Po214"]
+    assert "corrected_rate_Bq" not in summary.get("baseline", {})
+    assert "corrected_sigma_Bq" not in summary.get("baseline", {})
     assert summary["baseline"]["scales"]["Po214"] == pytest.approx(1.0)
 
 
@@ -438,6 +448,10 @@ def test_baseline_scaling_multiple_isotopes(tmp_path, monkeypatch):
 
     assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(exp_e214)
     assert summary["time_fit"]["Po214"]["dE_corrected"] == pytest.approx(exp_d214)
+    corr_rate = summary["baseline"]["corrected_rate_Bq"]["Po214"]
+    corr_sig = summary["baseline"]["corrected_sigma_Bq"]["Po214"]
+    assert corr_rate == pytest.approx(exp_e214)
+    assert corr_sig == pytest.approx(exp_d214)
     # Po-218 fit results may be absent in this minimal dataset
 
 


### PR DESCRIPTION
## Summary
- track corrected baseline rates and uncertainties per isotope
- persist them in summary.json
- test that baseline summaries include the new fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854aa4a0600832b8a1e0e7a9ad35d08