### PR TITLE
Implement parse_datetime

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -4,7 +4,8 @@ import shutil
 import json
 import logging
 import warnings
-from datetime import datetime
+from datetime import datetime, timezone
+from dateutil import parser as date_parser
 import pandas as pd
 from constants import load_nuclide_overrides
 
@@ -199,6 +200,41 @@ def ensure_dir(path):
     p = Path(path)
     if not p.is_dir():
         p.mkdir(parents=True, exist_ok=True)
+
+
+def parse_datetime(value):
+    """Parse an ISO-8601 string or numeric epoch value to ``numpy.datetime64``.
+
+    The function accepts strings like ``"2023-09-28T13:45:00-04:00"`` or
+    numeric Unix timestamps (as ``int``, ``float`` or numeric ``str``).  Any
+    parsed time lacking a timezone is interpreted as UTC.  On success a
+    ``numpy.datetime64`` object in UTC (nanosecond resolution) is returned.
+    ``ValueError`` is raised if the input cannot be parsed.
+    """
+
+    if isinstance(value, (int, float)):
+        ts = float(value)
+    elif isinstance(value, str):
+        try:
+            ts = float(value)
+        except ValueError:
+            try:
+                dt = date_parser.isoparse(value)
+            except (ValueError, OverflowError) as e:
+                raise ValueError(f"invalid datetime: {value!r}") from e
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            ts = dt.timestamp()
+    elif isinstance(value, datetime):
+        dt = value
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        ts = dt.timestamp()
+    else:
+        raise ValueError(f"invalid datetime: {value!r}")
+
+    ns = int(round(ts * 1e9))
+    return np.datetime64(ns, "ns")
 
 
 def load_config(config_path):


### PR DESCRIPTION
## Summary
- add `parse_datetime` helper in `io_utils`
- extend imports for timezone and dateutil parser
- add docstring and logic to convert numeric or ISO strings to `datetime64`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854afb06fdc832baacb985c40fca50a