### PR TITLE
Update baseline time parsing

### DIFF
--- a/baseline.py
+++ b/baseline.py
@@ -1,6 +1,7 @@
 import numpy as np
 import logging
 import pandas as pd
+from utils import parse_time
 
 __all__ = ["rate_histogram", "subtract_baseline"]
 
@@ -57,8 +58,8 @@ def subtract_baseline(df_analysis, df_full, bins, t_base0, t_base1,
         live_time_analysis = live_an
 
     # baseline slice
-    t0 = pd.to_datetime(t_base0, utc=True).timestamp()
-    t1 = pd.to_datetime(t_base1, utc=True).timestamp()
+    t0 = parse_time(t_base0)
+    t1 = parse_time(t_base1)
     ts_full = _seconds(df_full["timestamp"])
     mask = (ts_full >= t0) & (ts_full <= t1)
     if not mask.any():

--- a/utils.py
+++ b/utils.py
@@ -175,9 +175,15 @@ def cps_to_bq(rate_cps, volume_liters=None):
 
 
 def parse_time(s: str) -> float:
-    """Parse a timestamp string or integer into Unix epoch seconds as a float."""
+    """Parse a timestamp string, number, or ``datetime`` into Unix epoch seconds."""
     if isinstance(s, (int, float)):
         return float(s)
+
+    if isinstance(s, datetime):
+        dt = s
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return float(dt.timestamp())
 
     if isinstance(s, str):
         try:


### PR DESCRIPTION
## Summary
- handle `datetime` objects in `parse_time`
- import and use `parse_time` in `subtract_baseline`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854aaf9df0c832b9c796c2dd83de5e0