### PR TITLE
Handle timestamps as datetimes

### DIFF
--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 import pandas as pd
 import numpy as np
+from datetime import datetime, timezone
 import logging
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -2065,12 +2066,22 @@ def test_time_fields_written_back(tmp_path, monkeypatch):
     analyze.main()
 
     used = captured.get("cfg", {})
-    assert used["analysis"]["analysis_end_time"] == 5.0
-    assert used["analysis"]["spike_end_time"] == 0.0
-    assert used["analysis"]["spike_periods"] == [[2.0, 3.0]]
-    assert used["analysis"]["run_periods"] == [[0.0, 10.0]]
-    assert used["analysis"]["radon_interval"] == [3.0, 5.0]
-    assert used["baseline"]["range"] == [0.0, 1.0]
+    assert used["analysis"]["analysis_end_time"] == datetime.fromtimestamp(5, tz=timezone.utc)
+    assert used["analysis"]["spike_end_time"] == datetime.fromtimestamp(0, tz=timezone.utc)
+    assert used["analysis"]["spike_periods"] == [
+        [datetime.fromtimestamp(2, tz=timezone.utc), datetime.fromtimestamp(3, tz=timezone.utc)]
+    ]
+    assert used["analysis"]["run_periods"] == [
+        [datetime.fromtimestamp(0, tz=timezone.utc), datetime.fromtimestamp(10, tz=timezone.utc)]
+    ]
+    assert used["analysis"]["radon_interval"] == [
+        datetime.fromtimestamp(3, tz=timezone.utc),
+        datetime.fromtimestamp(5, tz=timezone.utc),
+    ]
+    assert used["baseline"]["range"] == [
+        datetime.fromtimestamp(0, tz=timezone.utc),
+        datetime.fromtimestamp(1, tz=timezone.utc),
+    ]
 
 
 

--- a/tests/test_baseline_range_empty.py
+++ b/tests/test_baseline_range_empty.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 import pandas as pd
 import numpy as np
+from datetime import datetime, timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
@@ -89,8 +90,11 @@ def test_cli_baseline_range_empty(tmp_path, monkeypatch):
     analyze.main()
 
     summary = captured.get("summary", {})
-    assert summary.get("baseline", {}).get("start") == 10.0
-    assert summary.get("baseline", {}).get("end") == 20.0
+    assert summary.get("baseline", {}).get("start") == datetime.fromtimestamp(10, tz=timezone.utc)
+    assert summary.get("baseline", {}).get("end") == datetime.fromtimestamp(20, tz=timezone.utc)
     assert summary.get("baseline", {}).get("n_events") == 0
     assert summary.get("baseline", {}).get("live_time") == 0.0
-    assert captured.get("cfg", {}).get("baseline", {}).get("range") == [10.0, 20.0]
+    assert captured.get("cfg", {}).get("baseline", {}).get("range") == [
+        datetime.fromtimestamp(10, tz=timezone.utc),
+        datetime.fromtimestamp(20, tz=timezone.utc),
+    ]

--- a/tests/test_cli_baseline_range.py
+++ b/tests/test_cli_baseline_range.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 import pandas as pd
 import numpy as np
+from datetime import datetime, timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
@@ -89,7 +90,10 @@ def test_cli_baseline_range_overrides_config(tmp_path, monkeypatch):
     analyze.main()
 
     summary = captured.get("summary", {})
-    assert summary.get("baseline", {}).get("start") == 1.0
-    assert summary.get("baseline", {}).get("end") == 2.0
+    assert summary.get("baseline", {}).get("start") == datetime.fromtimestamp(1, tz=timezone.utc)
+    assert summary.get("baseline", {}).get("end") == datetime.fromtimestamp(2, tz=timezone.utc)
     assert summary.get("baseline", {}).get("n_events") == 1
