### PR TITLE
Refactor timestamp parsing

### DIFF
--- a/baseline.py
+++ b/baseline.py
@@ -2,7 +2,6 @@ import numpy as np
 import logging
 import pandas as pd
 from utils import parse_timestamp
-from io_utils import parse_datetime
 
 __all__ = ["rate_histogram", "subtract_baseline"]
 
@@ -55,10 +54,10 @@ def _scaling_factor(dt_window: float, dt_baseline: float,
 def _seconds(col):
     """Return timestamp column as seconds from epoch."""
     ts = col
-    if not pd.api.types.is_datetime64_any_dtype(ts):
-        ts = ts.map(parse_datetime)
-    ts = pd.to_datetime(ts, utc=True)
-    return ts.view("int64").to_numpy() / 1e9
+    if pd.api.types.is_datetime64_any_dtype(ts):
+        return ts.view("int64").to_numpy() / 1e9
+    ts = ts.map(parse_timestamp)
+    return ts.astype(float).to_numpy()
 
 
 def rate_histogram(df, bins):

--- a/io_utils.py
+++ b/io_utils.py
@@ -312,6 +312,7 @@ def load_events(csv_path, *, column_map=None):
 
     # Parse timestamps (epoch seconds) into timezone-aware datetimes
     if "timestamp" in df.columns:
+        df["timestamp"] = df["timestamp"].map(parse_timestamp)
         df["timestamp"] = pd.to_datetime(df["timestamp"], unit="s", utc=True, errors="coerce")
 
     # Check required columns after renaming


### PR DESCRIPTION
## Summary
- load events with `parse_timestamp` before converting to datetime
- simplify `_seconds` to parse timestamps directly
- handle config time parsing uniformly in analysis

## Testing
- `pytest tests/test_adc_drift.py -q` *(fails: ModuleNotFoundError: No module named 'pymc')*

------
https://chatgpt.com/codex/tasks/task_e_685a08bb5cdc832ba44e10c35741fa8e