### PR TITLE
Add parse_datetime edge case tests

### DIFF
--- a/tests/test_parse_datetime.py
+++ b/tests/test_parse_datetime.py
@@ -1,6 +1,6 @@
 import sys
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -10,21 +10,50 @@ from io_utils import parse_datetime
 
 def test_parse_datetime_iso_string():
     ts = parse_datetime("1970-01-01T00:00:00Z")
+    assert isinstance(ts, np.datetime64)
     assert ts == np.datetime64("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_numeric():
     ts = parse_datetime(42)
+    assert isinstance(ts, np.datetime64)
     assert ts == np.datetime64("1970-01-01T00:00:42Z")
 
 
 def test_parse_datetime_numeric_str():
     ts = parse_datetime("42")
+    assert isinstance(ts, np.datetime64)
     assert ts == np.datetime64("1970-01-01T00:00:42Z")
 
 
 def test_parse_datetime_naive_datetime():
     dt = datetime(1970, 1, 1)
     ts = parse_datetime(dt)
+    assert isinstance(ts, np.datetime64)
+    assert ts == np.datetime64("1970-01-01T00:00:00Z")
+
+
+def test_parse_datetime_float():
+    ts = parse_datetime(42.5)
+    assert isinstance(ts, np.datetime64)
+    assert ts == np.datetime64("1970-01-01T00:00:42.500000000Z")
+
+
+def test_parse_datetime_iso_without_tz():
+    ts = parse_datetime("1970-01-01T00:00:00")
+    assert isinstance(ts, np.datetime64)
+    assert ts == np.datetime64("1970-01-01T00:00:00Z")
+
+
+def test_parse_datetime_iso_with_offset():
+    ts = parse_datetime("1970-01-01T01:00:00+01:00")
+    assert isinstance(ts, np.datetime64)
+    assert ts == np.datetime64("1970-01-01T00:00:00Z")
+
+
+def test_parse_datetime_datetime_with_tz():
+    dt = datetime(1970, 1, 1, 1, tzinfo=timezone(timedelta(hours=1)))
+    ts = parse_datetime(dt)
+    assert isinstance(ts, np.datetime64)
     assert ts == np.datetime64("1970-01-01T00:00:00Z")
 


### PR DESCRIPTION
## Summary
- expand parse_datetime unit test coverage
  - verify numeric timestamps with float values
  - verify ISO-8601 strings with and without timezone offsets
  - verify timezone-aware datetime objects
  - confirm results are numpy.datetime64

## Testing
- `pytest -q tests/test_parse_datetime.py`

------
https://chatgpt.com/codex/tasks/task_e_685a0a3aca28832b8ae9742765805503