### PR TITLE
Refactor time parsing

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -50,7 +50,7 @@ import argparse
 import sys
 import logging
 import random
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 import subprocess
 import hashlib
 import json
@@ -102,7 +102,7 @@ from utils import (
     find_adc_bin_peaks,
     adc_hist_edges,
     parse_timestamp,
-    parse_time_arg,
+    to_utc_datetime,
 )
 from io_utils import parse_datetime
 from radmon.baseline import subtract_baseline
@@ -151,6 +151,34 @@ def _ensure_events(events: pd.DataFrame, stage: str) -> None:
     if len(events) == 0:
         print(f"No events remaining after {stage}. Exiting.")
         sys.exit(1)
+
+
+def filter_time_windows(
+    df: pd.DataFrame,
+    *,
+    spike_end: datetime | None = None,
+    spike_periods: list[tuple[datetime, datetime]] | None = None,
+    run_periods: list[tuple[datetime, datetime]] | None = None,
+    analysis_end: datetime | None = None,
+) -> pd.DataFrame:
+    """Apply spike/run window cuts and optional end time."""
+
+    out = df.copy()
+    out["timestamp"] = pd.to_datetime(out["timestamp"], utc=True)
+    if spike_end is not None:
+        out = out[out["timestamp"] >= spike_end]
+    if spike_periods:
+        for start, end in spike_periods:
+            mask = (out["timestamp"] >= start) & (out["timestamp"] < end)
+            out = out[~mask]
+    if run_periods:
+        keep = np.zeros(len(out), dtype=bool)
+        for start, end in run_periods:
+            keep |= (out["timestamp"] >= start) & (out["timestamp"] < end)
+        out = out[keep]
+    if analysis_end is not None:
+        out = out[out["timestamp"] <= analysis_end]
+    return out.reset_index(drop=True)
 
 
 def window_prob(E, sigma, lo, hi):
@@ -540,25 +568,25 @@ def main(argv=None):
         sys.exit(1)
 
     if args.baseline_range:
-        args.baseline_range = [parse_time_arg(t, tz=tzinfo) for t in args.baseline_range]
+        args.baseline_range = [to_utc_datetime(t, tz=tzinfo) for t in args.baseline_range]
     if args.analysis_end_time is not None:
-        args.analysis_end_time = parse_time_arg(args.analysis_end_time, tz=tzinfo)
+        args.analysis_end_time = to_utc_datetime(args.analysis_end_time, tz=tzinfo)
     if args.analysis_start_time is not None:
-        args.analysis_start_time = parse_time_arg(args.analysis_start_time, tz=tzinfo)
+        args.analysis_start_time = to_utc_datetime(args.analysis_start_time, tz=tzinfo)
     if args.spike_end_time is not None:
-        args.spike_end_time = parse_time_arg(args.spike_end_time, tz=tzinfo)
+        args.spike_end_time = to_utc_datetime(args.spike_end_time, tz=tzinfo)
     if args.spike_period:
         args.spike_period = [
-            [parse_time_arg(s, tz=tzinfo), parse_time_arg(e, tz=tzinfo)] for s, e in args.spike_period
+            [to_utc_datetime(s, tz=tzinfo), to_utc_datetime(e, tz=tzinfo)] for s, e in args.spike_period
         ]
     if args.run_period:
         args.run_period = [
-            [parse_time_arg(s, tz=tzinfo), parse_time_arg(e, tz=tzinfo)] for s, e in args.run_period
+            [to_utc_datetime(s, tz=tzinfo), to_utc_datetime(e, tz=tzinfo)] for s, e in args.run_period
         ]
     if args.radon_interval:
         args.radon_interval = [
-            parse_time_arg(args.radon_interval[0], tz=tzinfo),
-            parse_time_arg(args.radon_interval[1], tz=tzinfo),
+            to_utc_datetime(args.radon_interval[0], tz=tzinfo),
+            to_utc_datetime(args.radon_interval[1], tz=tzinfo),
         ]
 
     # ────────────────────────────────────────────────────────────
