### PR TITLE
Store radon_interval as datetimes

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -991,14 +991,14 @@ def main(argv=None):
     if radon_interval_cfg:
         try:
             start_r, end_r = radon_interval_cfg
-            start_r_dt = pd.to_datetime(parse_datetime(start_r), utc=True)
-            end_r_dt = pd.to_datetime(parse_datetime(end_r), utc=True)
+            start_r_dt = pd.to_datetime(parse_datetime(start_r), utc=True).to_pydatetime()
+            end_r_dt = pd.to_datetime(parse_datetime(end_r), utc=True).to_pydatetime()
             if end_r_dt <= start_r_dt:
                 raise ValueError("end <= start")
             radon_interval = (start_r_dt, end_r_dt)
             cfg.setdefault("analysis", {})["radon_interval"] = [
-                parse_timestamp(start_r_dt),
-                parse_timestamp(end_r_dt),
+                start_r_dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                end_r_dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
             ]
         except Exception as e:
             logging.warning(f"Invalid radon_interval {radon_interval_cfg} -> {e}")

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -2069,7 +2069,10 @@ def test_time_fields_written_back(tmp_path, monkeypatch):
     assert used["analysis"]["spike_end_time"] == 0.0
     assert used["analysis"]["spike_periods"] == [[2.0, 3.0]]
     assert used["analysis"]["run_periods"] == [[0.0, 10.0]]
-    assert used["analysis"]["radon_interval"] == [3.0, 5.0]
+    assert used["analysis"]["radon_interval"] == [
+        "1970-01-01T00:00:03Z",
+        "1970-01-01T00:00:05Z",
+    ]
     assert used["baseline"]["range"] == [0.0, 1.0]
 
 


### PR DESCRIPTION
## Summary
- keep `radon_interval` as a tuple of UTC datetimes in `analyze.py`
- only serialize `radon_interval` to ISO timestamps when updating the config
- update config-merge test to match new timestamp format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a70f74ed0832bbadbb269dde21a7a