### PR TITLE
Implement variance-weighted event handling

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1343,6 +1343,8 @@ def main(argv=None):
                 "value": c_rate,
                 "uncertainty": c_sigma,
             }
+            weight_factor = 1.0 / (c_sigma ** 2) if c_sigma > 0 else 1.0
+            iso_events["weight"] *= weight_factor
         else:
             priors_time["N0"] = (
                 0.0,
@@ -1369,6 +1371,8 @@ def main(argv=None):
                 "value": c_rate,
                 "uncertainty": c_sigma,
             }
+            weight_factor = 1.0 / (c_sigma ** 2) if c_sigma > 0 else 1.0
+            iso_events["weight"] *= weight_factor
 
         # Store priors for use in systematics scanning
         priors_time_all[iso] = priors_time


### PR DESCRIPTION
## Summary
- scale per-event weights by `1/(c_sigma**2)` when available
- pass the scaled weights to `fit_time_series`

## Testing
- `pytest -q tests/test_time_series_weights.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854afcf6004832b89d372e3c9d70ccb