### PR TITLE
Update timestamp docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository provides a complete pipeline to analyze electrostatic radon monitor data.
 
-**Note:** All time quantities are expressed in seconds and all energies are given in MeV throughout the documentation and code. Event timestamps are stored as UTC `numpy.datetime64` objects throughout the pipeline. The helper function `parse_datetime` converts input values to this representation and accepts ISO‑8601 strings (with or without timezone), numeric epoch seconds or existing `datetime` objects. Command-line options that take timestamps (such as `--analysis-start-time`) are parsed with this helper, so both ISO‑8601 strings and Unix seconds work interchangeably. A global `--timezone` option controls which zone naïve times are interpreted in (default: `UTC`).
+**Note:** All time quantities are expressed in seconds and all energies are given in MeV throughout the documentation and code. Event timestamps are stored as UTC `numpy.datetime64` objects throughout the pipeline. The helper function `parse_datetime` converts input values to this representation and accepts ISO‑8601 strings (with or without timezone), numeric epoch seconds or existing `datetime` objects. The related helper `parse_timestamp` turns the same input forms into raw Unix seconds. Command-line options that take timestamps (such as `--analysis-start-time`) are parsed with these utilities, so both ISO‑8601 strings and Unix seconds work interchangeably. A global `--timezone` option controls which zone naïve times are interpreted in (default: `UTC`).
 
 ## Structure
 
@@ -14,8 +14,9 @@ This repository provides a complete pipeline to analyze electrostatic radon moni
 - `efficiency.py`: Efficiency calculations and BLUE combination helpers.
 - `systematics.py`: Scan for systematic uncertainties (optional).
 - `plot_utils.py`: Plotting routines for spectrum and time-series.
-- `utils.py`: Miscellaneous utilities (time conversion, JSON validation,
-  count-rate conversions).
+ - `utils.py`: Miscellaneous utilities including `parse_datetime` and
+    `parse_timestamp` for time conversion, JSON validation and count-rate
+    conversions.
 - `tests/`: `pytest` unit tests for calibration, fitting, and I/O.
 
 ## Installation
@@ -537,8 +538,8 @@ Example configuration to tighten the cut (set it to `null` to disable):
 
 ## Utility Conversions
 
-`utils.py` provides simple helpers to convert count rates and to search for
-peak centroids:
+`utils.py` provides simple helpers to convert count rates, work with timestamps
+and to search for peak centroids:
 
 - `cps_to_cpd(rate_cps)` converts counts/s to counts/day.
 - `cps_to_bq(rate_cps, volume_liters=None)` returns the activity in Bq, or
@@ -546,6 +547,19 @@ peak centroids:
 - `find_adc_bin_peaks(adc_values, expected, window=50, prominence=0.0, width=None)`
   histogramises the raw ADC spectrum, searches for maxima near each expected
   centroid and returns a `{peak: adc_centroid}` mapping in ADC units.
+- `parse_timestamp(value)` converts ISO‑8601 strings, numeric values or
+  ``datetime`` objects to Unix seconds.
+- `parse_datetime(value)` returns a UTC ``numpy.datetime64`` from the same set
+  of input types.
+
+Example:
+
+```python
+from utils import parse_datetime, parse_timestamp
+
+sec = parse_timestamp("1970-01-01T00:00:00Z")
+dt64 = parse_datetime(sec)
+```
 
 You can invoke these from the command line:
 

--- a/io_utils.py
+++ b/io_utils.py
@@ -11,7 +11,7 @@ import pandas as pd
 from constants import load_nuclide_overrides
 
 import numpy as np
-from utils import to_native, parse_timestamp
+from utils import to_native, parse_timestamp, parse_datetime
 import jsonschema
 
 
@@ -203,22 +203,6 @@ def ensure_dir(path):
         p.mkdir(parents=True, exist_ok=True)
 
 
-def parse_datetime(value):
-    """Parse an ISO-8601 string or numeric epoch value to ``numpy.datetime64``.
-
-    The function accepts strings like ``"2023-09-28T13:45:00-04:00"`` or
-    numeric Unix timestamps (as ``int``, ``float`` or numeric ``str``).  Any
-    parsed time lacking a timezone is interpreted as UTC.  On success a
-    ``numpy.datetime64`` object in UTC (nanosecond resolution) is returned.
-    ``ValueError`` is raised if the input cannot be parsed.
-    """
-
-    try:
-        ts = parse_timestamp(value)
-    except argparse.ArgumentTypeError as e:
-        raise ValueError(f"invalid datetime: {value!r}") from e
-
-    return pd.to_datetime(ts, unit="s", utc=True).to_datetime64()
 
 
 def _merge_dicts(base: dict, override: dict) -> dict:

--- a/tests/test_parse_datetime.py
+++ b/tests/test_parse_datetime.py
@@ -5,7 +5,7 @@ import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from io_utils import parse_datetime
+from utils import parse_datetime
 
 
 def test_parse_datetime_iso_string():


### PR DESCRIPTION
## Summary
- mention `parse_timestamp` in docs
- highlight time helpers from utils
- show helper usage examples
- expose `parse_datetime` from `utils.py`
- update tests for new import

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a0a3a4cdc832b84cf6d9f9bf42922