### PR TITLE
Fix baseline seconds conversion

### DIFF
--- a/baseline.py
+++ b/baseline.py
@@ -1,7 +1,7 @@
 import numpy as np
 import logging
 import pandas as pd
-from utils import parse_timestamp, parse_datetime
+from utils import parse_timestamp
 
 __all__ = ["rate_histogram", "subtract_baseline"]
 
@@ -54,10 +54,11 @@ def _scaling_factor(dt_window: float, dt_baseline: float,
 def _seconds(col):
     """Return timestamp column as seconds from epoch."""
     ts = col
-    if not pd.api.types.is_datetime64_any_dtype(ts):
-        ts = ts.map(parse_datetime)
-    ts = pd.to_datetime(ts, utc=True)
-    return ts.view("int64").to_numpy() / 1e9
+    if pd.api.types.is_datetime64_any_dtype(ts):
+        return ts.view("int64").to_numpy() / 1e9
+
+    ts = ts.map(parse_timestamp)
+    return ts.to_numpy()
 
 
 def rate_histogram(df, bins):


### PR DESCRIPTION
## Summary
- simplify `_seconds` to map `parse_timestamp` when needed
- drop unused `parse_datetime` import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a69aee88c832b9eca3e29343941a2