@@ -749,9 +777,7 @@ def main(argv=None):
         else:
             events_all["timestamp"] = events_all["timestamp"].dt.tz_convert(tzinfo)
 
-        # 3) Convert to epoch seconds (float)
-        #    astype(int) gives nanoseconds since epoch, so divide by 1e9
-        events_all["timestamp"] = events_all["timestamp"].astype("int64") / 1e9
+
 
     except Exception as e:
         print(f"ERROR: Could not load events from '{args.input}': {e}")
@@ -761,8 +787,7 @@ def main(argv=None):
         print("No events found in the input CSV. Exiting.")
         sys.exit(0)
 
-    # ``load_events()`` now returns timezone-aware datetimes; convert to epoch
-    # seconds for internal calculations.
+
 
     # ───────────────────────────────────────────────
     # 2a. Pedestal / electronic-noise cut (integer ADC)
@@ -823,25 +848,22 @@ def main(argv=None):
     t0_cfg = cfg.get("analysis", {}).get("analysis_start_time")
     if t0_cfg is not None:
         try:
-            t0_global = parse_timestamp(t0_cfg)
-            cfg.setdefault("analysis", {})["analysis_start_time"] = t0_global
+            t0_global = to_utc_datetime(t0_cfg)
+            cfg.setdefault("analysis", {})["analysis_start_time"] = t0_global.isoformat()
         except Exception:
             logging.warning(
                 f"Invalid analysis_start_time '{t0_cfg}' - using first event"
             )
-            t0_global = events_filtered["timestamp"].min()
+            t0_global = pd.to_datetime(events_filtered["timestamp"].iloc[0], utc=True).to_pydatetime()
     else:
-        t0_global = events_filtered["timestamp"].min()
-
-    if not isinstance(t0_global, (int, float)):
-        t0_global = parse_timestamp(t0_global)
+        t0_global = pd.to_datetime(events_filtered["timestamp"].iloc[0], utc=True).to_pydatetime()
 
     t_end_cfg = cfg.get("analysis", {}).get("analysis_end_time")
     t_end_global = None
     if t_end_cfg is not None:
         try:
