### PR TITLE
Unify datetime handling and consolidate time windows

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -203,37 +203,12 @@ def ensure_dir(path):
 
 
 def parse_datetime(value):
-    """Parse an ISO-8601 string or numeric epoch value to ``numpy.datetime64``.
+    """Return ``value`` converted to ``numpy.datetime64[ns, UTC]``."""
 
-    The function accepts strings like ``"2023-09-28T13:45:00-04:00"`` or
-    numeric Unix timestamps (as ``int``, ``float`` or numeric ``str``).  Any
-    parsed time lacking a timezone is interpreted as UTC.  On success a
-    ``numpy.datetime64`` object in UTC (nanosecond resolution) is returned.
-    ``ValueError`` is raised if the input cannot be parsed.
-    """
+    from utils import to_utc_datetime
 
-    if isinstance(value, (int, float)):
-        ts = float(value)
-    elif isinstance(value, str):
-        try:
-            ts = float(value)
-        except ValueError:
-            try:
-                dt = date_parser.isoparse(value)
-            except (ValueError, OverflowError) as e:
-                raise ValueError(f"invalid datetime: {value!r}") from e
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
-            ts = dt.timestamp()
-    elif isinstance(value, datetime):
-        dt = value
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        ts = dt.timestamp()
-    else:
-        raise ValueError(f"invalid datetime: {value!r}")
-
-    ns = int(round(ts * 1e9))
+    dt = to_utc_datetime(value)
+    ns = int(round(dt.timestamp() * 1e9))
     return np.datetime64(ns, "ns")
 
 

--- a/tests/test_cli_radon_interval.py
+++ b/tests/test_cli_radon_interval.py
@@ -1,0 +1,65 @@
+import json
+import sys
+from pathlib import Path
+import pandas as pd
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+
+
+def test_cli_radon_interval_overrides_config(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "baseline": {"range": [0, 5], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "analysis": {"radon_interval": ["0", "5"]},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1],
+        "fBits": [0],
+        "timestamp": [1.0],
+        "adc": [8.0],
+        "fchannel": [1],
+    })
+    data_path = tmp_path / "data.csv"
+    df.to_csv(data_path, index=False)
+
+    captured = {}
+    orig_load_config = analyze.load_config
+
+    def fake_load_config(path):
+        cfg_local = orig_load_config(path)
+        captured["cfg"] = cfg_local
+        return cfg_local
+
+    monkeypatch.setattr(analyze, "load_config", fake_load_config)
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "apply_burst_filter", lambda df, cfg, mode="rate": (df, 0))
+
+    args = [
+        "analyze.py",
+        "--config", str(cfg_path),
+        "--input", str(data_path),
+        "--output_dir", str(tmp_path),
+        "--radon-interval", "1970-01-01T00:00:01Z", "1970-01-01T00:00:02Z",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+
+    analyze.main()
+
+    used = captured.get("cfg", {})
+    assert used["analysis"]["radon_interval"] == [1.0, 2.0]

--- a/tests/test_time_parsing.py
+++ b/tests/test_time_parsing.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from utils import parse_time_arg
+from utils import to_utc_datetime
 
 @pytest.mark.parametrize("inp", [
     0,
@@ -14,7 +14,7 @@ from utils import parse_time_arg
     "1970-01-01T00:00:00+00:00",
 ])
 def test_parse_time_arg_variants(inp):
-    dt = parse_time_arg(inp)
+    dt = to_utc_datetime(inp)
     assert dt == datetime(1970, 1, 1, tzinfo=timezone.utc)
 
 
@@ -29,7 +29,7 @@ def test_parse_time_arg_variants(inp):
     ],
 )
 def test_parse_time_arg_iso_offsets(inp, expected):
-    assert parse_time_arg(inp) == expected
+    assert to_utc_datetime(inp) == expected
 
 
 @pytest.mark.parametrize(
@@ -40,15 +40,15 @@ def test_parse_time_arg_iso_offsets(inp, expected):
     ],
 )
 def test_parse_time_arg_numeric(inp, expected):
-    assert parse_time_arg(inp) == expected
+    assert to_utc_datetime(inp) == expected
 
 
 @pytest.mark.parametrize("inp", ["foo", "1970-13-01"])
 def test_parse_time_arg_invalid(inp):
-    with pytest.raises((argparse.ArgumentTypeError, ValueError)):
-        parse_time_arg(inp)
+    with pytest.raises(ValueError):
+        to_utc_datetime(inp)
 
 
 def test_parse_time_arg_naive_timezone():
-    dt = parse_time_arg("1970-01-01T01:00:00", tz="Europe/Berlin")
+    dt = to_utc_datetime("1970-01-01T01:00:00", tz="Europe/Berlin")
     assert dt == datetime(1970, 1, 1, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
- add `to_utc_datetime` helper returning timezone-aware datetimes
- adapt `parse_time`/`parse_time_arg` to use the new helper
- update config parsing and CLI processing to rely on timezone-aware datetimes
- centralize event filtering in `apply_time_windows`
- add regression test for CLI radon interval
- adjust existing tests to import the new helper

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: TypeError: Invalid comparison between dtype=datetime64[ns] and datetime)*

------
https://chatgpt.com/codex/tasks/task_e_685a03ad2984832b9909ba46fd4522b4