### PR TITLE
Implement baseline correction using counts

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1315,6 +1315,8 @@ def main(argv=None):
     time_fit_results = {}
     priors_time_all = {}
     time_plot_data = {}
+    iso_counts = {}
+    iso_live_time = {}
     if cfg.get("time_fit", {}).get("do_time_fit", False):
         for iso in ("Po218", "Po214"):
             win_key = f"window_{iso.lower()}"
@@ -1334,6 +1336,7 @@ def main(argv=None):
             iso_mask = probs > 0
             iso_events = df_analysis[iso_mask].copy()
             iso_events["weight"] = probs[iso_mask]
+            iso_counts[iso] = float(np.sum(iso_events["weight"]))
             if iso_events.empty:
                 print(f"WARNING: No events found for {iso} in [{lo}, {hi}] MeV.")
                 continue
@@ -1481,6 +1484,7 @@ def main(argv=None):
             t_start_fit = t0_global
             if args.settle_s is not None:
                 t_start_fit = t0_global + float(args.settle_s)
+            iso_live_time[iso] = float(t_end_global_ts - t_start_fit)
             try:
                 decay_out = fit_time_series(
                     times_dict,
@@ -1718,25 +1722,24 @@ def main(argv=None):
     corrected_rates = {}
     corrected_unc = {}
 
-    for iso, rate in baseline_rates.items():
-        fit = time_fit_results.get(iso)
+    for iso, fit in time_fit_results.items():
         params = _fit_params(fit)
-        if params and (f"E_{iso}" in params):
-            s = scales.get(iso, 1.0)
-            params["E_corrected"] = params[f"E_{iso}"] - s * rate
-            err_fit = params.get(f"dE_{iso}", 0.0)
-            sigma_rate = 0.0
-            if baseline_live_time > 0:
-                count = baseline_counts.get(iso, 0.0)
-                eff = cfg["time_fit"].get(
-                    f"eff_{iso.lower()}", [1.0]
-                )[0]
-                if eff > 0:
-                    sigma_rate = math.sqrt(count) / (baseline_live_time * eff)
-            dE_corr = float(math.hypot(err_fit, sigma_rate * s))
-            params["dE_corrected"] = dE_corr
-            corrected_rates[iso] = params["E_corrected"]
-            corrected_unc[iso] = dE_corr
+        if not params:
+            continue
+        eff = cfg["time_fit"].get(f"eff_{iso.lower()}", [1.0])[0]
+        if eff <= 0:
+            continue
+        corrected_rate, corrected_sigma = subtract_baseline_counts(
+            iso_counts.get(iso, 0.0),
+            eff,
+            iso_live_time.get(iso, 0.0),
+            baseline_counts.get(iso, 0.0),
+            baseline_live_time,
+        )
+        params["E_corrected"] = corrected_rate
+        params["dE_corrected"] = corrected_sigma
+        corrected_rates[iso] = corrected_rate
+        corrected_unc[iso] = corrected_sigma
 
     if baseline_rates:
         baseline_info["rate_Bq"] = baseline_rates


### PR DESCRIPTION
## Summary
- store probability-weighted counts and live time per isotope
- use `subtract_baseline_counts` for corrected rates
- keep baseline info using the new corrected values

## Testing
- `pytest -q tests/test_baseline.py::test_simple_baseline_subtraction -q` *(fails: TypeError: '>=' not supported between instances of 'numpy.ndarray' and 'Timestamp')*

------
https://chatgpt.com/codex/tasks/task_e_68564fea7ef8832b97796068b0c7fe62