-    assert captured.get("cfg", {}).get("baseline", {}).get("range") == [1.0, 2.0]
+    assert captured.get("cfg", {}).get("baseline", {}).get("range") == [
+        datetime.fromtimestamp(1, tz=timezone.utc),
+        datetime.fromtimestamp(2, tz=timezone.utc),
+    ]

--- a/tests/test_cli_baseline_range_iso.py
+++ b/tests/test_cli_baseline_range_iso.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 import pandas as pd
 import numpy as np
+from datetime import datetime, timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
@@ -89,10 +90,13 @@ def test_cli_baseline_range_iso_strings(tmp_path, monkeypatch):
     analyze.main()
 
     summary = captured.get("summary", {})
-    assert summary.get("baseline", {}).get("start") == 1.0
-    assert summary.get("baseline", {}).get("end") == 2.0
+    assert summary.get("baseline", {}).get("start") == datetime.fromtimestamp(1, tz=timezone.utc)
+    assert summary.get("baseline", {}).get("end") == datetime.fromtimestamp(2, tz=timezone.utc)
     assert summary.get("baseline", {}).get("n_events") == 1
-    assert captured.get("cfg", {}).get("baseline", {}).get("range") == [1.0, 2.0]
+    assert captured.get("cfg", {}).get("baseline", {}).get("range") == [
+        datetime.fromtimestamp(1, tz=timezone.utc),
+        datetime.fromtimestamp(2, tz=timezone.utc),
+    ]
 
 
 def test_cli_baseline_range_timezone(tmp_path, monkeypatch):
@@ -176,7 +180,10 @@ def test_cli_baseline_range_timezone(tmp_path, monkeypatch):
     ])
     analyze.main()
     summary = captured.get("summary", {})
-    assert summary.get("baseline", {}).get("start") == 1.0
-    assert summary.get("baseline", {}).get("end") == 2.0
+    assert summary.get("baseline", {}).get("start") == datetime.fromtimestamp(1, tz=timezone.utc)
+    assert summary.get("baseline", {}).get("end") == datetime.fromtimestamp(2, tz=timezone.utc)
     assert summary.get("baseline", {}).get("n_events") == 1
-    assert captured.get("cfg", {}).get("baseline", {}).get("range") == [1.0, 2.0]
+    assert captured.get("cfg", {}).get("baseline", {}).get("range") == [
+        datetime.fromtimestamp(1, tz=timezone.utc),
+        datetime.fromtimestamp(2, tz=timezone.utc),
+    ]

--- a/tests/test_cli_baseline_range_override2.py
+++ b/tests/test_cli_baseline_range_override2.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 import pandas as pd
 import numpy as np
+from datetime import datetime, timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
@@ -89,7 +90,10 @@ def test_cli_baseline_range_overrides_config_again(tmp_path, monkeypatch):
     analyze.main()
 
     summary = captured.get("summary", {})
-    assert summary.get("baseline", {}).get("start") == 2.0
-    assert summary.get("baseline", {}).get("end") == 3.0
+    assert summary.get("baseline", {}).get("start") == datetime.fromtimestamp(2, tz=timezone.utc)
+    assert summary.get("baseline", {}).get("end") == datetime.fromtimestamp(3, tz=timezone.utc)
     assert summary.get("baseline", {}).get("n_events") == 1
-    assert captured.get("cfg", {}).get("baseline", {}).get("range") == [2.0, 3.0]
+    assert captured.get("cfg", {}).get("baseline", {}).get("range") == [
+        datetime.fromtimestamp(2, tz=timezone.utc),
+        datetime.fromtimestamp(3, tz=timezone.utc),
+    ]


### PR DESCRIPTION
## Summary
- add `to_utc_datetime` helper
- convert datetimes to ISO strings in `to_native`
- use datetime objects when reading CLI/config times
- adjust baseline range tests for datetime

## Testing
- `pytest -q` *(fails: numpy missing)*

------
https://chatgpt.com/codex/tasks/task_e_685a6ad8cf9c832bb66cd0bc556cb898