### PR TITLE
Add check for nonpositive efficiency

### DIFF
--- a/radon/baseline.py
+++ b/radon/baseline.py
@@ -39,6 +39,8 @@ def subtract_baseline_counts(
         raise ValueError(
             "baseline_live_time must be nonzero for baseline correction"
         )
+    if efficiency <= 0:
+        raise ValueError("efficiency must be positive for baseline correction")
 
     rate = counts / live_time / efficiency
     sigma_sq = counts / live_time**2 / efficiency**2

--- a/tests/test_baseline_uncertainty.py
+++ b/tests/test_baseline_uncertainty.py
@@ -49,3 +49,23 @@ def test_zero_baseline_live_time_behaviour():
             counts, efficiency, 100.0, baseline_counts, 0.0
         )
 
+
+def test_zero_efficiency_behaviour():
+    counts = 10
+    baseline_counts = 2
+    efficiency = 0.0
+    with pytest.raises(ValueError):
+        subtract_baseline_counts(
+            counts, efficiency, 100.0, baseline_counts, 50.0
+        )
+
+
+def test_negative_efficiency_behaviour():
+    counts = 10
+    baseline_counts = 2
+    efficiency = -0.1
+    with pytest.raises(ValueError):
+        subtract_baseline_counts(
+            counts, efficiency, 100.0, baseline_counts, 50.0
+        )
+


### PR DESCRIPTION
## Summary
- validate efficiency > 0 in baseline subtraction
- add regression tests for zero and negative efficiency

## Testing
- `pytest tests/test_baseline_uncertainty.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68581940fe30832ba0f13661f5fd83c1