### PR TITLE
Rename radon baseline helper

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -107,7 +107,7 @@ from utils import (
     parse_time_arg,
 )
 from radmon.baseline import subtract_baseline
-from radon.baseline import subtract_baseline as subtract_radon_baseline
+from radon.baseline import subtract_baseline_counts
 
 
 def _fit_params(obj):
@@ -1253,7 +1253,7 @@ def main(argv=None):
             analysis_counts = float(np.sum(iso_events["weight"]))
             live_time_analysis = (analysis_end - analysis_start).total_seconds()
             if iso in isotopes_to_subtract and baseline_live_time > 0 and eff > 0:
-                c_rate, c_sigma = subtract_radon_baseline(
+                c_rate, c_sigma = subtract_baseline_counts(
                     analysis_counts,
                     eff,
                     live_time_analysis,

--- a/radon/__init__.py
+++ b/radon/__init__.py
@@ -1,5 +1,5 @@
 """Utilities for radon-related calculations."""
 
-from .baseline import subtract_baseline
+from .baseline import subtract_baseline_counts
 
-__all__ = ["subtract_baseline"]
+__all__ = ["subtract_baseline_counts"]

--- a/radon/baseline.py
+++ b/radon/baseline.py
@@ -1,9 +1,38 @@
+"""Utility functions for radon baseline subtraction using raw counts."""
+
 import numpy as np
 
-__all__ = ["subtract_baseline"]
+__all__ = ["subtract_baseline_counts"]
 
 
-def subtract_baseline(counts, efficiency, live_time, baseline_counts, baseline_live_time):
+def subtract_baseline_counts(
+    counts: float,
+    efficiency: float,
+    live_time: float,
+    baseline_counts: float,
+    baseline_live_time: float,
+) -> tuple[float, float]:
+    """Return background-corrected rate and uncertainty.
+
+    Parameters
+    ----------
+    counts : float
+        Number of signal counts in the analysis window.
+    efficiency : float
+        Detection efficiency for the signal counts.
+    live_time : float
+        Live time associated with ``counts`` in seconds.
+    baseline_counts : float
+        Counts measured in the baseline window.
+    baseline_live_time : float
+        Live time associated with ``baseline_counts`` in seconds.
+
+    Notes
+    -----
+    This function operates purely on scalar count values and efficiencies. It is
+    **not** intended for DataFrame-based spectra or time series.
+    """
+
     rate = counts / live_time / efficiency
     sigma_sq = counts / live_time**2 / efficiency**2
     baseline_rate = baseline_counts / baseline_live_time / efficiency

--- a/tests/test_baseline_uncertainty.py
+++ b/tests/test_baseline_uncertainty.py
@@ -3,7 +3,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import pytest
 import numpy as np
-from radon.baseline import subtract_baseline
+from radon.baseline import subtract_baseline_counts
 
 
 def test_subtract_baseline_uncertainty():
@@ -20,7 +20,7 @@ def test_subtract_baseline_uncertainty():
     )
     expected_sigma = np.sqrt(expected_sigma_sq)
 
-    rate, sigma = subtract_baseline(
+    rate, sigma = subtract_baseline_counts(
         counts, efficiency, live_time, baseline_counts, baseline_live_time
     )
 


### PR DESCRIPTION
## Summary
- rename `radon.baseline.subtract_baseline` to `subtract_baseline_counts`
- update imports and references
- clarify behaviour with docstring

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854ac1168f0832bb542682920f89830