### PR TITLE
Remove unused imports and clean up tests

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -61,7 +61,6 @@ import math
 import numpy as np
 import pandas as pd
 from scipy.stats import norm
-from dateutil import parser as date_parser
 from dateutil.tz import UTC, gettz
 
 from hierarchical import fit_hierarchical_runs
@@ -102,7 +101,6 @@ from visualize import cov_heatmap, efficiency_bar
 from utils import (
     find_adc_bin_peaks,
     adc_hist_edges,
-    cps_to_bq,
     parse_time,
     parse_time_arg,
 )

--- a/calibration.py
+++ b/calibration.py
@@ -2,7 +2,6 @@ import numpy as np
 from scipy.signal import find_peaks
 from scipy.optimize import curve_fit
 from scipy.stats import exponnorm
-import logging
 from constants import (
     _TAU_MIN,
     DEFAULT_NOISE_CUTOFF,

--- a/constants.py
+++ b/constants.py
@@ -2,7 +2,7 @@
 """Shared constants for analysis modules."""
 
 import numpy as np
-import math
+from dataclasses import dataclass
 
 # Minimum allowed value for the exponential tail constant used in EMG fits.
 _TAU_MIN = 1e-6
@@ -44,8 +44,6 @@ DEFAULT_KNOWN_ENERGIES = {
     "Po218": 6.002,  # MeV
     "Po214": 7.687,  # MeV
 }
-
-from dataclasses import dataclass
 
 
 @dataclass(frozen=True)

--- a/systematics.py
+++ b/systematics.py
@@ -1,7 +1,7 @@
 import math
 import copy
 import numpy as np
-from typing import Callable, Dict, Tuple, List
+from typing import Callable, Dict, Tuple
 
 
 def apply_linear_adc_shift(

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -1,4 +1,5 @@
-import sys, json
+import sys
+import json
 from pathlib import Path
 import pandas as pd
 import pytest

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 import sys
-import logging
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -4,7 +4,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from constants import PO210, PO214, PO218, load_nuclide_overrides, load_half_life_overrides
+from constants import PO210, load_nuclide_overrides, load_half_life_overrides
 
 
 def test_po210_default():

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -464,10 +464,9 @@ def test_fit_spectrum_covariance_checks(monkeypatch):
 def test_fit_time_series_covariance_checks(monkeypatch):
     """Minuit covariance validity should propagate to fit_valid."""
     T = 3600
-    E_true = 0.5
     eff = 0.4
     t_half = 164e-6
-    event_times = simulate_decay(E_true, eff, T)
+    event_times = simulate_decay(0.5, eff, T)
 
     times_dict = {"Po214": event_times}
     cfg = {
@@ -539,7 +538,6 @@ def test_fit_time_series_covariance_output():
     rng = np.random.default_rng(0)
     T = 10.0
     t_half = 164e-6
-    E_true = 0.1
     eff = 0.5
     times = np.sort(rng.uniform(0, T, 50))
     times_dict = {"Po214": times}

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -1,6 +1,4 @@
-import os
 import json
-import tempfile
 from pathlib import Path
 import sys
 import logging

--- a/tests/test_noise_cutoff.py
+++ b/tests/test_noise_cutoff.py
@@ -2,7 +2,6 @@ import json
 import sys
 from pathlib import Path
 import pandas as pd
-import logging
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_pipeline_after_fix.py
+++ b/tests/test_pipeline_after_fix.py
@@ -1,9 +1,6 @@
 import json
 import sys
 from pathlib import Path
-
-import pandas as pd
-import numpy as np
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_time_series_weights.py
+++ b/tests/test_time_series_weights.py
@@ -8,7 +8,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from fitting import (
     fit_time_series,
     _neg_log_likelihood_time,
-    _integral_model,
 )
 
 

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -4,7 +4,7 @@ import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-import plot_utils  # ensure matplotlib backend is set
+import plot_utils  # noqa: F401 - ensure matplotlib backend is set
 from visualize import cov_heatmap, efficiency_bar
 
 


### PR DESCRIPTION
## Summary
- drop unused imports in source code
- clean up and split several test imports
- remove unused variables in `tests/test_fitting.py`
- mark `plot_utils` import for side effects

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858367c76b0832ba725f9c3825cb4e4