### PR TITLE
Revise baseline subtraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,11 +461,12 @@ configuration's interval is ignored in favour of the CLI value.
 The `--baseline-mode` option selects the background removal strategy.
 Valid modes are `none`, `electronics`, `radon` and `all` (default).
 
-The uncertainty on each baseline-corrected rate is obtained with
-``radon.baseline.subtract_baseline_counts`` using the unweighted analysis
-counts, the analysis live time and the baseline live time.  This reflects
-the raw statistics of the analysis window rather than the BLUE-weighted
-totals.
+The baseline-subtracted activity for each isotope is computed with
+``radon.baseline.subtract_baseline_counts`` using the unweighted
+analysis counts, the analysis live time and the baseline live time.
+The returned rate and uncertainty are then multiplied by the dilution
+factor for Po-214 and Po-218.  This approach reflects the raw statistics
+of the analysis window rather than the BLUE-weighted totals.
 
 
 Example snippet:

--- a/analyze.py
+++ b/analyze.py
@@ -1751,25 +1751,26 @@ def main(argv=None):
         count = iso_counts_raw.get(iso, baseline_counts.get(iso, 0.0))
         eff = cfg["time_fit"].get(f"eff_{iso.lower()}", [1.0])[0]
         base_cnt = baseline_counts.get(iso, 0.0)
-        rate = baseline_rates.get(iso, 0.0)
         s = scales.get(iso, 1.0)
 
         if live_time_iso > 0 and eff > 0:
-            _, sigma_rate = subtract_baseline_counts(
+            corr_rate, corr_sigma = subtract_baseline_counts(
                 count,
                 eff,
                 live_time_iso,
                 base_cnt,
                 baseline_live_time,
             )
-            sigma_term = sigma_rate * s
+            corr_rate *= s
+            corr_sigma *= s
         else:
-            sigma_term = 0.0
+            corr_rate = 0.0
+            corr_sigma = 0.0
 
-        params["E_corrected"] = params[f"E_{iso}"] - s * rate
-        dE_corr = float(math.hypot(err_fit, sigma_term))
+        dE_corr = float(math.hypot(err_fit, corr_sigma))
+        params["E_corrected"] = corr_rate
         params["dE_corrected"] = dE_corr
-        corrected_rates[iso] = params["E_corrected"]
+        corrected_rates[iso] = corr_rate
         corrected_unc[iso] = dE_corr
 
     if baseline_rates:

--- a/radon_activity.py
+++ b/radon_activity.py
@@ -185,8 +185,6 @@ def compute_total_radon(
         raise ValueError("sample_volume must be non-negative")
     if err_bq < 0:
         raise ValueError("err_bq must be non-negative")
-    if activity_bq < 0:
-        raise ValueError("activity_bq must be non-negative")
     conc = activity_bq / monitor_volume
     sigma_conc = err_bq / monitor_volume
 

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -85,9 +85,9 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
     assert summary["baseline"]["scales"]["noise"] == pytest.approx(1.0)
     corr_rate = summary["baseline"]["corrected_rate_Bq"]["Po214"]
     corr_sig = summary["baseline"]["corrected_sigma_Bq"]["Po214"]
-    assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(0.8)
+    assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(-0.042105, rel=1e-5)
     assert summary["time_fit"]["Po214"]["dE_corrected"] == pytest.approx(0.1683, rel=1e-3)
-    assert corr_rate == pytest.approx(0.8)
+    assert corr_rate == pytest.approx(-0.042105, rel=1e-5)
     assert corr_sig == pytest.approx(0.1683, rel=1e-3)
     assert summary["baseline"].get("noise_level") == 5.0
     times = list(captured.get("times", []))
@@ -163,9 +163,9 @@ def test_baseline_scaling_factor(tmp_path, monkeypatch):
     assert summary["baseline"]["scales"]["Po218"] == pytest.approx(0.5)
     corr_rate = summary["baseline"]["corrected_rate_Bq"]["Po214"]
     corr_sig = summary["baseline"]["corrected_sigma_Bq"]["Po214"]
-    assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(0.9)
+    assert summary["time_fit"]["Po214"]["E_corrected"] == pytest.approx(-0.0210526, rel=1e-5)
     assert summary["time_fit"]["Po214"]["dE_corrected"] == pytest.approx(0.0841, rel=1e-3)
-    assert corr_rate == pytest.approx(0.9)
+    assert corr_rate == pytest.approx(-0.0210526, rel=1e-5)
     assert corr_sig == pytest.approx(0.0841, rel=1e-3)
 
 


### PR DESCRIPTION
## Summary
- compute baseline-corrected rates via `radon.baseline.subtract_baseline_counts`
- allow negative activities in `compute_total_radon`
- adjust baseline tests for new method
- document updated baseline correction

## Testing
- `pytest tests/test_baseline.py::test_simple_baseline_subtraction -q`
- `pytest tests/test_baseline.py::test_baseline_scaling_factor -q`
- `pytest tests/test_baseline.py::test_sigma_rate_uses_weighted_counts -q`
- `pytest tests/test_baseline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6858343bafac832b8b4e3684906486aa