### PR TITLE
Unify timestamp parsing helpers

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -103,8 +103,8 @@ from utils import (
     adc_hist_edges,
     parse_time,
     parse_time_arg,
+    parse_datetime,
 )
-from io_utils import parse_datetime
 from radmon.baseline import subtract_baseline
 from radon.baseline import subtract_baseline_counts, subtract_baseline_rate
 

--- a/baseline.py
+++ b/baseline.py
@@ -1,8 +1,7 @@
 import numpy as np
 import logging
 import pandas as pd
-from utils import parse_time
-from io_utils import parse_datetime
+from utils import parse_time, parse_datetime
 
 __all__ = ["rate_histogram", "subtract_baseline"]
 

--- a/io_utils.py
+++ b/io_utils.py
@@ -5,12 +5,11 @@ import json
 import logging
 import warnings
 from datetime import datetime, timezone
-from dateutil import parser as date_parser
 import pandas as pd
 from constants import load_nuclide_overrides
 
 import numpy as np
-from utils import to_native
+from utils import to_native, parse_datetime
 import jsonschema
 
 
@@ -201,40 +200,6 @@ def ensure_dir(path):
     if not p.is_dir():
         p.mkdir(parents=True, exist_ok=True)
 
-
-def parse_datetime(value):
-    """Parse an ISO-8601 string or numeric epoch value to ``numpy.datetime64``.
-
-    The function accepts strings like ``"2023-09-28T13:45:00-04:00"`` or
-    numeric Unix timestamps (as ``int``, ``float`` or numeric ``str``).  Any
-    parsed time lacking a timezone is interpreted as UTC.  On success a
-    ``numpy.datetime64`` object in UTC (nanosecond resolution) is returned.
-    ``ValueError`` is raised if the input cannot be parsed.
-    """
-
-    if isinstance(value, (int, float)):
-        ts = float(value)
-    elif isinstance(value, str):
-        try:
-            ts = float(value)
-        except ValueError:
-            try:
-                dt = date_parser.isoparse(value)
-            except (ValueError, OverflowError) as e:
-                raise ValueError(f"invalid datetime: {value!r}") from e
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
-            ts = dt.timestamp()
-    elif isinstance(value, datetime):
-        dt = value
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        ts = dt.timestamp()
-    else:
-        raise ValueError(f"invalid datetime: {value!r}")
-
-    ns = int(round(ts * 1e9))
-    return np.datetime64(ns, "ns")
 
 
 def _merge_dicts(base: dict, override: dict) -> dict:

--- a/utils.py
+++ b/utils.py
@@ -17,6 +17,8 @@ __all__ = [
     "cps_to_bq",
     "parse_time_arg",
     "parse_time",
+    "parse_timestamp",
+    "parse_datetime",
     "LITERS_PER_M3",
 ]
 
@@ -175,7 +177,7 @@ def cps_to_bq(rate_cps, volume_liters=None):
     return float(rate_cps) / volume_m3
 
 
-def parse_time(s, tz="UTC") -> float:
+def parse_timestamp(s, tz="UTC") -> float:
     """Parse a timestamp string, number, or ``datetime`` into Unix epoch seconds.
 
     Parameters
@@ -221,6 +223,18 @@ def parse_time(s, tz="UTC") -> float:
         return float(dt.timestamp())
 
     raise argparse.ArgumentTypeError(f"could not parse time: {s!r}")
+
+
+# ``parse_time`` remains for backward compatibility
+parse_time = parse_timestamp
+
+
+def parse_datetime(value, tz="UTC") -> np.datetime64:
+    """Return ``numpy.datetime64`` parsed from various inputs."""
+
+    ts = parse_timestamp(value, tz=tz)
+    ns = int(round(ts * 1e9))
+    return np.datetime64(ns, "ns")
 
 
 def parse_time_arg(val, tz="UTC") -> datetime:


### PR DESCRIPTION
## Summary
- introduce `parse_timestamp` and alias old `parse_time`
- provide `parse_datetime` via `utils` using `parse_timestamp`
- update modules to import the new helpers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a04ae98fc832b88e8c15e9eca13ba