### PR TITLE
Move parse_datetime to utils

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -104,7 +104,7 @@ from utils import (
     parse_timestamp,
     parse_time_arg,
 )
-from io_utils import parse_datetime
+from utils import parse_datetime
 from radmon.baseline import subtract_baseline
 from radon.baseline import subtract_baseline_counts, subtract_baseline_rate
 

--- a/baseline.py
+++ b/baseline.py
@@ -1,8 +1,7 @@
 import numpy as np
 import logging
 import pandas as pd
-from utils import parse_timestamp
-from io_utils import parse_datetime
+from utils import parse_timestamp, parse_datetime
 
 __all__ = ["rate_histogram", "subtract_baseline"]
 

--- a/io_utils.py
+++ b/io_utils.py
@@ -11,7 +11,7 @@ import pandas as pd
 from constants import load_nuclide_overrides
 
 import numpy as np
-from utils import to_native, parse_timestamp
+from utils import to_native, parse_timestamp, parse_datetime
 import jsonschema
 
 
@@ -203,22 +203,8 @@ def ensure_dir(path):
         p.mkdir(parents=True, exist_ok=True)
 
 
-def parse_datetime(value):
-    """Parse an ISO-8601 string or numeric epoch value to ``numpy.datetime64``.
-
-    The function accepts strings like ``"2023-09-28T13:45:00-04:00"`` or
-    numeric Unix timestamps (as ``int``, ``float`` or numeric ``str``).  Any
-    parsed time lacking a timezone is interpreted as UTC.  On success a
-    ``numpy.datetime64`` object in UTC (nanosecond resolution) is returned.
-    ``ValueError`` is raised if the input cannot be parsed.
-    """
-
-    try:
-        ts = parse_timestamp(value)
-    except argparse.ArgumentTypeError as e:
-        raise ValueError(f"invalid datetime: {value!r}") from e
-
-    return pd.to_datetime(ts, unit="s", utc=True).to_datetime64()
+# parse_datetime is re-exported from utils for backward compatibility
+# The implementation now lives in utils.parse_datetime
 
 
 def _merge_dicts(base: dict, override: dict) -> dict:

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -15,8 +15,8 @@ from io_utils import (
     write_summary,
     copy_config,
     apply_burst_filter,
-    parse_datetime,
 )
+from utils import parse_datetime
 
 
 def test_load_config(tmp_path):

--- a/tests/test_parse_datetime.py
+++ b/tests/test_parse_datetime.py
@@ -5,7 +5,7 @@ import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from io_utils import parse_datetime
+from utils import parse_datetime
 
 
 def test_parse_datetime_iso_string():

--- a/utils.py
+++ b/utils.py
@@ -17,6 +17,7 @@ __all__ = [
     "cps_to_bq",
     "parse_time_arg",
     "parse_timestamp",
+    "parse_datetime",
     "parse_time",
     "LITERS_PER_M3",
 ]
@@ -213,6 +214,27 @@ def parse_timestamp(s) -> float:
         return float(dt.timestamp())
 
     raise argparse.ArgumentTypeError(f"could not parse time: {s!r}")
+
+
+def parse_datetime(value):
+    """Parse an ISO-8601 string or numeric epoch value to ``numpy.datetime64``.
+
+    The function accepts strings like ``"2023-09-28T13:45:00-04:00"`` or
+    numeric Unix timestamps (as ``int``, ``float`` or numeric ``str``). Any
+    parsed time lacking a timezone is interpreted as UTC. On success a
+    ``numpy.datetime64`` object in UTC (nanosecond resolution) is returned.
+    ``ValueError`` is raised if the input cannot be parsed.
+    """
+
+    try:
+        ts = parse_timestamp(value)
+    except argparse.ArgumentTypeError as e:
+        raise ValueError(f"invalid datetime: {value!r}") from e
+
+    if pd is None:
+        raise RuntimeError("pandas is required for parse_datetime")
+
+    return pd.to_datetime(ts, unit="s", utc=True).to_datetime64()
 
 
 def parse_time(s, tz="UTC") -> float:


### PR DESCRIPTION
## Summary
- move `parse_datetime` from `io_utils.py` to `utils.py`
- export `parse_datetime` via `utils.__all__`
- keep a stub in `io_utils.py` that re-exports the function
- update imports in baseline, analyze and tests

## Testing
- `bash scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a0a38d3b4832b96850640f0ab5fe3