### PR TITLE
Update baseline documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,11 @@ configuration's interval is ignored in favour of the CLI value.
 The `--baseline-mode` option selects the background removal strategy.
 Valid modes are `none`, `electronics`, `radon` and `all` (default).
 
+The uncertainty on each baseline-corrected rate is calculated from the
+unweighted analysis counts.  The quantity ``sigma_rate`` therefore
+reflects the raw statistics of the analysis window rather than the
+BLUE-weighted totals.
+
 
 Example snippet:
 

--- a/analyze.py
+++ b/analyze.py
@@ -1706,6 +1706,14 @@ def main(argv=None):
     # ────────────────────────────────────────────────────────────
     # Baseline subtraction
     # ────────────────────────────────────────────────────────────
+    """Apply baseline correction and compute associated uncertainties.
+
+    The counts from the baseline interval are converted to rates and
+    subtracted from the fitted activities.  The error term ``sigma_rate``
+    used for this correction is derived from the **unweighted** analysis
+    counts so that the statistical uncertainty reflects the raw event
+    totals prior to any BLUE weighting.
+    """
     baseline_rates = {}
     baseline_unc = {}
     if baseline_live_time > 0:


### PR DESCRIPTION
## Summary
- document sigma_rate calculation in baseline section of README
- clarify baseline correction docstring in analyze

## Testing
- `pytest -q` *(fails: 3 failed, 294 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685808a9b4fc832b9bb712cd858a5660