### PR TITLE
Handle covariance of quadratic term and intercept

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1010,6 +1010,7 @@ def main(argv=None):
     cov_mat = np.asarray(cal_params.get("ac_covariance", [[0.0, 0.0], [0.0, 0.0]]), dtype=float)
     cov_ac = float(cov_mat[0, 1])
     cov_a_a2 = float(cal_params.get("cov_a_a2", 0.0))
+    cov_a2_c = float(cal_params.get("cov_a2_c", 0.0))
 
     # Apply calibration -> new column “energy_MeV” and its uncertainty
     df_analysis["energy_MeV"] = apply_calibration(df_analysis["adc"], a, c, quadratic_coeff=a2)
@@ -1021,6 +1022,7 @@ def main(argv=None):
         + c_sig ** 2
         + 2 * adc_vals * cov_ac
         + 2 * adc_vals ** 3 * cov_a_a2
+        + 2 * adc_vals ** 2 * cov_a2_c
     )
     df_analysis["denergy_MeV"] = np.sqrt(np.clip(var_energy, 0, None))
 
@@ -1075,6 +1077,7 @@ def main(argv=None):
                 + c_sig ** 2
                 + 2 * adc_b * cov_ac
                 + 2 * adc_b ** 3 * cov_a_a2
+                + 2 * adc_b ** 2 * cov_a2_c
             )
             base_events["denergy_MeV"] = np.sqrt(np.clip(var_base, 0, None))
         else:

--- a/calibration.py
+++ b/calibration.py
@@ -272,6 +272,7 @@ def calibrate_run(adc_values, config, hist_bins=None):
         var_a2, var_a, var_c = np.diag(cov_coeff)
         cov_a_a2 = cov_coeff[1, 0]
         cov_ac = cov_coeff[1, 2]
+        cov_a2_c = cov_coeff[0, 2]
     else:
         delta = adc214 - adc210
         var_a = (a / delta) ** 2 * (mu_err_210 ** 2 + mu_err_214 ** 2)
@@ -282,6 +283,7 @@ def calibrate_run(adc_values, config, hist_bins=None):
         cov_ac = (a ** 2 / delta ** 2) * (adc214 * mu_err_210 ** 2 + adc210 * mu_err_214 ** 2)
         var_a2 = 0.0
         cov_a_a2 = 0.0
+        cov_a2_c = 0.0
 
     # 8) Convert σADC -> σE (MeV) using local derivative at the Po-214 peak.
     slope_local = 2 * a2 * adc214 + a
@@ -304,6 +306,7 @@ def calibrate_run(adc_values, config, hist_bins=None):
         "ac_covariance": [[float(var_a), float(cov_ac)], [float(cov_ac), float(var_c)]],
         "a2_variance": float(var_a2),
         "cov_a_a2": float(cov_a_a2),
+        "cov_a2_c": float(cov_a2_c),
         "peaks": peak_fits,
     }
     return calib_dict
@@ -325,6 +328,7 @@ def derive_calibration_constants(adc_values, config):
         "peaks": res.get("peaks", {}),
         "ac_covariance": cov.tolist(),
         "cov_a_a2": float(res.get("cov_a_a2", 0.0)),
+        "cov_a2_c": float(res.get("cov_a2_c", 0.0)),
     }
     return out
 
@@ -398,6 +402,7 @@ def derive_calibration_constants_auto(
         "peaks": res.get("peaks", {}),
         "ac_covariance": cov.tolist(),
         "cov_a_a2": float(res.get("cov_a_a2", 0.0)),
+        "cov_a2_c": float(res.get("cov_a2_c", 0.0)),
     }
     return out
 

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -205,6 +205,7 @@ def test_energy_uncertainty_clipping():
     c_sig = 0.02
     cov_ac = -0.1
     cov_a_a2 = -0.05
+    cov_a2_c = -0.02
 
     var_energy = (
         (events["adc"] * a_sig) ** 2
@@ -212,6 +213,7 @@ def test_energy_uncertainty_clipping():
         + c_sig ** 2
         + 2 * events["adc"] * cov_ac
         + 2 * events["adc"] ** 3 * cov_a_a2
+        + 2 * events["adc"] ** 2 * cov_a2_c
     )
     assert var_energy.iloc[0] < 0
 


### PR DESCRIPTION
## Summary
- propagate covariance between quadratic term and intercept when computing calibration constants
- store the new `cov_a2_c` value and return it in calibration results
- include this covariance in energy uncertainty propagation
- update tests for new uncertainty formula

## Testing
- `pytest tests/test_calibration.py::test_energy_uncertainty_clipping -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a049a2a3c832b8150ee18e59a6da9