### PR TITLE
Delegate timezone handling to parse_time_arg

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import sys
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -11,6 +11,7 @@ from utils import (
     find_adc_bin_peaks,
     parse_timestamp,
     parse_time,
+    parse_time_arg,
     LITERS_PER_M3,
 )
 
@@ -72,7 +73,7 @@ def test_parse_time_iso_fraction():
 
 
 def test_parse_time_naive_timezone():
-    assert parse_time("1970-01-01T01:00:00", tz="Europe/Berlin") == pytest.approx(0.0)
+    assert parse_time_arg("1970-01-01T01:00:00", tz="Europe/Berlin") == datetime(1970, 1, 1, tzinfo=timezone.utc)
 
 
 def test_parse_timestamp_numeric():

--- a/utils.py
+++ b/utils.py
@@ -215,55 +215,14 @@ def parse_timestamp(s) -> float:
     raise argparse.ArgumentTypeError(f"could not parse time: {s!r}")
 
 
-def parse_time(s, tz="UTC") -> float:
-    """Parse a timestamp string, number, or ``datetime`` into Unix epoch seconds.
+def parse_time(s) -> float:
+    """Parse a timestamp string, number or ``datetime`` into Unix epoch seconds.
 
-    Parameters
-    ----------
-    s : str | float | int | datetime
-        Input value to parse.
-    tz : str or tzinfo, optional
-        Timezone to assume for naïve inputs. ``dateutil.tz.gettz`` is used to
-        resolve the value. Defaults to ``"UTC"``.
+    This function simply forwards to :func:`parse_timestamp` and therefore
+    always interprets naïve inputs as UTC.
     """
 
-    tzinfo_obj = tz if isinstance(tz, tzinfo) else gettz(tz)
-    if tzinfo_obj is None:
-        tzinfo_obj = timezone.utc
-
-    if tzinfo_obj.tzname(None) == "UTC":
-        return parse_timestamp(s)
-
-    if isinstance(s, (int, float)):
-        return float(s)
-
-    if isinstance(s, datetime):
-        dt = s
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=tzinfo_obj)
-        else:
-            dt = dt.astimezone(tzinfo_obj)
-        return float(dt.timestamp())
-
-    if isinstance(s, str):
-        try:
-            return float(s)
-        except ValueError:
-            pass
-
-        try:
-            dt = date_parser.isoparse(s)
-        except (ValueError, OverflowError) as e:
-            raise argparse.ArgumentTypeError(f"could not parse time: {s!r}") from e
-
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=tzinfo_obj)
-        else:
-            dt = dt.astimezone(tzinfo_obj)
-
-        return float(dt.timestamp())
-
-    raise argparse.ArgumentTypeError(f"could not parse time: {s!r}")
+    return parse_timestamp(s)
 
 
 def parse_time_arg(val, tz="UTC") -> datetime:
@@ -272,7 +231,29 @@ def parse_time_arg(val, tz="UTC") -> datetime:
     ``tz`` specifies the timezone for naïve inputs.
     """
 
-    ts = parse_time(val, tz=tz)
+    tzinfo_obj = tz if isinstance(tz, tzinfo) else gettz(tz)
+    if tzinfo_obj is None:
+        tzinfo_obj = timezone.utc
+
+    if isinstance(val, datetime):
+        dt = val
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=tzinfo_obj)
+    elif isinstance(val, str):
+        try:
+            ts = float(val)
+            return datetime.fromtimestamp(ts, tz=timezone.utc)
+        except ValueError:
+            try:
+                dt = date_parser.isoparse(val)
+            except (ValueError, OverflowError) as e:
+                raise argparse.ArgumentTypeError(f"could not parse time: {val!r}") from e
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=tzinfo_obj)
+    else:
+        return datetime.fromtimestamp(parse_timestamp(val), tz=timezone.utc)
+
+    ts = parse_timestamp(dt)
     return datetime.fromtimestamp(ts, tz=timezone.utc)
 
 


### PR DESCRIPTION
## Summary
- forward `parse_time` directly to `parse_timestamp`
- shift timezone handling logic into `parse_time_arg`
- test timezone parsing via `parse_time_arg`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a0a3e5368832b9b6952f63cbe7791