### PR TITLE
Pin pymc version in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ matplotlib>=3.3
 pytest>=6.0
 pandas==1.5.3
 iminuit>=2.0
-pymc
+pymc==5.23.0
 jsonschema>=4.0
 python-dateutil>=2.8.0
 pytest-mpl>=0.16


### PR DESCRIPTION
## Summary
- pin `pymc` to an explicit version
- run `pip install -r requirements.txt`
- run the test suite

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68584ab574d0832bbce471e1b92fed01