### PR TITLE
Add timezone option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository provides a complete pipeline to analyze electrostatic radon monitor data.
 
-**Note:** All time quantities are expressed in seconds and all energies are given in MeV throughout the documentation and code. Event timestamps are stored as UTC `datetime` objects throughout the pipeline. Command-line options that take timestamps (such as `--analysis-start-time`) accept either ISO‑8601 strings or Unix seconds and are parsed accordingly.
+**Note:** All time quantities are expressed in seconds and all energies are given in MeV throughout the documentation and code. Event timestamps are stored as timezone-aware `datetime` objects (UTC by default). Command-line options that take timestamps (such as `--analysis-start-time`) accept either ISO‑8601 strings or Unix seconds and are parsed in the timezone specified by `--timezone` (default `UTC`).
 
 ## Structure
 
@@ -30,7 +30,7 @@ pip install -r requirements.txt
 
 ```bash
 python analyze.py --config config.json --input merged_data.csv \
-    [--output_dir results] [--job-id MYRUN] [--overwrite] \
+    [--output_dir results] [--job-id MYRUN] [--overwrite] [--timezone TZ] \
     [--efficiency-json eff.json] [--systematics-json syst.json] \
     [--spike-count N --spike-count-err S] [--slope RATE] \
     [--noise-cutoff N] \

--- a/tests/test_time_parsing.py
+++ b/tests/test_time_parsing.py
@@ -1,6 +1,7 @@
 import pytest
 from datetime import datetime, timezone
 
+from dateutil.tz import gettz
 from utils import parse_time_arg
 
 @pytest.mark.parametrize("inp", [
@@ -11,3 +12,9 @@ from utils import parse_time_arg
 def test_parse_time_arg_variants(inp):
     dt = parse_time_arg(inp)
     assert dt == datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+def test_parse_time_arg_naive_with_zone():
+    dt = parse_time_arg("1970-01-01T00:00:00", tz="US/Eastern")
+    assert dt.tzinfo == gettz("US/Eastern")
+    assert dt.timestamp() == pytest.approx(18000.0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,3 +61,8 @@ def test_parse_time_iso_no_fraction():
 
 def test_parse_time_iso_fraction():
     assert parse_time("1970-01-01T00:00:00.5Z") == pytest.approx(0.5)
+
+
+def test_parse_time_naive_with_zone():
+    ts = parse_time("1970-01-01T00:00:00", tz="Europe/Berlin")
+    assert ts == pytest.approx(-3600.0)


### PR DESCRIPTION
## Summary
- add `--timezone` CLI option
- parse times with optional timezone in `utils`
- handle timezone conversions in `analyze.py`
- document the timezone option
- test naive ISO inputs with non-UTC zones

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854aef67184832b8aa8072c04cfc934