### PR TITLE
use parse_timestamp before datetime conversions

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -840,8 +840,9 @@ def main(argv=None):
     t_end_global = None
     if t_end_cfg is not None:
         try:
-            t_end_global = pd.to_datetime(parse_datetime(t_end_cfg), utc=True)
-            cfg.setdefault("analysis", {})["analysis_end_time"] = parse_timestamp(t_end_global)
+            t_end_global_ts = parse_timestamp(t_end_cfg)
+            t_end_global = pd.to_datetime(t_end_global_ts, unit="s", utc=True)
+            cfg.setdefault("analysis", {})["analysis_end_time"] = t_end_global_ts
         except Exception:
             logging.warning(
                 f"Invalid analysis_end_time '{t_end_cfg}' - using last event"
@@ -852,8 +853,9 @@ def main(argv=None):
     t_spike_end = None
     if spike_end_cfg is not None:
         try:
-            t_spike_end = pd.to_datetime(parse_datetime(spike_end_cfg), utc=True)
-            cfg.setdefault("analysis", {})["spike_end_time"] = parse_timestamp(t_spike_end)
+            spike_end_ts = parse_timestamp(spike_end_cfg)
+            t_spike_end = pd.to_datetime(spike_end_ts, unit="s", utc=True)
+            cfg.setdefault("analysis", {})["spike_end_time"] = spike_end_ts
         except Exception:
             logging.warning(f"Invalid spike_end_time '{spike_end_cfg}' - ignoring")
             t_spike_end = None
@@ -865,8 +867,8 @@ def main(argv=None):
     for period in spike_periods_cfg:
         try:
             start, end = period
-            start_ts = pd.to_datetime(parse_datetime(start), utc=True)
-            end_ts = pd.to_datetime(parse_datetime(end), utc=True)
+            start_ts = pd.to_datetime(parse_timestamp(start), unit="s", utc=True)
+            end_ts = pd.to_datetime(parse_timestamp(end), unit="s", utc=True)
             if end_ts <= start_ts:
                 raise ValueError("end <= start")
             spike_periods.append((start_ts, end_ts))
@@ -884,8 +886,8 @@ def main(argv=None):
     for period in run_periods_cfg:
         try:
             start, end = period
-            start_ts = pd.to_datetime(parse_datetime(start), utc=True)
-            end_ts = pd.to_datetime(parse_datetime(end), utc=True)
+            start_ts = pd.to_datetime(parse_timestamp(start), unit="s", utc=True)
+            end_ts = pd.to_datetime(parse_timestamp(end), unit="s", utc=True)
             if end_ts <= start_ts:
                 raise ValueError("end <= start")
             run_periods.append((start_ts, end_ts))
@@ -914,6 +916,7 @@ def main(argv=None):
     # Apply optional time window cuts before any baseline or fit operations
     df_analysis = events_filtered.copy()
     # Ensure timestamps are timezone-aware for comparisons
+    df_analysis["timestamp"] = df_analysis["timestamp"].map(parse_timestamp)
     df_analysis["timestamp"] = pd.to_datetime(
         df_analysis["timestamp"], unit="s", utc=True
     )
@@ -1053,11 +1056,13 @@ def main(argv=None):
     mask_base = None
 
     if baseline_range:
-        t_start_base = pd.to_datetime(parse_datetime(baseline_range[0]), utc=True)
-        t_end_base = pd.to_datetime(parse_datetime(baseline_range[1]), utc=True)
+        t_start_base_ts = parse_timestamp(baseline_range[0])
+        t_end_base_ts = parse_timestamp(baseline_range[1])
+        t_start_base = pd.to_datetime(t_start_base_ts, unit="s", utc=True)
+        t_end_base = pd.to_datetime(t_end_base_ts, unit="s", utc=True)
         if t_end_base <= t_start_base:
             raise ValueError("baseline_range end time must be greater than start time")
-        events_all_ts = pd.to_datetime(events_all["timestamp"], unit="s", utc=True)
+        events_all_ts = pd.to_datetime(events_all["timestamp"].map(parse_timestamp), unit="s", utc=True)
         mask_base_full = (events_all_ts >= t_start_base) & (
             events_all_ts < t_end_base
         )
@@ -1477,7 +1482,8 @@ def main(argv=None):
 
         # Build configuration for fit_time_series
         if args.settle_s is not None:
-            cut = pd.to_datetime(t0_global + float(args.settle_s), unit="s", utc=True)
+            cut_ts = parse_timestamp(t0_global + float(args.settle_s))
+            cut = pd.to_datetime(cut_ts, unit="s", utc=True)
             iso_events = iso_events[iso_events["timestamp"] >= cut]
         ts_vals = iso_events["timestamp"]
         if pd.api.types.is_datetime64_any_dtype(ts_vals):
@@ -1544,7 +1550,7 @@ def main(argv=None):
         mask210 = (
             (df_analysis["energy_MeV"] >= lo)
             & (df_analysis["energy_MeV"] <= hi)
-            & (df_analysis["timestamp"] >= pd.to_datetime(t0_global, unit="s", utc=True))
+            & (df_analysis["timestamp"] >= pd.to_datetime(parse_timestamp(t0_global), unit="s", utc=True))
             & (df_analysis["timestamp"] <= t_end_global)
         )
         events_p210 = df_analysis[mask210]

--- a/baseline.py
+++ b/baseline.py
@@ -2,7 +2,6 @@ import numpy as np
 import logging
 import pandas as pd
 from utils import parse_timestamp
-from io_utils import parse_datetime
 
 __all__ = ["rate_histogram", "subtract_baseline"]
 
@@ -55,10 +54,10 @@ def _scaling_factor(dt_window: float, dt_baseline: float,
 def _seconds(col):
     """Return timestamp column as seconds from epoch."""
     ts = col
-    if not pd.api.types.is_datetime64_any_dtype(ts):
-        ts = ts.map(parse_datetime)
-    ts = pd.to_datetime(ts, utc=True)
-    return ts.view("int64").to_numpy() / 1e9
+    if pd.api.types.is_datetime64_any_dtype(ts):
+        return ts.view("int64").to_numpy() / 1e9
+    ts = ts.map(parse_timestamp)
+    return np.asarray(ts, dtype=float)
 
 
 def rate_histogram(df, bins):

--- a/io_utils.py
+++ b/io_utils.py
@@ -312,6 +312,7 @@ def load_events(csv_path, *, column_map=None):
 
     # Parse timestamps (epoch seconds) into timezone-aware datetimes
     if "timestamp" in df.columns:
+        df["timestamp"] = df["timestamp"].map(parse_timestamp)
         df["timestamp"] = pd.to_datetime(df["timestamp"], unit="s", utc=True, errors="coerce")
 
     # Check required columns after renaming


### PR DESCRIPTION
## Summary
- parse timestamps early in `load_events`
- drop redundant conversions in baseline helper
- consistently call `parse_timestamp` before `pd.to_datetime` in the analysis CLI

## Testing
- `pytest -q` *(fails: Package 'numpy' is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_685a08bb5cdc832ba44e10c35741fa8e