### PR TITLE
Improve baseline uncertainty calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,10 +461,11 @@ configuration's interval is ignored in favour of the CLI value.
 The `--baseline-mode` option selects the background removal strategy.
 Valid modes are `none`, `electronics`, `radon` and `all` (default).
 
-The uncertainty on each baseline-corrected rate is calculated from the
-unweighted analysis counts.  The quantity ``sigma_rate`` therefore
-reflects the raw statistics of the analysis window rather than the
-BLUE-weighted totals.
+The uncertainty on each baseline-corrected rate is obtained with
+``radon.baseline.subtract_baseline_counts`` using the unweighted analysis
+counts, the analysis live time and the baseline live time.  This reflects
+the raw statistics of the analysis window rather than the BLUE-weighted
+totals.
 
 
 Example snippet:

--- a/analyze.py
+++ b/analyze.py
@@ -1758,15 +1758,23 @@ def main(argv=None):
         if params and (f"E_{iso}" in params):
             s = scales.get(iso, 1.0)
             err_fit = params.get(f"dE_{iso}", 0.0)
-            if iso_live_time.get(iso, 0) > 0 and baseline_live_time > 0:
+            live_time_iso = iso_live_time.get(iso, 0.0)
+            if live_time_iso > 0 and baseline_live_time > 0:
                 params["E_corrected"] = params[f"E_{iso}"] - s * rate
-                sigma_rate = 0.0
                 count = iso_counts_raw.get(iso, baseline_counts.get(iso, 0.0))
                 eff = cfg["time_fit"].get(
                     f"eff_{iso.lower()}", [1.0]
                 )[0]
                 if eff > 0:
-                    sigma_rate = math.sqrt(count) / (baseline_live_time * eff)
+                    _, sigma_rate = subtract_baseline_counts(
+                        count,
+                        eff,
+                        live_time_iso,
+                        baseline_counts.get(iso, 0.0),
+                        baseline_live_time,
+                    )
+                else:
+                    sigma_rate = 0.0
                 dE_corr = float(math.hypot(err_fit, sigma_rate * s))
             else:
                 params["E_corrected"] = params[f"E_{iso}"]

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -86,9 +86,9 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
     corr_rate = summary["baseline"]["corrected_rate_Bq"]["Po214"]
     corr_sig = summary["baseline"]["corrected_sigma_Bq"]["Po214"]
     assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(0.8)
-    assert summary["time_fit"]["Po214"]["dE_corrected"] == pytest.approx(np.sqrt(3.0)/10)
+    assert summary["time_fit"]["Po214"]["dE_corrected"] == pytest.approx(0.1683, rel=1e-3)
     assert corr_rate == pytest.approx(0.8)
-    assert corr_sig == pytest.approx(np.sqrt(3.0)/10)
+    assert corr_sig == pytest.approx(0.1683, rel=1e-3)
     assert summary["baseline"].get("noise_level") == 5.0
     times = list(captured.get("times", []))
     assert times == [1, 2, 20]
@@ -164,9 +164,9 @@ def test_baseline_scaling_factor(tmp_path, monkeypatch):
     corr_rate = summary["baseline"]["corrected_rate_Bq"]["Po214"]
     corr_sig = summary["baseline"]["corrected_sigma_Bq"]["Po214"]
     assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(0.9)
-    assert summary["time_fit"]["Po214"]["dE_corrected"] == pytest.approx(np.sqrt(3.0)/20)
+    assert summary["time_fit"]["Po214"]["dE_corrected"] == pytest.approx(0.0841, rel=1e-3)
     assert corr_rate == pytest.approx(0.9)
-    assert corr_sig == pytest.approx(np.sqrt(3.0)/20)
+    assert corr_sig == pytest.approx(0.0841, rel=1e-3)
 
 
 def test_n0_prior_from_baseline(tmp_path, monkeypatch):
@@ -580,7 +580,7 @@ def test_sigma_rate_uses_weighted_counts(tmp_path, monkeypatch):
     analyze.main()
 
     dE_corr = captured["summary"]["time_fit"]["Po214"]["dE_corrected"]
-    assert dE_corr == pytest.approx(np.sqrt(3.0) / 10.0)
+    assert dE_corr == pytest.approx(0.2198, rel=1e-3)
 
 
 def test_rate_histogram_single_event():


### PR DESCRIPTION
## Summary
- compute baseline corrected uncertainty via `subtract_baseline_counts`
- adjust unit tests for new propagation
- document baseline subtraction uncertainty in README

## Testing
- `pytest tests/test_baseline.py::test_baseline_scaling_factor tests/test_baseline.py::test_sigma_rate_uses_weighted_counts -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685823d638a8832b89ae97a177b0d776