### PR TITLE
Update baseline subtraction

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -109,6 +109,7 @@ from utils import (
 from io_utils import parse_datetime
 from radmon.baseline import subtract_baseline
 from radon.baseline import subtract_baseline_counts
+import radon
 
 
 def _fit_params(obj):
@@ -1315,6 +1316,8 @@ def main(argv=None):
     time_fit_results = {}
     priors_time_all = {}
     time_plot_data = {}
+    iso_counts: dict[str, float] = {}
+    iso_live_time: dict[str, float] = {}
     if cfg.get("time_fit", {}).get("do_time_fit", False):
         for iso in ("Po218", "Po214"):
             win_key = f"window_{iso.lower()}"
@@ -1334,6 +1337,7 @@ def main(argv=None):
             iso_mask = probs > 0
             iso_events = df_analysis[iso_mask].copy()
             iso_events["weight"] = probs[iso_mask]
+            iso_counts[iso] = iso_events["weight"].sum()
             if iso_events.empty:
                 print(f"WARNING: No events found for {iso} in [{lo}, {hi}] MeV.")
                 continue
@@ -1480,7 +1484,9 @@ def main(argv=None):
         try:
             t_start_fit = t0_global
             if args.settle_s is not None:
-                t_start_fit = t0_global + float(args.settle_s)
+                t_start_fit += float(args.settle_s)
+            live = t_end_global_ts - t_start_fit
+            iso_live_time[iso] = live
             try:
                 decay_out = fit_time_series(
                     times_dict,
@@ -1717,26 +1723,21 @@ def main(argv=None):
 
     corrected_rates = {}
     corrected_unc = {}
-
-    for iso, rate in baseline_rates.items():
-        fit = time_fit_results.get(iso)
+    for iso, fit in time_fit_results.items():
         params = _fit_params(fit)
-        if params and (f"E_{iso}" in params):
-            s = scales.get(iso, 1.0)
-            params["E_corrected"] = params[f"E_{iso}"] - s * rate
-            err_fit = params.get(f"dE_{iso}", 0.0)
-            sigma_rate = 0.0
-            if baseline_live_time > 0:
-                count = baseline_counts.get(iso, 0.0)
-                eff = cfg["time_fit"].get(
-                    f"eff_{iso.lower()}", [1.0]
-                )[0]
-                if eff > 0:
-                    sigma_rate = math.sqrt(count) / (baseline_live_time * eff)
-            dE_corr = float(math.hypot(err_fit, sigma_rate * s))
-            params["dE_corrected"] = dE_corr
-            corrected_rates[iso] = params["E_corrected"]
-            corrected_unc[iso] = dE_corr
+        if params and f"E_{iso}" in params:
+            eff = cfg["time_fit"].get(f"eff_{iso.lower()}", [1.0])[0]
+            corrected_rate, corrected_sigma = radon.baseline.subtract_baseline_counts(
+                iso_counts.get(iso, 0.0),
+                eff,
+                iso_live_time.get(iso, 0.0),
+                baseline_counts.get(iso, 0.0),
+                baseline_live_time,
+            )
+            params["E_corrected"] = corrected_rate
+            params["dE_corrected"] = corrected_sigma
+            corrected_rates[iso] = corrected_rate
+            corrected_unc[iso] = corrected_sigma
 
     if baseline_rates:
         baseline_info["rate_Bq"] = baseline_rates


### PR DESCRIPTION
## Summary
- track per-isotope counts and live time for baseline subtraction
- apply radon baseline subtraction routine

## Testing
- `pytest -q` *(fails: TypeError in pandas comparisons, ZeroDivisionError)*

------
https://chatgpt.com/codex/tasks/task_e_68564acd0af8832b95384e752a00801c