### PR TITLE
Use helper for baseline rate calc

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1725,8 +1725,17 @@ def main(argv=None):
     if baseline_live_time > 0:
         for iso, n in baseline_counts.items():
             eff = cfg["time_fit"].get(f"eff_{iso.lower()}", [1.0])[0]
-            baseline_rates[iso] = n / (baseline_live_time * eff) if eff > 0 else 0.0
-            baseline_unc[iso] = np.sqrt(n) / (baseline_live_time * eff) if eff > 0 else 0.0
+            if eff > 0:
+                baseline_rates[iso], baseline_unc[iso] = subtract_baseline_counts(
+                    n,
+                    eff,
+                    baseline_live_time,
+                    0.0,
+                    baseline_live_time,
+                )
+            else:
+                baseline_rates[iso] = 0.0
+                baseline_unc[iso] = 0.0
 
     dilution_factor = monitor_vol / (monitor_vol + sample_vol) if (monitor_vol + sample_vol) > 0 else 0.0
     scales = {"Po214": dilution_factor, "Po218": dilution_factor, "Po210": 1.0, "noise": 1.0}


### PR DESCRIPTION
## Summary
- compute baseline rates with `subtract_baseline_counts`
- drop manual calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68583b33ebbc832b9189304488e05729