### PR TITLE
Add datetime parsing tests and unify time filters

### DIFF
--- a/tests/test_baseline_range_cli.py
+++ b/tests/test_baseline_range_cli.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 import pandas as pd
 import numpy as np
+from datetime import datetime, timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
@@ -87,7 +88,9 @@ def test_baseline_range_cli_overrides_config(tmp_path, monkeypatch):
     analyze.main()
 
     summary = captured.get("summary", {})
-    assert summary["baseline"]["start"] == 10.0
-    assert summary["baseline"]["end"] == 20.0
+    exp_start = datetime(1970, 1, 1, 0, 0, 10, tzinfo=timezone.utc)
+    exp_end = datetime(1970, 1, 1, 0, 0, 20, tzinfo=timezone.utc)
+    assert summary["baseline"]["start"] == exp_start
+    assert summary["baseline"]["end"] == exp_end
     assert summary["baseline"]["n_events"] == 1
     assert captured.get("cfg", {}).get("baseline", {}).get("range") == [10.0, 20.0]

--- a/tests/test_baseline_range_empty.py
+++ b/tests/test_baseline_range_empty.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 import pandas as pd
 import numpy as np
+from datetime import datetime, timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
@@ -89,8 +90,10 @@ def test_cli_baseline_range_empty(tmp_path, monkeypatch):
     analyze.main()
 
     summary = captured.get("summary", {})
-    assert summary.get("baseline", {}).get("start") == 10.0
-    assert summary.get("baseline", {}).get("end") == 20.0
+    exp_start = datetime(1970, 1, 1, 0, 0, 10, tzinfo=timezone.utc)
+    exp_end = datetime(1970, 1, 1, 0, 0, 20, tzinfo=timezone.utc)
+    assert summary.get("baseline", {}).get("start") == exp_start
+    assert summary.get("baseline", {}).get("end") == exp_end
     assert summary.get("baseline", {}).get("n_events") == 0
     assert summary.get("baseline", {}).get("live_time") == 0.0
     assert captured.get("cfg", {}).get("baseline", {}).get("range") == [10.0, 20.0]

--- a/tests/test_cli_baseline_range.py
+++ b/tests/test_cli_baseline_range.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 import pandas as pd
 import numpy as np
+from datetime import datetime, timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
@@ -89,7 +90,9 @@ def test_cli_baseline_range_overrides_config(tmp_path, monkeypatch):
     analyze.main()
 
     summary = captured.get("summary", {})
-    assert summary.get("baseline", {}).get("start") == 1.0
-    assert summary.get("baseline", {}).get("end") == 2.0
+    exp_start = datetime(1970, 1, 1, 0, 0, 1, tzinfo=timezone.utc)
+    exp_end = datetime(1970, 1, 1, 0, 0, 2, tzinfo=timezone.utc)
+    assert summary.get("baseline", {}).get("start") == exp_start
+    assert summary.get("baseline", {}).get("end") == exp_end
     assert summary.get("baseline", {}).get("n_events") == 1
     assert captured.get("cfg", {}).get("baseline", {}).get("range") == [1.0, 2.0]

--- a/tests/test_cli_baseline_range_iso.py
+++ b/tests/test_cli_baseline_range_iso.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 import pandas as pd
 import numpy as np
+from datetime import datetime, timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
@@ -89,8 +90,10 @@ def test_cli_baseline_range_iso_strings(tmp_path, monkeypatch):
     analyze.main()
 
     summary = captured.get("summary", {})
-    assert summary.get("baseline", {}).get("start") == 1.0
-    assert summary.get("baseline", {}).get("end") == 2.0
+    exp_start = datetime(1970, 1, 1, 0, 0, 1, tzinfo=timezone.utc)
+    exp_end = datetime(1970, 1, 1, 0, 0, 2, tzinfo=timezone.utc)
+    assert summary.get("baseline", {}).get("start") == exp_start
+    assert summary.get("baseline", {}).get("end") == exp_end
     assert summary.get("baseline", {}).get("n_events") == 1
     assert captured.get("cfg", {}).get("baseline", {}).get("range") == [1.0, 2.0]
 
@@ -176,7 +179,9 @@ def test_cli_baseline_range_timezone(tmp_path, monkeypatch):
     ])
     analyze.main()
     summary = captured.get("summary", {})
