### PR TITLE
Add scaling factor helper with tests

### DIFF
--- a/tests/test_scaling_factor.py
+++ b/tests/test_scaling_factor.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import baseline
+
+
+def test_scaling_factor_basic():
+    s, ds = baseline._scaling_factor(10.0, 5.0)
+    assert s == pytest.approx(2.0)
+    assert ds == pytest.approx(0.0)
+
+
+def test_scaling_factor_uncertainty():
+    s, ds = baseline._scaling_factor(10.0, 5.0, 0.1, 0.2)
+    assert s == pytest.approx(2.0)
+    expected_var = (0.1/5.0)**2 + ((10.0*0.2)/5.0**2)**2
+    assert ds == pytest.approx((expected_var)**0.5)
+
+
+def test_scaling_factor_zero_baseline():
+    with pytest.raises(ValueError):
+        baseline._scaling_factor(1.0, 0.0)


### PR DESCRIPTION
## Summary
- implement internal `_scaling_factor` for baseline handling with propagated uncertainty
- add dedicated tests covering this helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685813c2a1f8832ba5843532df5e546e