### PR TITLE
Use helper for baseline uncertainty

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,8 +462,9 @@ The `--baseline-mode` option selects the background removal strategy.
 Valid modes are `none`, `electronics`, `radon` and `all` (default).
 
 The uncertainty on each baseline-corrected rate is calculated from the
-unweighted analysis counts.  The quantity ``sigma_rate`` therefore
-reflects the raw statistics of the analysis window rather than the
+unweighted analysis counts using ``radon.baseline.subtract_baseline_counts``.
+This helper propagates Poisson errors with the analysis live time so the
+variance reflects the raw event statistics rather than the
 BLUE-weighted totals.
 
 

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -86,9 +86,9 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
     corr_rate = summary["baseline"]["corrected_rate_Bq"]["Po214"]
     corr_sig = summary["baseline"]["corrected_sigma_Bq"]["Po214"]
     assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(0.8)
-    assert summary["time_fit"]["Po214"]["dE_corrected"] == pytest.approx(np.sqrt(3.0)/10)
+    assert summary["time_fit"]["Po214"]["dE_corrected"] == pytest.approx(0.1682564986)
     assert corr_rate == pytest.approx(0.8)
-    assert corr_sig == pytest.approx(np.sqrt(3.0)/10)
+    assert corr_sig == pytest.approx(0.1682564986)
     assert summary["baseline"].get("noise_level") == 5.0
     times = list(captured.get("times", []))
     assert times == [1, 2, 20]
@@ -164,9 +164,9 @@ def test_baseline_scaling_factor(tmp_path, monkeypatch):
     corr_rate = summary["baseline"]["corrected_rate_Bq"]["Po214"]
     corr_sig = summary["baseline"]["corrected_sigma_Bq"]["Po214"]
     assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(0.9)
-    assert summary["time_fit"]["Po214"]["dE_corrected"] == pytest.approx(np.sqrt(3.0)/20)
+    assert summary["time_fit"]["Po214"]["dE_corrected"] == pytest.approx(0.0841282493)
     assert corr_rate == pytest.approx(0.9)
-    assert corr_sig == pytest.approx(np.sqrt(3.0)/20)
+    assert corr_sig == pytest.approx(0.0841282493)
 
 
 def test_n0_prior_from_baseline(tmp_path, monkeypatch):
@@ -580,7 +580,7 @@ def test_sigma_rate_uses_weighted_counts(tmp_path, monkeypatch):
     analyze.main()
 
     dE_corr = captured["summary"]["time_fit"]["Po214"]["dE_corrected"]
-    assert dE_corr == pytest.approx(np.sqrt(3.0) / 10.0)
+    assert dE_corr == pytest.approx(0.2197959265)
 
 
 def test_rate_histogram_single_event():


### PR DESCRIPTION
## Summary
- replace manual baseline-sigma calculation with `radon.baseline.subtract_baseline_counts`
- update docs on baseline subtraction
- refresh baseline tests for the new uncertainty values

## Testing
- `pytest tests/test_baseline.py::test_simple_baseline_subtraction -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582a29f9e0832ba8468e9af852bb19