### PR TITLE
Update baseline subtraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,11 +461,12 @@ configuration's interval is ignored in favour of the CLI value.
 The `--baseline-mode` option selects the background removal strategy.
 Valid modes are `none`, `electronics`, `radon` and `all` (default).
 
-The uncertainty on each baseline-corrected rate is obtained with
+Both the corrected rate and its uncertainty are obtained with
 ``radon.baseline.subtract_baseline_counts`` using the unweighted analysis
-counts, the analysis live time and the baseline live time.  This reflects
-the raw statistics of the analysis window rather than the BLUE-weighted
-totals.
+counts, the analysis live time and the baseline live time.  The returned
+values are scaled by the dilution factor before being stored in
+``summary.json``.  This reflects the raw statistics of the analysis
+window rather than the BLUE-weighted totals.
 
 
 Example snippet:

--- a/analyze.py
+++ b/analyze.py
@@ -1751,25 +1751,26 @@ def main(argv=None):
         count = iso_counts_raw.get(iso, baseline_counts.get(iso, 0.0))
         eff = cfg["time_fit"].get(f"eff_{iso.lower()}", [1.0])[0]
         base_cnt = baseline_counts.get(iso, 0.0)
-        rate = baseline_rates.get(iso, 0.0)
         s = scales.get(iso, 1.0)
 
         if live_time_iso > 0 and eff > 0:
-            _, sigma_rate = subtract_baseline_counts(
+            c_rate, c_sigma = subtract_baseline_counts(
                 count,
                 eff,
                 live_time_iso,
                 base_cnt,
                 baseline_live_time,
             )
-            sigma_term = sigma_rate * s
+            c_rate *= s
+            c_sigma *= s
         else:
-            sigma_term = 0.0
+            c_rate = params[f"E_{iso}"]
+            c_sigma = 0.0
 
-        params["E_corrected"] = params[f"E_{iso}"] - s * rate
-        dE_corr = float(math.hypot(err_fit, sigma_term))
+        params["E_corrected"] = c_rate
+        dE_corr = float(math.hypot(err_fit, c_sigma))
         params["dE_corrected"] = dE_corr
-        corrected_rates[iso] = params["E_corrected"]
+        corrected_rates[iso] = c_rate
         corrected_unc[iso] = dE_corr
 
     if baseline_rates:

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -85,9 +85,9 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
     assert summary["baseline"]["scales"]["noise"] == pytest.approx(1.0)
     corr_rate = summary["baseline"]["corrected_rate_Bq"]["Po214"]
     corr_sig = summary["baseline"]["corrected_sigma_Bq"]["Po214"]
-    assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(0.8)
+    assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(-0.0421, rel=1e-3)
     assert summary["time_fit"]["Po214"]["dE_corrected"] == pytest.approx(0.1683, rel=1e-3)
-    assert corr_rate == pytest.approx(0.8)
+    assert corr_rate == pytest.approx(-0.0421, rel=1e-3)
     assert corr_sig == pytest.approx(0.1683, rel=1e-3)
     assert summary["baseline"].get("noise_level") == 5.0
     times = list(captured.get("times", []))
@@ -163,9 +163,9 @@ def test_baseline_scaling_factor(tmp_path, monkeypatch):
     assert summary["baseline"]["scales"]["Po218"] == pytest.approx(0.5)
     corr_rate = summary["baseline"]["corrected_rate_Bq"]["Po214"]
     corr_sig = summary["baseline"]["corrected_sigma_Bq"]["Po214"]
-    assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(0.9)
+    assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(-0.0211, rel=1e-3)
     assert summary["time_fit"]["Po214"]["dE_corrected"] == pytest.approx(0.0841, rel=1e-3)
-    assert corr_rate == pytest.approx(0.9)
+    assert corr_rate == pytest.approx(-0.0211, rel=1e-3)
     assert corr_sig == pytest.approx(0.0841, rel=1e-3)
 
 


### PR DESCRIPTION
## Summary
- update baseline subtraction to use subtract_baseline_counts
- adjust baseline tests for new corrected values
- document behaviour in README

## Testing
- `pytest -q` *(fails: Package 'iminuit' is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_6858343bafac832b8b4e3684906486aa