### PR TITLE
Fix timestamp parsing

### DIFF
--- a/baseline.py
+++ b/baseline.py
@@ -53,11 +53,12 @@ def _scaling_factor(dt_window: float, dt_baseline: float,
 
 def _seconds(col):
     """Return timestamp column as seconds from epoch."""
-    ts = col
-    if not pd.api.types.is_datetime64_any_dtype(ts):
-        ts = ts.map(parse_datetime)
-    ts = pd.to_datetime(ts, utc=True)
-    return ts.view("int64").to_numpy() / 1e9
+    ts = (
+        col.map(parse_timestamp)
+        if not pd.api.types.is_datetime64_any_dtype(col)
+        else col.view("int64") / 1e9
+    )
+    return np.asarray(ts, dtype=float)
 
 
 def rate_histogram(df, bins):

--- a/io_utils.py
+++ b/io_utils.py
@@ -298,7 +298,8 @@ def load_events(csv_path, *, column_map=None):
 
     # Parse timestamps (epoch seconds) into timezone-aware datetimes
     if "timestamp" in df.columns:
-        df["timestamp"] = pd.to_datetime(df["timestamp"], unit="s", utc=True, errors="coerce")
+        df["timestamp"] = df["timestamp"].map(parse_timestamp)
+        df["timestamp"] = pd.to_datetime(df["timestamp"], unit="s", utc=True)
 
     # Check required columns after renaming
     required_cols = ["fUniqueID", "fBits", "timestamp", "adc", "fchannel"]


### PR DESCRIPTION
## Summary
- handle timestamp columns via `parse_timestamp`
- use parsed timestamps for baseline windows and analysis periods
- revise internal seconds helper for baseline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a69ae0a38832b809be7bf40c76f10