### PR TITLE
Implement CalibrationResult dataclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ This repository provides a complete pipeline to analyze electrostatic radon moni
 - `analyze.py`: Main entry point to run the full analysis.
 - `config.json`: JSON configuration file containing thresholds and options.
 - `io_utils.py`: Functions to load raw data and write outputs.
-- `calibration.py`: Peak-finding and energy calibration routines.
+- `calibration.py`: Peak-finding and energy calibration routines. The module
+  defines a `CalibrationResult` dataclass whose `predict` and `uncertainty`
+  methods evaluate the calibration polynomial and propagate coefficient
+  covariance.
 - `fitting.py`: Unbinned likelihood fit for Po-214 (and optional Po-218).
 - `efficiency.py`: Efficiency calculations and BLUE combination helpers.
 - `systematics.py`: Scan for systematic uncertainties (optional).

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -80,7 +80,7 @@ def test_derive_calibration_constants_peak_search_radius():
     cfg_ok["calibration"]["peak_search_radius"] = 5
 
     out = derive_calibration_constants(adc, cfg_ok)
-    assert set(out["peaks"].keys()) == {"Po210", "Po218", "Po214"}
+    assert set(out.peaks.keys()) == {"Po210", "Po218", "Po214"}
 
     cfg_bad = {"calibration": dict(base_cfg["calibration"])}
     cfg_bad["calibration"]["peak_search_radius"] = 1
@@ -115,8 +115,8 @@ def test_calibration_uses_known_energies_from_config():
 
     out = derive_calibration_constants(adc, cfg)
 
-    a, _ = out["a"]
-    c, _ = out["c"]
+    a = out.coeff(1)
+    c = out.coeff(0)
 
     assert pytest.approx(a * 1000 + c, rel=1e-3) == 5.1
     assert pytest.approx(a * 2000 + c, rel=1e-3) == 8.2
@@ -177,9 +177,9 @@ def test_calibrate_run_quadratic_option(caplog):
 
     out = derive_calibration_constants(adc, cfg)
 
-    a, _ = out["a"]
-    a2, _ = out["a2"]
-    c, _ = out["c"]
+    a = out.coeff(1)
+    a2 = out.coeff(2)
+    c = out.coeff(0)
 
     adc_test = np.array([1000, 1500, 2000])
     energies = apply_calibration(adc_test, a, c, quadratic_coeff=a2)


### PR DESCRIPTION
## Summary
- add dataclass `CalibrationResult` with `predict` and `uncertainty`
- return `CalibrationResult` from calibration helpers
- use the new API in analysis pipeline
- update calibration tests
- document calibration result class in README

## Testing
- `pip install numpy scipy matplotlib pandas iminuit`
- `pip install pymc`
- `pip install jsonschema`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a0499f10c832b8772e16622b77ed9