### PR TITLE
Check zero live time in baseline calculations

### DIFF
--- a/radon/baseline.py
+++ b/radon/baseline.py
@@ -33,6 +33,13 @@ def subtract_baseline_counts(
     **not** intended for DataFrame-based spectra or time series.
     """
 
+    if live_time == 0:
+        raise ValueError("live_time must be nonzero for baseline correction")
+    if baseline_live_time == 0:
+        raise ValueError(
+            "baseline_live_time must be nonzero for baseline correction"
+        )
+
     rate = counts / live_time / efficiency
     sigma_sq = counts / live_time**2 / efficiency**2
     baseline_rate = baseline_counts / baseline_live_time / efficiency

--- a/tests/test_baseline_uncertainty.py
+++ b/tests/test_baseline_uncertainty.py
@@ -32,8 +32,8 @@ def test_zero_live_time_behaviour():
     counts = 10
     baseline_counts = 5
     efficiency = 1.0
-    # live_time zero -> expect divide-by-zero results
-    with pytest.raises(ZeroDivisionError):
+    # live_time zero -> should raise descriptive ValueError
+    with pytest.raises(ValueError):
         subtract_baseline_counts(
             counts, efficiency, 0.0, baseline_counts, 50.0
         )
@@ -43,8 +43,8 @@ def test_zero_baseline_live_time_behaviour():
     counts = 10
     baseline_counts = 0
     efficiency = 1.0
-    # baseline_live_time zero -> divide by zero
-    with pytest.raises(ZeroDivisionError):
+    # baseline_live_time zero -> should raise descriptive ValueError
+    with pytest.raises(ValueError):
         subtract_baseline_counts(
             counts, efficiency, 100.0, baseline_counts, 0.0
         )


### PR DESCRIPTION
## Summary
- raise `ValueError` if `live_time` or `baseline_live_time` is zero
- update uncertainty tests to expect `ValueError`

## Testing
- `pytest tests/test_baseline_uncertainty.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685813c405b8832b9945bf7a8a550a6a