-    assert summary.get("baseline", {}).get("start") == 1.0
-    assert summary.get("baseline", {}).get("end") == 2.0
+    exp_start = datetime(1970, 1, 1, 0, 0, 1, tzinfo=timezone.utc)
+    exp_end = datetime(1970, 1, 1, 0, 0, 2, tzinfo=timezone.utc)
+    assert summary.get("baseline", {}).get("start") == exp_start
+    assert summary.get("baseline", {}).get("end") == exp_end
     assert summary.get("baseline", {}).get("n_events") == 1
     assert captured.get("cfg", {}).get("baseline", {}).get("range") == [1.0, 2.0]

--- a/tests/test_cli_baseline_range_override2.py
+++ b/tests/test_cli_baseline_range_override2.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 import pandas as pd
 import numpy as np
+from datetime import datetime, timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
@@ -89,7 +90,9 @@ def test_cli_baseline_range_overrides_config_again(tmp_path, monkeypatch):
     analyze.main()
 
     summary = captured.get("summary", {})
-    assert summary.get("baseline", {}).get("start") == 2.0
-    assert summary.get("baseline", {}).get("end") == 3.0
+    exp_start = datetime(1970, 1, 1, 0, 0, 2, tzinfo=timezone.utc)
+    exp_end = datetime(1970, 1, 1, 0, 0, 3, tzinfo=timezone.utc)
+    assert summary.get("baseline", {}).get("start") == exp_start
+    assert summary.get("baseline", {}).get("end") == exp_end
     assert summary.get("baseline", {}).get("n_events") == 1
     assert captured.get("cfg", {}).get("baseline", {}).get("range") == [2.0, 3.0]

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -4,9 +4,9 @@ from pathlib import Path
 import pandas as pd
 import pytest
 import numpy as np
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from fitting import FitResult
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
 
@@ -386,3 +386,77 @@ def test_baseline_range_iso_strings(tmp_path, monkeypatch, start, end):
     assert summary["baseline"]["n_events"] == 2
     assert captured.get("times") == [2.0, 6.0]
 
+
+
+def test_unified_filter_combined_windows(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "baseline": {"range": ["1970-01-01T00:00:00Z", "1970-01-01T00:00:01Z"], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "analysis": {
+            "run_periods": [["1970-01-01T00:00:01Z", "1970-01-01T00:00:04Z"]],
+            "spike_periods": [["1970-01-01T00:00:02Z", "1970-01-01T00:00:02.5Z"]],
+        },
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": True,
+            "window_po214": [0, 10],
+            "hl_po214": [1.0, 0.0],
+            "eff_po214": [1.0, 0.0],
+            "flags": {},
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1, 2, 3, 4, 5, 6],
+        "fBits": [0, 0, 0, 0, 0, 0],
+        "timestamp": [0.0, 1.0, 2.0, 2.2, 3.0, 5.0],
+        "adc": [8.0]*6,
+        "fchannel": [1]*6,
+    })
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(baseline_noise, "estimate_baseline_noise", lambda *a, **k: (5.0, {}))
+
+    captured = {}
+
+    def fake_fit(ts_dict, t_start, t_end, cfg, **kwargs):
+        captured["times"] = ts_dict.get("Po214", []).tolist()
+        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
+
+    monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
+
+    def fake_write(out_dir, summary, timestamp=None):
+        captured["summary"] = summary
+        d = Path(out_dir) / (timestamp or "x")
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config", str(cfg_path),
+        "--input", str(data_path),
+        "--output_dir", str(tmp_path),
+        "--analysis-end-time", "1970-01-01T00:00:04Z",
+        "--spike-end-time", "1970-01-01T00:00:00.5Z",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert captured.get("times") == [1.0, 3.0]


### PR DESCRIPTION
## Summary
- store baseline interval datetimes directly and parse radon interval to datetimes
- add regression tests for CLI/config interval parsing
- update baseline range tests for new datetime outputs
- ensure time window filtering works with combined intervals

## Testing
- `pytest -q tests/test_interval_parsing.py`
- `pytest -q tests/test_cli_baseline_range.py::test_cli_baseline_range_overrides_config`
- `pytest -q tests/test_cli_baseline_range_iso.py::test_cli_baseline_range_iso_strings tests/test_cli_baseline_range_iso.py::test_cli_baseline_range_timezone`
- `pytest -q tests/test_baseline_range_cli.py::test_baseline_range_cli_overrides_config`
- `pytest -q tests/test_baseline_range_empty.py::test_cli_baseline_range_empty`
- `pytest -q tests/test_cli_baseline_range_override2.py::test_cli_baseline_range_overrides_config_again`
- `pytest -q tests/test_time_window.py::test_unified_filter_combined_windows`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a6adac6d0832ba7df44ac75a78cba