### PR TITLE
Add timezone support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository provides a complete pipeline to analyze electrostatic radon monitor data.
 
-**Note:** All time quantities are expressed in seconds and all energies are given in MeV throughout the documentation and code. Event timestamps are stored as UTC `numpy.datetime64` objects throughout the pipeline. The helper function `parse_datetime` converts input values to this representation and accepts ISO‑8601 strings (with or without timezone), numeric epoch seconds or existing `datetime` objects. Command-line options that take timestamps (such as `--analysis-start-time`) are parsed with this helper, so both ISO‑8601 strings and Unix seconds work interchangeably.
+**Note:** All time quantities are expressed in seconds and all energies are given in MeV throughout the documentation and code. Event timestamps are stored as UTC `numpy.datetime64` objects throughout the pipeline. The helper function `parse_datetime` converts input values to this representation and accepts ISO‑8601 strings (with or without timezone), numeric epoch seconds or existing `datetime` objects. Command-line options that take timestamps (such as `--analysis-start-time`) are parsed with this helper, so both ISO‑8601 strings and Unix seconds work interchangeably. A global `--timezone` option controls which zone naïve times are interpreted in (default: `UTC`).
 
 ## Structure
 
@@ -42,6 +42,7 @@ python analyze.py --config config.json --input merged_data.csv \
     [--ambient-file amb.txt (time conc)] [--ambient-concentration 0.1] \
     [--burst-mode rate] \
     [--plot-time-binning-mode fixed --plot-time-bin-width 3600] [--dump-time-series-json] \
