### PR TITLE
Refactor calibration tests to use CalibrationResult

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -74,6 +74,7 @@ from io_utils import (
     apply_burst_filter,
 )
 from calibration import (
+    CalibrationResult,
     derive_calibration_constants,
     derive_calibration_constants_auto,
     apply_calibration,
@@ -1003,14 +1004,27 @@ def main(argv=None):
         cal_params = {"a": (0.005, 0.001), "c": (0.02, 0.005), "sigma_E": (0.3, 0.1)}
 
     # Save “a, c, sigma_E” so we can reconstruct energies
-    a, a_sig = cal_params["a"]
-    a2, a2_sig = cal_params.get("a2", (0.0, 0.0))
-    c, c_sig = cal_params["c"]
-    sigE_mean, sigE_sigma = cal_params["sigma_E"]
-    cov_mat = np.asarray(cal_params.get("ac_covariance", [[0.0, 0.0], [0.0, 0.0]]), dtype=float)
-    cov_ac = float(cov_mat[0, 1])
-    cov_a_a2 = float(cal_params.get("cov_a_a2", 0.0))
-    cov_a2_c = float(cal_params.get("cov_a2_c", 0.0))
+    if isinstance(cal_params, CalibrationResult):
+        a = cal_params.slope
+        a_sig = cal_params.slope_uncertainty
+        a2 = cal_params.quadratic
+        a2_sig = cal_params.quadratic_uncertainty
+        c = cal_params.intercept
+        c_sig = cal_params.intercept_uncertainty
+        sigE_mean = cal_params.sigma_E
+        sigE_sigma = cal_params.sigma_E_uncertainty
+        cov_ac = cal_params.cov_ac
+        cov_a_a2 = cal_params.cov_a_a2
+        cov_a2_c = cal_params.cov_a2_c
+    else:
+        a, a_sig = cal_params["a"]
+        a2, a2_sig = cal_params.get("a2", (0.0, 0.0))
+        c, c_sig = cal_params["c"]
+        sigE_mean, sigE_sigma = cal_params.get("sigma_E", (0.0, 0.0))
+        cov_mat = np.asarray(cal_params.get("ac_covariance", [[0.0, 0.0], [0.0, 0.0]]), dtype=float)
+        cov_ac = float(cov_mat[0, 1])
+        cov_a_a2 = float(cal_params.get("cov_a_a2", 0.0))
+        cov_a2_c = float(cal_params.get("cov_a2_c", 0.0))
 
     # Apply calibration -> new column “energy_MeV” and its uncertainty
     df_analysis["energy_MeV"] = apply_calibration(df_analysis["adc"], a, c, quadratic_coeff=a2)

--- a/tests/test_analyze_noise_cutoff.py
+++ b/tests/test_analyze_noise_cutoff.py
@@ -6,6 +6,7 @@ import pandas as pd
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import numpy as np
+from calibration import CalibrationResult
 from fitting import FitResult
 
 
@@ -38,7 +39,7 @@ def test_analyze_noise_cutoff(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {}}
+    cal_mock = CalibrationResult(slope=1.0, intercept=0.0, sigma_E=1.0, peaks={})
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_analyze_systematics.py
+++ b/tests/test_analyze_systematics.py
@@ -6,6 +6,7 @@ import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from calibration import CalibrationResult
 from fitting import FitResult
 
 
@@ -38,7 +39,7 @@ def test_analyze_systematics_runs(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {}}
+    cal_mock = CalibrationResult(slope=1.0, intercept=0.0, sigma_E=1.0, peaks={})
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -9,6 +9,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
 import baseline
+from calibration import CalibrationResult
 from radon.baseline import subtract_baseline_counts
 from fitting import FitResult
 
@@ -43,7 +44,12 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        slope=1.0,
+        intercept=0.0,
+        sigma_E=1.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     captured = {}
@@ -134,7 +140,12 @@ def test_baseline_scaling_factor(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        slope=1.0,
+        intercept=0.0,
+        sigma_E=1.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({"E_Po214": 1.0}, np.zeros((1,1)), 0))
@@ -216,7 +227,12 @@ def test_n0_prior_from_baseline(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        slope=1.0,
+        intercept=0.0,
+        sigma_E=1.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
 
@@ -300,7 +316,12 @@ def test_isotopes_to_subtract_control(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        slope=1.0,
+        intercept=0.0,
+        sigma_E=1.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({"E_Po214": 1.0}, np.zeros((1,1)), 0))
@@ -380,12 +401,12 @@ def test_baseline_scaling_multiple_isotopes(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {
-        "a": (1.0, 0.0),
-        "c": (0.0, 0.0),
-        "sigma_E": (1.0, 0.0),
-        "peaks": {"Po210": {"centroid_adc": 10}},
-    }
+    cal_mock = CalibrationResult(
+        slope=1.0,
+        intercept=0.0,
+        sigma_E=1.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
 
@@ -494,7 +515,12 @@ def test_noise_level_none_not_recorded(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        slope=1.0,
+        intercept=0.0,
+        sigma_E=1.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({"E_Po214": 1.0}, np.zeros((1,1)), 0))
@@ -559,7 +585,12 @@ def test_sigma_rate_uses_weighted_counts(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        slope=1.0,
+        intercept=0.0,
+        sigma_E=1.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({"E_Po214": 1.0}, np.zeros((1,1)), 0))

--- a/tests/test_baseline_flow.py
+++ b/tests/test_baseline_flow.py
@@ -6,6 +6,7 @@ import pandas as pd
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
+from calibration import CalibrationResult
 
 
 def test_baseline_event_from_unfiltered_data(tmp_path, monkeypatch):
@@ -32,7 +33,12 @@ def test_baseline_event_from_unfiltered_data(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        slope=1.0,
+        intercept=0.0,
+        sigma_E=1.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_baseline_noise_propagation.py
+++ b/tests/test_baseline_noise_propagation.py
@@ -6,6 +6,7 @@ import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from calibration import CalibrationResult
 import baseline_noise
 from fitting import FitResult
 
@@ -40,7 +41,12 @@ def test_baseline_noise_propagation(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        slope=1.0,
+        intercept=0.0,
+        sigma_E=1.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_baseline_range_cli.py
+++ b/tests/test_baseline_range_cli.py
@@ -7,6 +7,7 @@ import numpy as np
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
+from calibration import CalibrationResult
 from fitting import FitResult
 
 
@@ -40,7 +41,12 @@ def test_baseline_range_cli_overrides_config(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        slope=1.0,
+        intercept=0.0,
+        sigma_E=1.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_baseline_range_empty.py
+++ b/tests/test_baseline_range_empty.py
@@ -7,6 +7,7 @@ import numpy as np
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
+from calibration import CalibrationResult
 from fitting import FitResult
 
 
@@ -42,7 +43,12 @@ def test_cli_baseline_range_empty(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        slope=1.0,
+        intercept=0.0,
+        sigma_E=1.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -80,7 +80,7 @@ def test_derive_calibration_constants_peak_search_radius():
     cfg_ok["calibration"]["peak_search_radius"] = 5
 
     out = derive_calibration_constants(adc, cfg_ok)
-    assert set(out["peaks"].keys()) == {"Po210", "Po218", "Po214"}
+    assert set(out.peaks.keys()) == {"Po210", "Po218", "Po214"}
 
     cfg_bad = {"calibration": dict(base_cfg["calibration"])}
     cfg_bad["calibration"]["peak_search_radius"] = 1
@@ -115,11 +115,8 @@ def test_calibration_uses_known_energies_from_config():
 
     out = derive_calibration_constants(adc, cfg)
 
-    a, _ = out["a"]
-    c, _ = out["c"]
-
-    assert pytest.approx(a * 1000 + c, rel=1e-3) == 5.1
-    assert pytest.approx(a * 2000 + c, rel=1e-3) == 8.2
+    assert pytest.approx(out.predict([1000])[0], rel=1e-3) == 5.1
+    assert pytest.approx(out.predict([2000])[0], rel=1e-3) == 8.2
 
 
 def test_calibration_sanity_check_triggers_error():
@@ -177,12 +174,8 @@ def test_calibrate_run_quadratic_option(caplog):
 
     out = derive_calibration_constants(adc, cfg)
 
-    a, _ = out["a"]
-    a2, _ = out["a2"]
-    c, _ = out["c"]
-
     adc_test = np.array([1000, 1500, 2000])
-    energies = apply_calibration(adc_test, a, c, quadratic_coeff=a2)
+    energies = out.predict(adc_test)
     assert np.allclose(
         energies,
         [

--- a/tests/test_cli_baseline_range.py
+++ b/tests/test_cli_baseline_range.py
@@ -7,6 +7,7 @@ import numpy as np
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
+from calibration import CalibrationResult
 from fitting import FitResult
 
 
@@ -42,7 +43,12 @@ def test_cli_baseline_range_overrides_config(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        slope=1.0,
+        intercept=0.0,
+        sigma_E=1.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_cli_baseline_range_iso.py
+++ b/tests/test_cli_baseline_range_iso.py
@@ -7,6 +7,7 @@ import numpy as np
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
+from calibration import CalibrationResult
 from fitting import FitResult
 
 
@@ -42,7 +43,12 @@ def test_cli_baseline_range_iso_strings(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        slope=1.0,
+        intercept=0.0,
+        sigma_E=1.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -153,7 +159,12 @@ def test_cli_baseline_range_timezone(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "write_summary", fake_write)
     monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        slope=1.0,
+        intercept=0.0,
+        sigma_E=1.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_cli_baseline_range_override2.py
+++ b/tests/test_cli_baseline_range_override2.py
@@ -7,6 +7,7 @@ import numpy as np
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
+from calibration import CalibrationResult
 from fitting import FitResult
 
 
@@ -42,7 +43,12 @@ def test_cli_baseline_range_overrides_config_again(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        slope=1.0,
+        intercept=0.0,
+        sigma_E=1.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_cli_metadata.py
+++ b/tests/test_cli_metadata.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from calibration import CalibrationResult
 import numpy as np
 from fitting import FitResult
 
@@ -32,8 +33,9 @@ def test_summary_includes_git_and_cli(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
-    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    cal_mock = CalibrationResult(slope=1.0, intercept=0.0, sigma_E=1.0)
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())

--- a/tests/test_noise_cut.py
+++ b/tests/test_noise_cut.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from calibration import CalibrationResult
 
 
 def test_noise_cutoff_cli_overrides(tmp_path, monkeypatch):
@@ -42,7 +43,7 @@ def test_noise_cutoff_cli_overrides(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {}}
+    cal_mock = CalibrationResult(slope=1.0, intercept=0.0, sigma_E=1.0, peaks={})
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_noise_cutoff.py
+++ b/tests/test_noise_cutoff.py
@@ -6,6 +6,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from calibration import CalibrationResult
 import numpy as np
 from fitting import FitResult
 
@@ -39,7 +40,7 @@ def test_noise_cutoff_filters_events(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {}}
+    cal_mock = CalibrationResult(slope=1.0, intercept=0.0, sigma_E=1.0, peaks={})
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -107,7 +108,7 @@ def test_invalid_noise_cutoff_skips_cut(tmp_path, monkeypatch, caplog):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {}}
+    cal_mock = CalibrationResult(slope=1.0, intercept=0.0, sigma_E=1.0, peaks={})
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_sample_radon.py
+++ b/tests/test_sample_radon.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import radon_activity
 import numpy as np
+from calibration import CalibrationResult
 from fitting import FitResult
 
 
@@ -36,7 +37,12 @@ def test_total_radon_uses_sample_volume(tmp_path, monkeypatch):
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        slope=1.0,
+        intercept=0.0,
+        sigma_E=1.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -9,6 +9,7 @@ from fitting import FitResult
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
+from calibration import CalibrationResult
 
 
 def test_time_window_filters_events(tmp_path, monkeypatch):
@@ -41,12 +42,12 @@ def test_time_window_filters_events(tmp_path, monkeypatch):
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {
-        "a": (1.0, 0.0),
-        "c": (0.0, 0.0),
-        "sigma_E": (1.0, 0.0),
-        "peaks": {"Po210": {"centroid_adc": 10}},
-    }
+    cal_mock = CalibrationResult(
+        slope=1.0,
+        intercept=0.0,
+        sigma_E=1.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -173,12 +174,12 @@ def test_time_window_filters_events_config(tmp_path, monkeypatch):
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {
-        "a": (1.0, 0.0),
-        "c": (0.0, 0.0),
-        "sigma_E": (1.0, 0.0),
-        "peaks": {"Po210": {"centroid_adc": 10}},
-    }
+    cal_mock = CalibrationResult(
+        slope=1.0,
+        intercept=0.0,
+        sigma_E=1.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -252,12 +253,12 @@ def test_run_period_filters_events(tmp_path, monkeypatch):
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {
-        "a": (1.0, 0.0),
-        "c": (0.0, 0.0),
-        "sigma_E": (1.0, 0.0),
-        "peaks": {"Po210": {"centroid_adc": 10}},
-    }
+    cal_mock = CalibrationResult(
+        slope=1.0,
+        intercept=0.0,
+        sigma_E=1.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -339,12 +340,12 @@ def test_baseline_range_iso_strings(tmp_path, monkeypatch, start, end):
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {
-        "a": (1.0, 0.0),
-        "c": (0.0, 0.0),
-        "sigma_E": (1.0, 0.0),
-        "peaks": {"Po210": {"centroid_adc": 10}},
-    }
+    cal_mock = CalibrationResult(
+        slope=1.0,
+        intercept=0.0,
+        sigma_E=1.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)


### PR DESCRIPTION
## Summary
- extend `CalibrationResult` with additional fields and predict() alias
- return `CalibrationResult` from calibration routines
- update `analyze` to handle `CalibrationResult`
- modernize many tests to patch with `CalibrationResult`

## Testing
- `pip install numpy`
- `pip install scipy`
- `pip install matplotlib`
- `pip install pandas`
- `pip install iminuit`
- `pytest -q` *(fails: 37 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685a69ded08c832b92e56bebce6b7936