### PR TITLE
Implement parse_timestamp and update time parsing

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -101,7 +101,7 @@ from visualize import cov_heatmap, efficiency_bar
 from utils import (
     find_adc_bin_peaks,
     adc_hist_edges,
-    parse_time,
+    parse_timestamp,
     parse_time_arg,
 )
 from io_utils import parse_datetime
@@ -823,7 +823,7 @@ def main(argv=None):
     t0_cfg = cfg.get("analysis", {}).get("analysis_start_time")
     if t0_cfg is not None:
         try:
-            t0_global = parse_time(t0_cfg)
+            t0_global = parse_timestamp(t0_cfg)
             cfg.setdefault("analysis", {})["analysis_start_time"] = t0_global
         except Exception:
             logging.warning(
@@ -834,14 +834,14 @@ def main(argv=None):
         t0_global = events_filtered["timestamp"].min()
 
     if not isinstance(t0_global, (int, float)):
-        t0_global = parse_time(t0_global)
+        t0_global = parse_timestamp(t0_global)
 
     t_end_cfg = cfg.get("analysis", {}).get("analysis_end_time")
     t_end_global = None
     if t_end_cfg is not None:
         try:
             t_end_global = pd.to_datetime(parse_datetime(t_end_cfg), utc=True)
-            cfg.setdefault("analysis", {})["analysis_end_time"] = parse_time(t_end_global)
+            cfg.setdefault("analysis", {})["analysis_end_time"] = parse_timestamp(t_end_global)
         except Exception:
             logging.warning(
                 f"Invalid analysis_end_time '{t_end_cfg}' - using last event"
@@ -853,7 +853,7 @@ def main(argv=None):
     if spike_end_cfg is not None:
         try:
             t_spike_end = pd.to_datetime(parse_datetime(spike_end_cfg), utc=True)
-            cfg.setdefault("analysis", {})["spike_end_time"] = parse_time(t_spike_end)
+            cfg.setdefault("analysis", {})["spike_end_time"] = parse_timestamp(t_spike_end)
         except Exception:
             logging.warning(f"Invalid spike_end_time '{spike_end_cfg}' - ignoring")
             t_spike_end = None
@@ -874,7 +874,7 @@ def main(argv=None):
             logging.warning(f"Invalid spike_period {period} -> {e}")
     if spike_periods:
         cfg.setdefault("analysis", {})["spike_periods"] = [
-            [parse_time(s), parse_time(e)] for s, e in spike_periods
+            [parse_timestamp(s), parse_timestamp(e)] for s, e in spike_periods
         ]
 
     run_periods_cfg = cfg.get("analysis", {}).get("run_periods", [])
@@ -893,7 +893,7 @@ def main(argv=None):
             logging.warning(f"Invalid run_period {period} -> {e}")
     if run_periods:
         cfg.setdefault("analysis", {})["run_periods"] = [
-            [parse_time(s), parse_time(e)] for s, e in run_periods
+            [parse_timestamp(s), parse_timestamp(e)] for s, e in run_periods
         ]
 
     radon_interval_cfg = cfg.get("analysis", {}).get("radon_interval")
@@ -901,8 +901,8 @@ def main(argv=None):
     if radon_interval_cfg:
         try:
             start_r, end_r = radon_interval_cfg
-            start_r_ts = parse_time(start_r)
-            end_r_ts = parse_time(end_r)
+            start_r_ts = parse_timestamp(start_r)
+            end_r_ts = parse_timestamp(end_r)
             if end_r_ts <= start_r_ts:
                 raise ValueError("end <= start")
             radon_interval = (start_r_ts, end_r_ts)
@@ -940,7 +940,7 @@ def main(argv=None):
         t_end_global = df_analysis["timestamp"].max()
 
     if not isinstance(t_end_global, (int, float)):
-        t_end_global_ts = parse_time(t_end_global)
+        t_end_global_ts = parse_timestamp(t_end_global)
     else:
         t_end_global_ts = float(t_end_global)
 
@@ -1088,12 +1088,12 @@ def main(argv=None):
         else:
             baseline_live_time = float((t_end_base - t_start_base) / np.timedelta64(1, "s"))
         cfg.setdefault("baseline", {})["range"] = [
-            parse_time(t_start_base),
-            parse_time(t_end_base),
+            parse_timestamp(t_start_base),
+            parse_timestamp(t_end_base),
         ]
         baseline_info = {
-            "start": parse_time(t_start_base),
-            "end": parse_time(t_end_base),
+            "start": parse_timestamp(t_start_base),
+            "end": parse_timestamp(t_end_base),
             "n_events": len(base_events),
             "live_time": baseline_live_time,
         }

--- a/baseline.py
+++ b/baseline.py
@@ -1,7 +1,7 @@
 import numpy as np
 import logging
 import pandas as pd
-from utils import parse_time
+from utils import parse_timestamp
 from io_utils import parse_datetime
 
 __all__ = ["rate_histogram", "subtract_baseline"]
@@ -105,8 +105,8 @@ def subtract_baseline(df_analysis, df_full, bins, t_base0, t_base1,
         live_time_analysis = live_an
 
     # baseline slice
-    t0 = parse_time(t_base0)
-    t1 = parse_time(t_base1)
+    t0 = parse_timestamp(t_base0)
+    t1 = parse_timestamp(t_base1)
     ts_full = _seconds(df_full["timestamp"])
     mask = (ts_full >= t0) & (ts_full <= t1)
     if not mask.any():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,18 @@
 import sys
 from pathlib import Path
+from datetime import datetime
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from utils import cps_to_cpd, cps_to_bq, find_adc_bin_peaks, parse_time, LITERS_PER_M3
+from utils import (
+    cps_to_cpd,
+    cps_to_bq,
+    find_adc_bin_peaks,
+    parse_timestamp,
+    parse_time,
+    LITERS_PER_M3,
+)
 
 
 def test_cps_to_cpd():
@@ -65,3 +73,15 @@ def test_parse_time_iso_fraction():
 
 def test_parse_time_naive_timezone():
     assert parse_time("1970-01-01T01:00:00", tz="Europe/Berlin") == pytest.approx(0.0)
+
+
+def test_parse_timestamp_numeric():
+    assert parse_timestamp(42) == pytest.approx(42.0)
+
+
+def test_parse_timestamp_iso():
+    assert parse_timestamp("1970-01-01T00:00:00Z") == pytest.approx(0.0)
+
+
+def test_parse_timestamp_datetime_naive():
+    assert parse_timestamp(datetime(1970, 1, 1)) == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- add `parse_timestamp` for UTC epoch seconds
- make `parse_time` a wrapper and update call sites
- convert `parse_datetime` to use `parse_timestamp`
- adjust baseline and analysis code to new API
- extend tests for `parse_timestamp`

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a04accac0832baa591c8d3905c3a2