### PR TITLE
Update baseline correction logic

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -108,7 +108,7 @@ from utils import (
 )
 from io_utils import parse_datetime
 from radmon.baseline import subtract_baseline
-from radon.baseline import subtract_baseline_counts
+from radon.baseline import subtract_baseline_counts, subtract_baseline
 
 
 def _fit_params(obj):
@@ -1315,6 +1315,8 @@ def main(argv=None):
     time_fit_results = {}
     priors_time_all = {}
     time_plot_data = {}
+    iso_counts = {}
+    iso_live_time = {}
     if cfg.get("time_fit", {}).get("do_time_fit", False):
         for iso in ("Po218", "Po214"):
             win_key = f"window_{iso.lower()}"
@@ -1334,6 +1336,7 @@ def main(argv=None):
             iso_mask = probs > 0
             iso_events = df_analysis[iso_mask].copy()
             iso_events["weight"] = probs[iso_mask]
+            iso_counts[iso] = float(np.sum(iso_events["weight"]))
             if iso_events.empty:
                 print(f"WARNING: No events found for {iso} in [{lo}, {hi}] MeV.")
                 continue
@@ -1481,6 +1484,8 @@ def main(argv=None):
             t_start_fit = t0_global
             if args.settle_s is not None:
                 t_start_fit = t0_global + float(args.settle_s)
+            live = t_end_global_ts - t_start_fit
+            iso_live_time[iso] = live
             try:
                 decay_out = fit_time_series(
                     times_dict,
@@ -1718,25 +1723,25 @@ def main(argv=None):
     corrected_rates = {}
     corrected_unc = {}
 
-    for iso, rate in baseline_rates.items():
-        fit = time_fit_results.get(iso)
+    for iso, fit in time_fit_results.items():
         params = _fit_params(fit)
         if params and (f"E_{iso}" in params):
-            s = scales.get(iso, 1.0)
-            params["E_corrected"] = params[f"E_{iso}"] - s * rate
-            err_fit = params.get(f"dE_{iso}", 0.0)
-            sigma_rate = 0.0
-            if baseline_live_time > 0:
-                count = baseline_counts.get(iso, 0.0)
-                eff = cfg["time_fit"].get(
-                    f"eff_{iso.lower()}", [1.0]
-                )[0]
-                if eff > 0:
-                    sigma_rate = math.sqrt(count) / (baseline_live_time * eff)
-            dE_corr = float(math.hypot(err_fit, sigma_rate * s))
-            params["dE_corrected"] = dE_corr
-            corrected_rates[iso] = params["E_corrected"]
-            corrected_unc[iso] = dE_corr
+            eff = cfg["time_fit"].get(
+                f"eff_{iso.lower()}", [1.0]
+            )[0]
+            counts = iso_counts.get(iso, 0.0)
+            live = iso_live_time.get(iso, 0.0)
+            corrected_rate, corrected_sigma = subtract_baseline(
+                counts,
+                eff,
+                live,
+                baseline_counts.get(iso, 0.0),
+                baseline_live_time,
+            )
+            params["E_corrected"] = corrected_rate
+            params["dE_corrected"] = corrected_sigma
+            corrected_rates[iso] = corrected_rate
+            corrected_unc[iso] = corrected_sigma
 
     if baseline_rates:
         baseline_info["rate_Bq"] = baseline_rates

--- a/radon/baseline.py
+++ b/radon/baseline.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-__all__ = ["subtract_baseline_counts"]
+__all__ = ["subtract_baseline_counts", "subtract_baseline"]
 
 
 def subtract_baseline_counts(
@@ -40,3 +40,9 @@ def subtract_baseline_counts(
     corrected_rate = rate - baseline_rate
     corrected_sigma = np.sqrt(sigma_sq + baseline_sigma_sq)
     return corrected_rate, corrected_sigma
+
+
+def subtract_baseline(*args, **kwargs):
+    """Alias for :func:`subtract_baseline_counts`."""
+    return subtract_baseline_counts(*args, **kwargs)
+


### PR DESCRIPTION
## Summary
- add new alias `subtract_baseline` to `radon.baseline`
- track counts and live time per isotope in `analyze.py`
- compute corrected rates using `radon.baseline.subtract_baseline`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: 32 failed, 262 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685646e3ad70832b9759a8a7d5b14036