### PR TITLE
Update README timestamp note

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository provides a complete pipeline to analyze electrostatic radon monitor data.
 
-**Note:** All time quantities are expressed in seconds and all energies are given in MeV throughout the documentation and code. Input timestamps are parsed with `parse_timestamp` which accepts ISO‑8601 strings (with or without timezone), numeric epoch seconds and `datetime` objects and converts them to Unix seconds. The wrapper `parse_datetime` converts the parsed value to a UTC `numpy.datetime64`. These helpers are available from `utils.py`. Command-line options that take timestamps (such as `--analysis-start-time`) use them so both ISO‑8601 strings and Unix seconds work interchangeably. A global `--timezone` option controls which zone naïve times are interpreted in (default: `UTC`). Event timestamps are stored internally as UTC `numpy.datetime64` objects throughout the pipeline.
+**Note:** All time quantities are expressed in seconds and all energies are given in MeV throughout the documentation and code. Input timestamps are converted with `to_utc_datetime` which accepts ISO‑8601 strings (with or without timezone), numeric epoch seconds and `datetime` objects and returns a timezone‑aware `numpy.datetime64` in UTC. The function is available from `utils.py` and is used throughout the command-line interface so both ISO‑8601 strings and Unix seconds work interchangeably. A global `--timezone` option controls which zone naïve times are interpreted in (default: `UTC`). Event timestamps remain timezone‑aware `datetime64` objects inside the pipeline; epoch seconds are produced only for numeric computations such as histogramming or fits.
 
 ## Structure
 


### PR DESCRIPTION
## Summary
- document `to_utc_datetime` as the standard way to parse timestamps
- clarify that timestamps stay timezone-aware `datetime64`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a6adb8b8c832bb7be56bf55871ad8