### PR TITLE
Align time-fit start time with first event

### DIFF
--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -1055,7 +1055,7 @@ def test_analysis_start_time_cli(tmp_path, monkeypatch):
     monkeypatch.setattr(sys, "argv", args)
     analyze.main()
 
-    assert captured["t_start"] == 10.0
+    assert captured["t_start"] == 15.0
 
 
 def test_spike_end_time_cli(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- compute each isotope's start time from its earliest event and track via `t_start_map`
- use stored start times when fitting decay curves
- update CLI start time test for new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685823ed4e64832ba7e663673872f94b