### PR TITLE
Add tests for parse_time_arg helper

### DIFF
--- a/tests/test_time_parsing.py
+++ b/tests/test_time_parsing.py
@@ -1,5 +1,10 @@
+import sys
+from pathlib import Path
+import argparse
 import pytest
 from datetime import datetime, timezone
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from utils import parse_time_arg
 
@@ -11,3 +16,34 @@ from utils import parse_time_arg
 def test_parse_time_arg_variants(inp):
     dt = parse_time_arg(inp)
     assert dt == datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize(
+    "inp,expected",
+    [
+        ("1970-01-01T00:00:00", datetime(1970, 1, 1, tzinfo=timezone.utc)),
+        (
+            "1970-01-01T01:00:00+01:00",
+            datetime(1970, 1, 1, tzinfo=timezone.utc),
+        ),
+    ],
+)
+def test_parse_time_arg_iso_offsets(inp, expected):
+    assert parse_time_arg(inp) == expected
+
+
+@pytest.mark.parametrize(
+    "inp,expected",
+    [
+        (0, datetime(1970, 1, 1, tzinfo=timezone.utc)),
+        (0.5, datetime(1970, 1, 1, 0, 0, 0, 500000, tzinfo=timezone.utc)),
+    ],
+)
+def test_parse_time_arg_numeric(inp, expected):
+    assert parse_time_arg(inp) == expected
+
+
+@pytest.mark.parametrize("inp", ["foo", "1970-13-01"])
+def test_parse_time_arg_invalid(inp):
+    with pytest.raises((argparse.ArgumentTypeError, ValueError)):
+        parse_time_arg(inp)


### PR DESCRIPTION
## Summary
- expand test suite for `parse_time_arg`
- cover ISO strings with/without timezone offsets
- ensure epoch integers/floats are parsed correctly
- check invalid values raise ArgumentTypeError/ValueError

## Testing
- `pytest -q tests/test_time_parsing.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854afb10988832b810a5e04d2be9670