### PR TITLE
Handle baseline range as datetime

### DIFF
--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -2070,7 +2070,10 @@ def test_time_fields_written_back(tmp_path, monkeypatch):
     assert used["analysis"]["spike_periods"] == [[2.0, 3.0]]
     assert used["analysis"]["run_periods"] == [[0.0, 10.0]]
     assert used["analysis"]["radon_interval"] == [3.0, 5.0]
-    assert used["baseline"]["range"] == [0.0, 1.0]
+    assert used["baseline"]["range"] == [
+        "1970-01-01T00:00:00+00:00",
+        "1970-01-01T00:00:01+00:00",
+    ]
 
 
 

--- a/tests/test_baseline_range_cli.py
+++ b/tests/test_baseline_range_cli.py
@@ -93,4 +93,7 @@ def test_baseline_range_cli_overrides_config(tmp_path, monkeypatch):
     assert summary["baseline"]["start"] == exp_start
     assert summary["baseline"]["end"] == exp_end
     assert summary["baseline"]["n_events"] == 1
-    assert captured.get("cfg", {}).get("baseline", {}).get("range") == [10.0, 20.0]
+    assert captured.get("cfg", {}).get("baseline", {}).get("range") == [
+        "1970-01-01T00:00:10+00:00",
+        "1970-01-01T00:00:20+00:00",
+    ]

--- a/tests/test_baseline_range_empty.py
+++ b/tests/test_baseline_range_empty.py
@@ -96,4 +96,7 @@ def test_cli_baseline_range_empty(tmp_path, monkeypatch):
     assert summary.get("baseline", {}).get("end") == exp_end
     assert summary.get("baseline", {}).get("n_events") == 0
     assert summary.get("baseline", {}).get("live_time") == 0.0
-    assert captured.get("cfg", {}).get("baseline", {}).get("range") == [10.0, 20.0]
+    assert captured.get("cfg", {}).get("baseline", {}).get("range") == [
+        "1970-01-01T00:00:10+00:00",
+        "1970-01-01T00:00:20+00:00",
+    ]

--- a/tests/test_cli_baseline_range.py
+++ b/tests/test_cli_baseline_range.py
@@ -95,4 +95,7 @@ def test_cli_baseline_range_overrides_config(tmp_path, monkeypatch):
     assert summary.get("baseline", {}).get("start") == exp_start
     assert summary.get("baseline", {}).get("end") == exp_end
     assert summary.get("baseline", {}).get("n_events") == 1
-    assert captured.get("cfg", {}).get("baseline", {}).get("range") == [1.0, 2.0]
+    assert captured.get("cfg", {}).get("baseline", {}).get("range") == [
+        "1970-01-01T00:00:01+00:00",
+        "1970-01-01T00:00:02+00:00",
+    ]

--- a/tests/test_cli_baseline_range_iso.py
+++ b/tests/test_cli_baseline_range_iso.py
@@ -95,7 +95,10 @@ def test_cli_baseline_range_iso_strings(tmp_path, monkeypatch):
     assert summary.get("baseline", {}).get("start") == exp_start
     assert summary.get("baseline", {}).get("end") == exp_end
     assert summary.get("baseline", {}).get("n_events") == 1
-    assert captured.get("cfg", {}).get("baseline", {}).get("range") == [1.0, 2.0]
+    assert captured.get("cfg", {}).get("baseline", {}).get("range") == [
+        "1970-01-01T00:00:01+00:00",
+        "1970-01-01T00:00:02+00:00",
+    ]
 
 
 def test_cli_baseline_range_timezone(tmp_path, monkeypatch):
@@ -184,4 +187,7 @@ def test_cli_baseline_range_timezone(tmp_path, monkeypatch):
     assert summary.get("baseline", {}).get("start") == exp_start
     assert summary.get("baseline", {}).get("end") == exp_end
     assert summary.get("baseline", {}).get("n_events") == 1
-    assert captured.get("cfg", {}).get("baseline", {}).get("range") == [1.0, 2.0]
+    assert captured.get("cfg", {}).get("baseline", {}).get("range") == [
+        "1970-01-01T00:00:01+00:00",
+        "1970-01-01T00:00:02+00:00",
+    ]

--- a/tests/test_cli_baseline_range_override2.py
+++ b/tests/test_cli_baseline_range_override2.py
@@ -95,4 +95,7 @@ def test_cli_baseline_range_overrides_config_again(tmp_path, monkeypatch):
     assert summary.get("baseline", {}).get("start") == exp_start
     assert summary.get("baseline", {}).get("end") == exp_end
     assert summary.get("baseline", {}).get("n_events") == 1
-    assert captured.get("cfg", {}).get("baseline", {}).get("range") == [2.0, 3.0]
+    assert captured.get("cfg", {}).get("baseline", {}).get("range") == [
+        "1970-01-01T00:00:02+00:00",
+        "1970-01-01T00:00:03+00:00",
+    ]


### PR DESCRIPTION
## Summary
- keep `baseline_range` as datetimes when loaded from CLI or config
- convert baseline range from config using `parse_datetime`
- store ISO strings in output config
- update tests for new baseline range format

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a70f723a0832bafa2712c10e80370