### PR TITLE
Align baseline tests with new subtraction

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1774,10 +1774,13 @@ def main(argv=None):
         baseline_info["rate_Bq"] = baseline_rates
         baseline_info["rate_unc_Bq"] = baseline_unc
         baseline_info["dilution_factor"] = dilution_factor
-    if corrected_rates:
-        baseline_info["corrected_rate_Bq"] = corrected_rates
-    if corrected_unc:
-        baseline_info["corrected_sigma_Bq"] = corrected_unc
+    if baseline_info.get("corrected_activity"):
+        baseline_info["corrected_rate_Bq"] = {
+            iso: vals["value"] for iso, vals in baseline_info["corrected_activity"].items()
+        }
+        baseline_info["corrected_sigma_Bq"] = {
+            iso: vals["uncertainty"] for iso, vals in baseline_info["corrected_activity"].items()
+        }
 
     # ────────────────────────────────────────────────────────────
     # Radon activity extrapolation


### PR DESCRIPTION
## Summary
- compute baseline-corrected values in tests using `subtract_baseline_counts`
- update baseline logic to populate `corrected_rate_Bq` from `corrected_activity`
- remove outdated assertions about manual correction

## Testing
- `pytest tests/test_baseline.py::test_simple_baseline_subtraction -q`
- `pytest tests/test_baseline.py::test_baseline_scaling_factor -q`
- `pytest tests/test_baseline.py::test_baseline_scaling_multiple_isotopes -q`
- `pytest tests/test_baseline.py::test_isotopes_to_subtract_control -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68583b34974c832bb14968b81ca0c752