### PR TITLE
Update calibration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,26 @@ python utils.py 0.5 --to cpd
 python utils.py 0.5 --to bq --volume_liters 10
 ```
 
+## CalibrationResult Usage
+
+`calibration.CalibrationResult` stores the energy calibration
+parameters.  Use `predict()` to convert ADC values to MeV and
+`uncertainty()` to propagate the 1‑σ error:
+
+```python
+from calibration import CalibrationResult
+
+cal = CalibrationResult(
+    slope=0.001,
+    intercept=0.0,
+    slope_uncertainty=5e-5,
+    intercept_uncertainty=0.1,
+)
+
+energies = cal.predict([1500, 1700])
+sigmas = cal.uncertainty([1500, 1700])
+```
+
 ## Radon Activity Output
 
 After the decay fits a weighted average of the Po‑218 and Po‑214 rates is

--- a/calibration.py
+++ b/calibration.py
@@ -29,6 +29,10 @@ class CalibrationResult:
         """Return calibrated energies for ``adc_values``."""
         return apply_calibration(adc_values, self.slope, self.intercept, quadratic_coeff=self.quadratic)
 
+    def predict(self, adc_values):
+        """Alias for :py:meth:`apply`. Use for scikit-learn style APIs."""
+        return self.apply(adc_values)
+
     def uncertainty(self, adc_values):
         """Return propagated 1-sigma energy uncertainty for ``adc_values``."""
         adc_arr = np.asarray(adc_values, dtype=float)
@@ -100,14 +104,22 @@ def apply_calibration(adc_values, slope, intercept, quadratic_coeff=0.0):
 def calibrate_run(adc_values, config, hist_bins=None):
     """
     Main entry to derive calibration constants for a single run:
-      - Build histogram of ADC values.
-        By default each ADC channel is its own bin.
-        If ``hist_bins`` is provided the range is divided into that
-        many bins instead.
-      - Identify approximate peak locations (Po-210, Po-218, Po-214).
-      - Fit each peak with (EMG or Gaussian) depending on config flags.
-      - Compute two-point linear calibration (using Po-210 & Po-214).
-      - Return a dict with {a, c, sigma_E, peak_centroids_ADC, peak_sigmas_ADC, tau_ADC (if any)}.
+      - Build a histogram of the ADC spectrum. By default each ADC
+        channel forms its own bin. When ``hist_bins`` is given the
+        range is divided into that many bins instead.
+      - Locate the approximate Po-210, Po-218 and Po-214 peaks.
+      - Fit each peak with an EMG or Gaussian depending on the
+        configuration flags.
+      - Compute the two-point calibration using Po-210 and Po-214.
+
+    Returns
+    -------
+    dict
+        Dictionary with calibration results. Keys include ``slope_MeV_per_ch``,
+        ``quadratic_MeV_per_ch2``, ``intercept``, ``sigma_E`` and
+        ``sigma_E_error`` together with the covariance terms
+        ``ac_covariance``, ``a2_variance``, ``cov_a_a2``, ``cov_a2_c`` and the
+        fitted ``peaks`` mapping.
     """
     # 1) Build histogram
     min_adc = int(np.min(adc_values))


### PR DESCRIPTION
## Summary
- document using `CalibrationResult.predict` with example code
- explain calibration result keys in README
- add `CalibrationResult.predict` alias method
- improve `calibrate_run` docstring

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a69dd9eb8832b9600009b29bf43cf