-            t_end_global = pd.to_datetime(parse_datetime(t_end_cfg), utc=True)
-            cfg.setdefault("analysis", {})["analysis_end_time"] = parse_timestamp(t_end_global)
+            t_end_global = to_utc_datetime(t_end_cfg)
+            cfg.setdefault("analysis", {})["analysis_end_time"] = t_end_global.isoformat()
         except Exception:
             logging.warning(
                 f"Invalid analysis_end_time '{t_end_cfg}' - using last event"
@@ -852,8 +874,8 @@ def main(argv=None):
     t_spike_end = None
     if spike_end_cfg is not None:
         try:
-            t_spike_end = pd.to_datetime(parse_datetime(spike_end_cfg), utc=True)
-            cfg.setdefault("analysis", {})["spike_end_time"] = parse_timestamp(t_spike_end)
+            t_spike_end = to_utc_datetime(spike_end_cfg)
+            cfg.setdefault("analysis", {})["spike_end_time"] = t_spike_end.isoformat()
         except Exception:
             logging.warning(f"Invalid spike_end_time '{spike_end_cfg}' - ignoring")
             t_spike_end = None
@@ -865,8 +887,8 @@ def main(argv=None):
     for period in spike_periods_cfg:
         try:
             start, end = period
-            start_ts = pd.to_datetime(parse_datetime(start), utc=True)
-            end_ts = pd.to_datetime(parse_datetime(end), utc=True)
+            start_ts = to_utc_datetime(start)
+            end_ts = to_utc_datetime(end)
             if end_ts <= start_ts:
                 raise ValueError("end <= start")
             spike_periods.append((start_ts, end_ts))
@@ -874,7 +896,7 @@ def main(argv=None):
             logging.warning(f"Invalid spike_period {period} -> {e}")
     if spike_periods:
         cfg.setdefault("analysis", {})["spike_periods"] = [
-            [parse_timestamp(s), parse_timestamp(e)] for s, e in spike_periods
+            [s.isoformat(), e.isoformat()] for s, e in spike_periods
         ]
 
     run_periods_cfg = cfg.get("analysis", {}).get("run_periods", [])
@@ -884,8 +906,8 @@ def main(argv=None):
     for period in run_periods_cfg:
         try:
             start, end = period
-            start_ts = pd.to_datetime(parse_datetime(start), utc=True)
-            end_ts = pd.to_datetime(parse_datetime(end), utc=True)
+            start_ts = to_utc_datetime(start)
+            end_ts = to_utc_datetime(end)
             if end_ts <= start_ts:
                 raise ValueError("end <= start")
             run_periods.append((start_ts, end_ts))
@@ -893,7 +915,7 @@ def main(argv=None):
             logging.warning(f"Invalid run_period {period} -> {e}")
     if run_periods:
         cfg.setdefault("analysis", {})["run_periods"] = [
-            [parse_timestamp(s), parse_timestamp(e)] for s, e in run_periods
+            [s.isoformat(), e.isoformat()] for s, e in run_periods
         ]
 
     radon_interval_cfg = cfg.get("analysis", {}).get("radon_interval")
@@ -901,53 +923,36 @@ def main(argv=None):
     if radon_interval_cfg:
         try:
             start_r, end_r = radon_interval_cfg
-            start_r_ts = parse_timestamp(start_r)
-            end_r_ts = parse_timestamp(end_r)
+            start_r_ts = to_utc_datetime(start_r)
+            end_r_ts = to_utc_datetime(end_r)
             if end_r_ts <= start_r_ts:
                 raise ValueError("end <= start")
             radon_interval = (start_r_ts, end_r_ts)
-            cfg.setdefault("analysis", {})["radon_interval"] = [start_r_ts, end_r_ts]
+            cfg.setdefault("analysis", {})["radon_interval"] = [start_r_ts.isoformat(), end_r_ts.isoformat()]
         except Exception as e:
             logging.warning(f"Invalid radon_interval {radon_interval_cfg} -> {e}")
             radon_interval = None
 
     # Apply optional time window cuts before any baseline or fit operations
-    df_analysis = events_filtered.copy()
-    # Ensure timestamps are timezone-aware for comparisons
-    df_analysis["timestamp"] = pd.to_datetime(
-        df_analysis["timestamp"], unit="s", utc=True
+    df_analysis = filter_time_windows(
+        events_filtered,
+        spike_end=t_spike_end,
+        spike_periods=spike_periods,
+        run_periods=run_periods,
+        analysis_end=t_end_global,
     )
-    if t_spike_end is not None:
-        df_analysis = df_analysis[df_analysis["timestamp"] >= t_spike_end].reset_index(drop=True)
-    for start_ts, end_ts in spike_periods:
-        mask = (df_analysis["timestamp"] >= start_ts) & (
-            df_analysis["timestamp"] < end_ts
-        )
-        if mask.any():
-            df_analysis = df_analysis[~mask].reset_index(drop=True)
-    if run_periods:
-        keep_mask = np.zeros(len(df_analysis), dtype=bool)
-        for start_ts, end_ts in run_periods:
-            keep_mask |= (df_analysis["timestamp"] >= start_ts) & (
-                df_analysis["timestamp"] < end_ts
-            )
-        df_analysis = df_analysis[keep_mask].reset_index(drop=True)
-        if t_end_cfg is None and len(df_analysis) > 0:
-            t_end_global = df_analysis["timestamp"].max()
-    if t_end_global is not None:
-        df_analysis = df_analysis[df_analysis["timestamp"] <= t_end_global].reset_index(drop=True)
-    else:
+    if t_end_cfg is None and len(df_analysis) > 0:
+        t_end_global = df_analysis["timestamp"].max()
+    if t_end_global is None:
         t_end_global = df_analysis["timestamp"].max()
 
-    if not isinstance(t_end_global, (int, float)):
-        t_end_global_ts = parse_timestamp(t_end_global)
-    else:
-        t_end_global_ts = float(t_end_global)
+    t_end_global_ts = t_end_global.timestamp()
+    t0_global_ts = t0_global.timestamp()
 
     _ensure_events(df_analysis, "time-window selection")
 
-    analysis_start = datetime.fromtimestamp(t0_global, tz=timezone.utc)
-    analysis_end = datetime.fromtimestamp(t_end_global_ts, tz=timezone.utc)
+    analysis_start = t0_global
+    analysis_end = t_end_global
 
     # Optional ADC drift correction before calibration
     # Applied once using either the CLI value or the config default.
@@ -969,7 +974,7 @@ def main(argv=None):
                 df_analysis["adc"].values,
                 ts_seconds,
                 float(drift_rate),
-                t_ref=t0_global,
+                t_ref=t0_global_ts,
                 mode=drift_mode,
                 params=drift_params,
             )
@@ -1036,15 +1041,15 @@ def main(argv=None):
     baseline_range = None
     if args.baseline_range:
         _log_override("baseline", "range", args.baseline_range)
-        t0_epoch = args.baseline_range[0].timestamp()
-        t1_epoch = args.baseline_range[1].timestamp()
+        t_start_base = args.baseline_range[0]
+        t_end_base = args.baseline_range[1]
         logging.info(
-            f"Baseline window (epoch seconds): {t0_epoch} \u2192 {t1_epoch}"
+            f"Baseline window: {t_start_base.isoformat()} \u2192 {t_end_base.isoformat()}"
         )
-        cfg.setdefault("baseline", {})["range"] = [t0_epoch, t1_epoch]
-        baseline_range = [t0_epoch, t1_epoch]
+        cfg.setdefault("baseline", {})["range"] = [t_start_base.isoformat(), t_end_base.isoformat()]
+        baseline_range = [t_start_base, t_end_base]
     elif "range" in baseline_cfg:
-        baseline_range = baseline_cfg.get("range")
+        baseline_range = [to_utc_datetime(t) for t in baseline_cfg.get("range")]
 
     monitor_vol = float(baseline_cfg.get("monitor_volume_l", 605.0))
     sample_vol = float(baseline_cfg.get("sample_volume_l", 0.0))
@@ -1053,11 +1058,10 @@ def main(argv=None):
     mask_base = None
 
     if baseline_range:
-        t_start_base = pd.to_datetime(parse_datetime(baseline_range[0]), utc=True)
-        t_end_base = pd.to_datetime(parse_datetime(baseline_range[1]), utc=True)
+        t_start_base, t_end_base = baseline_range
         if t_end_base <= t_start_base:
             raise ValueError("baseline_range end time must be greater than start time")
-        events_all_ts = pd.to_datetime(events_all["timestamp"], unit="s", utc=True)
+        events_all_ts = pd.to_datetime(events_all["timestamp"], utc=True)
         mask_base_full = (events_all_ts >= t_start_base) & (
             events_all_ts < t_end_base
         )
@@ -1091,12 +1095,12 @@ def main(argv=None):
         else:
             baseline_live_time = float((t_end_base - t_start_base) / np.timedelta64(1, "s"))
         cfg.setdefault("baseline", {})["range"] = [
-            parse_timestamp(t_start_base),
-            parse_timestamp(t_end_base),
+            t_start_base.isoformat(),
+            t_end_base.isoformat(),
         ]
         baseline_info = {
-            "start": parse_timestamp(t_start_base),
-            "end": parse_timestamp(t_end_base),
+            "start": t_start_base.timestamp(),
+            "end": t_end_base.timestamp(),
             "n_events": len(base_events),
             "live_time": baseline_live_time,
         }
@@ -1357,7 +1361,7 @@ def main(argv=None):
                 first_sec = first_ts.to_datetime64().view("int64") / 1e9
             else:
                 first_sec = float(first_ts)
-            t_start_fit = max(first_sec, t0_global + float(args.settle_s or 0))
+            t_start_fit = max(first_sec, t0_global_ts + float(args.settle_s or 0))
             t_start_map[iso] = t_start_fit
             iso_live_time[iso] = t_end_global_ts - t_start_fit
 
@@ -1477,7 +1481,7 @@ def main(argv=None):
 
         # Build configuration for fit_time_series
         if args.settle_s is not None:
-            cut = pd.to_datetime(t0_global + float(args.settle_s), unit="s", utc=True)
+            cut = t0_global + timedelta(seconds=float(args.settle_s))
             iso_events = iso_events[iso_events["timestamp"] >= cut]
         ts_vals = iso_events["timestamp"]
         if pd.api.types.is_datetime64_any_dtype(ts_vals):
@@ -1508,7 +1512,7 @@ def main(argv=None):
         # Run time-series fit
         decay_out = None  # fresh variable each iteration
         try:
-            t_start_fit = t_start_map.get(iso, t0_global)
+            t_start_fit = t_start_map.get(iso, t0_global_ts)
             try:
                 decay_out = fit_time_series(
                     times_dict,
@@ -1544,7 +1548,7 @@ def main(argv=None):
         mask210 = (
             (df_analysis["energy_MeV"] >= lo)
             & (df_analysis["energy_MeV"] <= hi)
-            & (df_analysis["timestamp"] >= pd.to_datetime(t0_global, unit="s", utc=True))
+            & (df_analysis["timestamp"] >= t0_global)
             & (df_analysis["timestamp"] <= t_end_global)
         )
         events_p210 = df_analysis[mask210]
@@ -1612,7 +1616,7 @@ def main(argv=None):
                 try:
                     out = fit_time_series(
                         times_dict,
-                        t0_global,
+                        t0_global_ts,
                         t_end_global_ts,
                         cfg_fit,
                         weights=weights_local,
@@ -1621,7 +1625,7 @@ def main(argv=None):
                 except TypeError:
                     out = fit_time_series(
                         times_dict,
-                        t0_global,
+                        t0_global_ts,
                         t_end_global_ts,
                         cfg_fit,
                         strict=args.strict_covariance,
@@ -1843,8 +1847,8 @@ def main(argv=None):
     if radon_interval is not None:
         from radon_activity import radon_delta
 
-        t_start_rel = radon_interval[0] - t0_global
-        t_end_rel = radon_interval[1] - t0_global
+        t_start_rel = (radon_interval[0] - t0_global).total_seconds()
+        t_end_rel = (radon_interval[1] - t0_global).total_seconds()
 
         delta214 = err_delta214 = None
         if "Po214" in time_fit_results:
@@ -2016,7 +2020,7 @@ def main(argv=None):
             if np.issubdtype(ts_times.dtype, "datetime64"):
                 ts_times = ts_times.view("int64") / 1e9
             centers, widths = _ts_bin_centers_widths(
-                ts_times, plot_cfg, t0_global, t_end_global_ts
+                ts_times, plot_cfg, t0_global_ts, t_end_global_ts
             )
             normalise = bool(plot_cfg.get("plot_time_normalise_rate", False))
             model_errs = {}
@@ -2036,7 +2040,7 @@ def main(argv=None):
                 all_timestamps=ts_times,
                 all_energies=ts_energy,
                 fit_results=fit_dict,
-                t_start=t0_global,
+                t_start=t0_global_ts,
                 t_end=t_end_global_ts,
                 config=plot_cfg,
                 out_png=Path(out_dir) / f"time_series_{iso}.png",
@@ -2070,8 +2074,8 @@ def main(argv=None):
     try:
         from radon_activity import radon_activity_curve
 
-        times = np.linspace(t0_global, t_end_global_ts, 100)
-        t_rel = times - t0_global
+        times = np.linspace(t0_global_ts, t_end_global_ts, 100)
+        t_rel = times - t0_global_ts
 
         A214 = dA214 = None
         if "Po214" in time_fit_results:
@@ -2143,8 +2147,10 @@ def main(argv=None):
         )
 
         if radon_interval is not None:
-            times_trend = np.linspace(radon_interval[0], radon_interval[1], 50)
-            rel_trend = times_trend - t0_global
+            times_trend = np.linspace(
+                radon_interval[0].timestamp(), radon_interval[1].timestamp(), 50
+            )
+            rel_trend = times_trend - t0_global_ts
             A214_tr = None
             if "Po214" in time_fit_results:
                 fit_result = time_fit_results["Po214"]

--- a/io_utils.py
+++ b/io_utils.py
@@ -11,7 +11,7 @@ import pandas as pd
 from constants import load_nuclide_overrides
 
 import numpy as np
-from utils import to_native, parse_timestamp
+from utils import to_native, parse_timestamp, to_utc_datetime
 import jsonschema
 
 
@@ -203,22 +203,20 @@ def ensure_dir(path):
         p.mkdir(parents=True, exist_ok=True)
 
 
-def parse_datetime(value):
-    """Parse an ISO-8601 string or numeric epoch value to ``numpy.datetime64``.
+def parse_datetime(value, tz="UTC"):
+    """Parse ``value`` to ``numpy.datetime64`` in UTC.
 
-    The function accepts strings like ``"2023-09-28T13:45:00-04:00"`` or
-    numeric Unix timestamps (as ``int``, ``float`` or numeric ``str``).  Any
-    parsed time lacking a timezone is interpreted as UTC.  On success a
-    ``numpy.datetime64`` object in UTC (nanosecond resolution) is returned.
-    ``ValueError`` is raised if the input cannot be parsed.
+    Strings lacking a timezone are interpreted according to ``tz`` (default
+    ``"UTC"``). Numeric epoch seconds are also accepted. ``ValueError`` is
+    raised if parsing fails.
     """
 
     try:
-        ts = parse_timestamp(value)
+        dt = to_utc_datetime(value, tz=tz)
     except argparse.ArgumentTypeError as e:
         raise ValueError(f"invalid datetime: {value!r}") from e
 
-    return pd.to_datetime(ts, unit="s", utc=True).to_datetime64()
+    return pd.Timestamp(dt).to_datetime64()
 
 
 def _merge_dicts(base: dict, override: dict) -> dict:

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -2065,12 +2065,12 @@ def test_time_fields_written_back(tmp_path, monkeypatch):
     analyze.main()
 
     used = captured.get("cfg", {})
-    assert used["analysis"]["analysis_end_time"] == 5.0
-    assert used["analysis"]["spike_end_time"] == 0.0
-    assert used["analysis"]["spike_periods"] == [[2.0, 3.0]]
-    assert used["analysis"]["run_periods"] == [[0.0, 10.0]]
-    assert used["analysis"]["radon_interval"] == [3.0, 5.0]
-    assert used["baseline"]["range"] == [0.0, 1.0]
+    assert used["analysis"]["analysis_end_time"] == "1970-01-01T00:00:05+00:00"
+    assert used["analysis"]["spike_end_time"] == "1970-01-01T00:00:00+00:00"
+    assert used["analysis"]["spike_periods"] == [["1970-01-01T00:00:02+00:00", "1970-01-01T00:00:03+00:00"]]
+    assert used["analysis"]["run_periods"] == [["1970-01-01T00:00:00+00:00", "1970-01-01T00:00:10+00:00"]]
+    assert used["analysis"]["radon_interval"] == ["1970-01-01T00:00:03+00:00", "1970-01-01T00:00:05+00:00"]
+    assert used["baseline"]["range"] == ["1970-01-01T00:00:00+00:00", "1970-01-01T00:00:01+00:00"]
 
 
 

--- a/tests/test_baseline_radon_parse.py
+++ b/tests/test_baseline_radon_parse.py
@@ -1,0 +1,55 @@
+import json
+import sys
+from pathlib import Path
+import pandas as pd
+import numpy as np
+from fitting import FitResult
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+
+
+def test_baseline_and_radon_intervals_parsed(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "baseline": {"range": [0, 1], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "analysis": {},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0.5], "adc": [1], "fchannel": [1]})
+    data = tmp_path / "d.csv"
+    df.to_csv(data, index=False)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0, 0)), 0))
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+
+    captured = {}
+    monkeypatch.setattr(analyze, "copy_config", lambda outdir, cfg_in, exist_ok=False: captured.update({"cfg": cfg_in}))
+
+    args = [
+        "analyze.py",
+        "--config", str(cfg_path),
+        "--input", str(data),
+        "--output_dir", str(tmp_path),
+        "--baseline_range", "1970-01-01T00:00:01Z", "1970-01-01T00:00:02Z",
+        "--radon-interval", "1970-01-01T00:00:03Z", "1970-01-01T00:00:04Z",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    used = captured.get("cfg", {})
+    assert used["baseline"]["range"] == ["1970-01-01T00:00:01+00:00", "1970-01-01T00:00:02+00:00"]
+    assert used["analysis"]["radon_interval"] == ["1970-01-01T00:00:03+00:00", "1970-01-01T00:00:04+00:00"]

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -1,0 +1,14 @@
+import datetime
+from utils import to_utc_datetime
+
+
+def test_to_utc_datetime_parses_iso_and_epoch():
+    dt1 = to_utc_datetime("1970-01-01T00:00:10Z")
+    dt2 = to_utc_datetime(10)
+    assert dt1 == datetime.datetime(1970, 1, 1, 0, 0, 10, tzinfo=datetime.timezone.utc)
+    assert dt2 == dt1
+
+
+def test_to_utc_datetime_with_timezone():
+    dt = to_utc_datetime("1970-01-01 01:00:00", tz="Europe/Berlin")
+    assert dt == datetime.datetime(1970, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)

--- a/utils.py
+++ b/utils.py
@@ -16,6 +16,7 @@ __all__ = [
     "cps_to_cpd",
     "cps_to_bq",
     "parse_time_arg",
+    "to_utc_datetime",
     "parse_timestamp",
     "parse_time",
     "LITERS_PER_M3",
@@ -49,6 +50,10 @@ def to_native(obj):
             return obj.isoformat()
         elif isinstance(obj, (pd.Series, pd.Index)):
             return [to_native(x) for x in obj.tolist()]
+    if isinstance(obj, datetime):
+        if obj.tzinfo is None:
+            obj = obj.replace(tzinfo=timezone.utc)
+        return obj.isoformat()
     if isinstance(obj, np.ndarray):
         # Convert array into list of native types
         return [to_native(x) for x in obj.tolist()]
@@ -271,6 +276,11 @@ def parse_time_arg(val, tz="UTC") -> datetime:
 
     ``tz`` specifies the timezone for naïve inputs.
     """
+    return to_utc_datetime(val, tz=tz)
+
+
+def to_utc_datetime(val, tz="UTC") -> datetime:
+    """Return ``val`` parsed as a timezone-aware UTC ``datetime``."""
 
     ts = parse_time(val, tz=tz)
     return datetime.fromtimestamp(ts, tz=timezone.utc)


### PR DESCRIPTION
## Summary
- centralize datetime parsing with `to_utc_datetime`
- convert config timestamp handling to ISO strings
- add DataFrame time-window filter helper
- add focused tests for new helper and interval parsing

## Testing
- `pytest tests/test_time_utils.py tests/test_baseline_radon_parse.py tests/test_analyze_config_merge.py::test_time_fields_written_back -q`

------
https://chatgpt.com/codex/tasks/task_e_685a08755710832b89b7924281ce246d