+    [--timezone Europe/Berlin] \
     [--hierarchical-summary OUT.json]
 ```
 

--- a/analyze.py
+++ b/analyze.py
@@ -62,7 +62,7 @@ import numpy as np
 import pandas as pd
 from scipy.stats import norm
 from dateutil import parser as date_parser
-from dateutil.tz import UTC
+from dateutil.tz import UTC, gettz
 
 from hierarchical import fit_hierarchical_runs
 
@@ -299,10 +299,15 @@ def parse_args(argv=None):
         help="Directory under which to create a timestamped analysis folder (override with --job-id)",
     )
     p.add_argument(
+        "--timezone",
+        default="UTC",
+        help="Timezone for naive input timestamps (default: UTC)",
+    )
+    p.add_argument(
         "--baseline_range",
         nargs=2,
         metavar=("TSTART", "TEND"),
-        type=parse_time_arg,
+        type=str,
         help=(
             "Optional baseline-run interval. Providing this option overrides `baseline.range` in config.json. Provide two values (either ISO strings or epoch floats). If set, those events are extracted (same energy cuts) and listed in `baseline` of the summary."
         ),
@@ -347,12 +352,12 @@ def parse_args(argv=None):
     )
     p.add_argument(
         "--analysis-end-time",
-        type=parse_time_arg,
+        type=str,
         help="Ignore events occurring after this ISO timestamp. Providing this option overrides `analysis.analysis_end_time` in config.json",
     )
     p.add_argument(
         "--analysis-start-time",
-        type=parse_time_arg,
+        type=str,
         help="Reference start time of the analysis (ISO string or epoch). Overrides `analysis.analysis_start_time` in config.json",
     )
     p.add_argument(
@@ -526,6 +531,34 @@ def main(argv=None):
     if args.hierarchical_summary:
         args.hierarchical_summary = Path(args.hierarchical_summary)
 
+    # Resolve timezone for subsequent time parsing
+    tzinfo = gettz(args.timezone)
+    if tzinfo is None:
+        print(f"ERROR: Unknown timezone '{args.timezone}'")
+        sys.exit(1)
+
+    if args.baseline_range:
+        args.baseline_range = [parse_time_arg(t, tz=tzinfo) for t in args.baseline_range]
+    if args.analysis_end_time is not None:
+        args.analysis_end_time = parse_time_arg(args.analysis_end_time, tz=tzinfo)
+    if args.analysis_start_time is not None:
+        args.analysis_start_time = parse_time_arg(args.analysis_start_time, tz=tzinfo)
+    if args.spike_end_time is not None:
+        args.spike_end_time = parse_time_arg(args.spike_end_time, tz=tzinfo)
+    if args.spike_period:
+        args.spike_period = [
+            [parse_time_arg(s, tz=tzinfo), parse_time_arg(e, tz=tzinfo)] for s, e in args.spike_period
+        ]
+    if args.run_period:
+        args.run_period = [
+            [parse_time_arg(s, tz=tzinfo), parse_time_arg(e, tz=tzinfo)] for s, e in args.run_period
+        ]
+    if args.radon_interval:
+        args.radon_interval = [
+            parse_time_arg(args.radon_interval[0], tz=tzinfo),
+            parse_time_arg(args.radon_interval[1], tz=tzinfo),
+        ]
+
     # ────────────────────────────────────────────────────────────
     # 1. Load configuration
     # ────────────────────────────────────────────────────────────
@@ -587,19 +620,26 @@ def main(argv=None):
 
     if args.spike_end_time is not None:
         _log_override("analysis", "spike_end_time", args.spike_end_time)
-        cfg.setdefault("analysis", {})["spike_end_time"] = args.spike_end_time
+        cfg.setdefault("analysis", {})["spike_end_time"] = args.spike_end_time.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     if args.spike_period:
         _log_override("analysis", "spike_periods", args.spike_period)
-        cfg.setdefault("analysis", {})["spike_periods"] = args.spike_period
+        cfg.setdefault("analysis", {})["spike_periods"] = [
+            [s.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"), e.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")] for s, e in args.spike_period
+        ]
 
     if args.run_period:
         _log_override("analysis", "run_periods", args.run_period)
-        cfg.setdefault("analysis", {})["run_periods"] = args.run_period
+        cfg.setdefault("analysis", {})["run_periods"] = [
+            [s.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"), e.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")] for s, e in args.run_period
+        ]
 
     if args.radon_interval:
         _log_override("analysis", "radon_interval", args.radon_interval)
-        cfg.setdefault("analysis", {})["radon_interval"] = args.radon_interval
+        cfg.setdefault("analysis", {})["radon_interval"] = [
+            args.radon_interval[0].astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            args.radon_interval[1].astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        ]
 
     if args.settle_s is not None:
         _log_override("analysis", "settle_s", float(args.settle_s))
@@ -696,6 +736,7 @@ def main(argv=None):
     try:
         events_all = load_events(args.input, column_map=cfg.get("columns"))
         if pd.api.types.is_datetime64_any_dtype(events_all["timestamp"]):
+            events_all["timestamp"] = events_all["timestamp"].dt.tz_convert(tzinfo)
             events_all["timestamp"] = events_all["timestamp"].view("int64") / 1e9
     except Exception as e:
         print(f"ERROR: Could not load events from '{args.input}': {e}")

--- a/tests/test_cli_baseline_range_iso.py
+++ b/tests/test_cli_baseline_range_iso.py
@@ -93,3 +93,90 @@ def test_cli_baseline_range_iso_strings(tmp_path, monkeypatch):
     assert summary.get("baseline", {}).get("end") == 2.0
     assert summary.get("baseline", {}).get("n_events") == 1
     assert captured.get("cfg", {}).get("baseline", {}).get("range") == [1.0, 2.0]
+
+
+def test_cli_baseline_range_timezone(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "baseline": {"range": [0, 5], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": True,
+            "window_po214": [0, 20],
+            "hl_po214": [1.0, 0.0],
+            "eff_po214": [1.0, 0.0],
+            "flags": {},
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame(
+        {
+            "fUniqueID": [1, 2, 3],
+            "fBits": [0, 0, 0],
+            "timestamp": [0.5, 1.5, 2.5],
+            "adc": [8.0, 8.0, 8.0],
+            "fchannel": [1, 1, 1],
+        }
+    )
+    data_path = tmp_path / "data.csv"
+    df.to_csv(data_path, index=False)
+
+    captured = {}
+
+    orig_load_config = analyze.load_config
+
+    def fake_load_config(path):
+        cfg_local = orig_load_config(path)
+        captured["cfg"] = cfg_local
+        return cfg_local
+
+    monkeypatch.setattr(analyze, "load_config", fake_load_config)
+
+    def fake_fit(ts_dict, t_start, t_end, cfg):
+        captured["times"] = ts_dict.get("Po214", []).tolist()
+        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
+
+    monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
+
+    def fake_write(out_dir, summary, timestamp=None):
+        captured["summary"] = summary
+        d = Path(out_dir) / (timestamp or "x")
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "apply_burst_filter", lambda df, cfg, mode="rate": (df, 0))
+    monkeypatch.setattr(baseline_noise, "estimate_baseline_noise", lambda *a, **k: (None, {}))
+
+
+    monkeypatch.setattr(analyze, "load_config", fake_load_config)
+
+    monkeypatch.setattr(sys, "argv", [
+        "analyze.py",
+        "--config", str(cfg_path),
+        "--input", str(data_path),
+        "--output_dir", str(tmp_path),
+        "--timezone", "Europe/Berlin",
+        "--baseline_range", "1970-01-01T01:00:01", "1970-01-01T01:00:02",
+    ])
+    analyze.main()
+    summary = captured.get("summary", {})
+    assert summary.get("baseline", {}).get("start") == 1.0
+    assert summary.get("baseline", {}).get("end") == 2.0
+    assert summary.get("baseline", {}).get("n_events") == 1
+    assert captured.get("cfg", {}).get("baseline", {}).get("range") == [1.0, 2.0]

--- a/tests/test_time_parsing.py
+++ b/tests/test_time_parsing.py
@@ -47,3 +47,8 @@ def test_parse_time_arg_numeric(inp, expected):
 def test_parse_time_arg_invalid(inp):
     with pytest.raises((argparse.ArgumentTypeError, ValueError)):
         parse_time_arg(inp)
+
+
+def test_parse_time_arg_naive_timezone():
+    dt = parse_time_arg("1970-01-01T01:00:00", tz="Europe/Berlin")
+    assert dt == datetime(1970, 1, 1, tzinfo=timezone.utc)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,3 +61,7 @@ def test_parse_time_iso_no_fraction():
 
 def test_parse_time_iso_fraction():
     assert parse_time("1970-01-01T00:00:00.5Z") == pytest.approx(0.5)
+
+
+def test_parse_time_naive_timezone():
+    assert parse_time("1970-01-01T01:00:00", tz="Europe/Berlin") == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- allow specifying timezone for naive timestamps
- use dateutil tz conversions in utilities
- convert CSV timestamps to timezone in main
- store CLI time overrides in UTC ISO format
- document timezone option
- test timezone conversions

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854c3956b7c832b959b8f27854cc423