### PR TITLE
Update tests for CalibrationResult

### DIFF
--- a/tests/test_adc_drift.py
+++ b/tests/test_adc_drift.py
@@ -52,7 +52,7 @@ def test_adc_drift_applied(tmp_path, monkeypatch):
 
     def fake_cal(adc_vals, config=None):
         captured["cal_adc"] = np.array(adc_vals)
-        return {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)}
+        return CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0)
 
     monkeypatch.setattr(analyze, "apply_linear_adc_shift", fake_shift)
     monkeypatch.setattr(analyze, "derive_calibration_constants", fake_cal)
@@ -100,7 +100,7 @@ def test_adc_drift_zero_noop(tmp_path, monkeypatch):
 
     def fake_cal(adc_vals, config=None):
         captured["cal_adc"] = np.array(adc_vals)
-        return {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)}
+        return CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0)
 
     monkeypatch.setattr(analyze, "apply_linear_adc_shift", fake_shift)
     monkeypatch.setattr(analyze, "derive_calibration_constants", fake_cal)
@@ -151,12 +151,12 @@ def test_adc_drift_quadratic_cfg(tmp_path, monkeypatch):
     monkeypatch.setattr(
         analyze,
         "derive_calibration_constants",
-        lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)},
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
     )
     monkeypatch.setattr(
         analyze,
         "derive_calibration_constants_auto",
-        lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)},
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
     )
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -198,12 +198,12 @@ def test_adc_drift_piecewise_cfg(tmp_path, monkeypatch):
     monkeypatch.setattr(
         analyze,
         "derive_calibration_constants",
-        lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)},
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
     )
     monkeypatch.setattr(
         analyze,
         "derive_calibration_constants_auto",
-        lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)},
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
     )
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -234,7 +234,7 @@ def test_adc_drift_warning_on_failure(tmp_path, monkeypatch, capsys):
         raise ValueError("boom")
 
     def fake_cal(adc_vals, config=None):
-        return {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)}
+        return CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0)
 
     monkeypatch.setattr(analyze, "apply_linear_adc_shift", bad_shift)
     monkeypatch.setattr(analyze, "derive_calibration_constants", fake_cal)

--- a/tests/test_analyze_noise_cutoff.py
+++ b/tests/test_analyze_noise_cutoff.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from calibration import CalibrationResult
 import numpy as np
 from fitting import FitResult
 
@@ -38,7 +39,13 @@ def test_analyze_noise_cutoff(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {}}
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_analyze_systematics.py
+++ b/tests/test_analyze_systematics.py
@@ -38,7 +38,13 @@ def test_analyze_systematics_runs(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {}}
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -43,7 +43,13 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     captured = {}
@@ -134,7 +140,13 @@ def test_baseline_scaling_factor(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({"E_Po214": 1.0}, np.zeros((1,1)), 0))
@@ -216,7 +228,13 @@ def test_n0_prior_from_baseline(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
 
@@ -300,7 +318,13 @@ def test_isotopes_to_subtract_control(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({"E_Po214": 1.0}, np.zeros((1,1)), 0))
@@ -380,12 +404,13 @@ def test_baseline_scaling_multiple_isotopes(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {
-        "a": (1.0, 0.0),
-        "c": (0.0, 0.0),
-        "sigma_E": (1.0, 0.0),
-        "peaks": {"Po210": {"centroid_adc": 10}},
-    }
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
 
@@ -494,7 +519,13 @@ def test_noise_level_none_not_recorded(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({"E_Po214": 1.0}, np.zeros((1,1)), 0))
@@ -559,7 +590,13 @@ def test_sigma_rate_uses_weighted_counts(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({"E_Po214": 1.0}, np.zeros((1,1)), 0))

--- a/tests/test_baseline_flow.py
+++ b/tests/test_baseline_flow.py
@@ -2,9 +2,11 @@ import json
 import sys
 from pathlib import Path
 import pandas as pd
+import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from calibration import CalibrationResult
 import baseline_noise
 
 
@@ -32,7 +34,13 @@ def test_baseline_event_from_unfiltered_data(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_baseline_noise_propagation.py
+++ b/tests/test_baseline_noise_propagation.py
@@ -6,6 +6,7 @@ import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from calibration import CalibrationResult
 import baseline_noise
 from fitting import FitResult
 
@@ -40,7 +41,13 @@ def test_baseline_noise_propagation(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_baseline_range_cli.py
+++ b/tests/test_baseline_range_cli.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from calibration import CalibrationResult
 import baseline_noise
 from fitting import FitResult
 
@@ -41,7 +42,13 @@ def test_baseline_range_cli_overrides_config(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_baseline_range_empty.py
+++ b/tests/test_baseline_range_empty.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from calibration import CalibrationResult
 import baseline_noise
 from fitting import FitResult
 
@@ -43,7 +44,13 @@ def test_cli_baseline_range_empty(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_blue_weights.py
+++ b/tests/test_blue_weights.py
@@ -6,6 +6,7 @@ import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from calibration import CalibrationResult
 from fitting import FitResult
 
 
@@ -32,8 +33,16 @@ def test_blue_weights_summary(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
-    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants",
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
+    )
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants_auto",
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
+    )
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0, 0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())

--- a/tests/test_cli_baseline_range.py
+++ b/tests/test_cli_baseline_range.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from calibration import CalibrationResult
 import baseline_noise
 from fitting import FitResult
 
@@ -43,7 +44,13 @@ def test_cli_baseline_range_overrides_config(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_cli_baseline_range_iso.py
+++ b/tests/test_cli_baseline_range_iso.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from calibration import CalibrationResult
 import baseline_noise
 from fitting import FitResult
 
@@ -43,7 +44,13 @@ def test_cli_baseline_range_iso_strings(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -156,7 +163,13 @@ def test_cli_baseline_range_timezone(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "write_summary", fake_write)
     monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_cli_baseline_range_override2.py
+++ b/tests/test_cli_baseline_range_override2.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from calibration import CalibrationResult
 import baseline_noise
 from fitting import FitResult
 
@@ -43,7 +44,13 @@ def test_cli_baseline_range_overrides_config_again(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_cli_metadata.py
+++ b/tests/test_cli_metadata.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from calibration import CalibrationResult
 import numpy as np
 from fitting import FitResult
 
@@ -32,8 +33,16 @@ def test_summary_includes_git_and_cli(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
-    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants",
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
+    )
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants_auto",
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
+    )
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())

--- a/tests/test_empty_after_filters.py
+++ b/tests/test_empty_after_filters.py
@@ -2,10 +2,12 @@ import json
 import sys
 from pathlib import Path
 import pandas as pd
+import numpy as np
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from calibration import CalibrationResult
 
 
 def test_exit_when_noise_cut_removes_all(tmp_path, monkeypatch):
@@ -33,8 +35,16 @@ def test_exit_when_noise_cut_removes_all(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
-    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants",
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
+    )
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants_auto",
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
+    )
     monkeypatch.setattr(analyze, "apply_burst_filter", lambda df, cfg, mode="rate": (df, 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k.get("out_png", "x")).touch())

--- a/tests/test_expected_peaks_default.py
+++ b/tests/test_expected_peaks_default.py
@@ -8,6 +8,7 @@ import numpy as np
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import analyze
+from calibration import CalibrationResult
 from constants import DEFAULT_ADC_CENTROIDS
 from io_utils import load_config
 from fitting import FitResult
@@ -50,12 +51,12 @@ def test_expected_peaks_default(tmp_path, monkeypatch):
     monkeypatch.setattr(
         analyze,
         "derive_calibration_constants",
-        lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)},
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
     )
     monkeypatch.setattr(
         analyze,
         "derive_calibration_constants_auto",
-        lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)},
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
     )
     monkeypatch.setattr(analyze, "fit_spectrum", lambda *a, **k: FitResult({}, np.zeros((0, 0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_hierarchical_summary.py
+++ b/tests/test_hierarchical_summary.py
@@ -3,9 +3,11 @@ import sys
 from pathlib import Path
 
 import pandas as pd
+import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from calibration import CalibrationResult
 from fitting import FitResult
 
 
@@ -43,8 +45,16 @@ def test_hierarchical_summary(tmp_path, monkeypatch):
                 "calibration": {"a": [1.0, 0.1], "c": [0.0, 0.1]},
             }, f)
 
-    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
-    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0)})
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants",
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
+    )
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants_auto",
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
+    )
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, None, 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())

--- a/tests/test_job_id_duplicate.py
+++ b/tests/test_job_id_duplicate.py
@@ -10,6 +10,7 @@ import numpy as np
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import analyze
+from calibration import CalibrationResult
 from fitting import FitResult
 
 
@@ -37,8 +38,16 @@ def test_duplicate_job_id_raises(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
-    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants",
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
+    )
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants_auto",
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
+    )
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0, 0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
@@ -95,8 +104,16 @@ def test_job_id_overwrite_allows_rerun(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
-    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants",
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
+    )
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants_auto",
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
+    )
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0, 0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())

--- a/tests/test_linear_background.py
+++ b/tests/test_linear_background.py
@@ -10,6 +10,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from background import estimate_linear_background
 import analyze
+from calibration import CalibrationResult
 from fitting import FitResult
 
 
@@ -91,8 +92,16 @@ def test_auto_background_priors(monkeypatch, tmp_path):
         return FitResult({}, np.zeros((0, 0)), 0)
 
     monkeypatch.setattr(analyze, "fit_spectrum", fake_fit_spectrum)
-    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (0.001, 0.0), "c": (0.0, 0.0), "sigma_E": (0.05, 0.01)})
-    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (0.001, 0.0), "c": (0.0, 0.0), "sigma_E": (0.05, 0.01)})
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants",
+        lambda *a, **k: CalibrationResult([0.0, 0.001], np.zeros((2, 2)), sigma_E=0.05),
+    )
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants_auto",
+        lambda *a, **k: CalibrationResult([0.0, 0.001], np.zeros((2, 2)), sigma_E=0.05),
+    )
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: None)

--- a/tests/test_noise_cut.py
+++ b/tests/test_noise_cut.py
@@ -2,9 +2,11 @@ import json
 import sys
 from pathlib import Path
 import pandas as pd
+import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from calibration import CalibrationResult
 
 
 def test_noise_cutoff_cli_overrides(tmp_path, monkeypatch):
@@ -42,7 +44,13 @@ def test_noise_cutoff_cli_overrides(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {}}
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_noise_cutoff.py
+++ b/tests/test_noise_cutoff.py
@@ -6,6 +6,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from calibration import CalibrationResult
 import numpy as np
 from fitting import FitResult
 
@@ -39,7 +40,13 @@ def test_noise_cutoff_filters_events(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {}}
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -107,7 +114,13 @@ def test_invalid_noise_cutoff_skips_cut(tmp_path, monkeypatch, caplog):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {}}
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_override_logging.py
+++ b/tests/test_override_logging.py
@@ -7,12 +7,21 @@ import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from calibration import CalibrationResult
 from fitting import FitResult
 
 
 def _minimal_patches(monkeypatch):
-    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
-    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants",
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
+    )
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants_auto",
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
+    )
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0, 0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())

--- a/tests/test_sample_radon.py
+++ b/tests/test_sample_radon.py
@@ -7,6 +7,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import radon_activity
+from calibration import CalibrationResult
 import numpy as np
 from fitting import FitResult
 
@@ -36,7 +37,13 @@ def test_total_radon_uses_sample_volume(tmp_path, monkeypatch):
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))

--- a/tests/test_systematics.py
+++ b/tests/test_systematics.py
@@ -8,6 +8,7 @@ import math
 import json
 import pandas as pd
 import analyze
+from calibration import CalibrationResult
 from fitting import FitResult
 from systematics import scan_systematics, apply_linear_adc_shift
 
@@ -145,12 +146,12 @@ def test_analyze_systematics_skip_unknown(tmp_path, monkeypatch):
     monkeypatch.setattr(
         analyze,
         "derive_calibration_constants",
-        lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)},
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
     )
     monkeypatch.setattr(
         analyze,
         "derive_calibration_constants_auto",
-        lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)},
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
     )
 
     monkeypatch.setattr(

--- a/tests/test_time_bin_mode_conflict.py
+++ b/tests/test_time_bin_mode_conflict.py
@@ -3,9 +3,11 @@ from pathlib import Path
 import json
 import pandas as pd
 import pytest
+import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from calibration import CalibrationResult
 
 
 def test_time_bin_mode_conflict(tmp_path, monkeypatch):
@@ -25,8 +27,16 @@ def test_time_bin_mode_conflict(tmp_path, monkeypatch):
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
-    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
-    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants",
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
+    )
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants_auto",
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
+    )
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
 

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from fitting import FitResult
 
 import analyze
+from calibration import CalibrationResult
 import baseline_noise
 
 
@@ -41,12 +42,13 @@ def test_time_window_filters_events(tmp_path, monkeypatch):
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {
-        "a": (1.0, 0.0),
-        "c": (0.0, 0.0),
-        "sigma_E": (1.0, 0.0),
-        "peaks": {"Po210": {"centroid_adc": 10}},
-    }
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -119,8 +121,16 @@ def test_invalid_baseline_range_raises(tmp_path, monkeypatch):
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
-    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
-    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0)})
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants",
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
+    )
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants_auto",
+        lambda *a, **k: CalibrationResult([0.0, 1.0], np.zeros((2, 2)), sigma_E=1.0),
+    )
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -173,12 +183,13 @@ def test_time_window_filters_events_config(tmp_path, monkeypatch):
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {
-        "a": (1.0, 0.0),
-        "c": (0.0, 0.0),
-        "sigma_E": (1.0, 0.0),
-        "peaks": {"Po210": {"centroid_adc": 10}},
-    }
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -252,12 +263,13 @@ def test_run_period_filters_events(tmp_path, monkeypatch):
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {
-        "a": (1.0, 0.0),
-        "c": (0.0, 0.0),
-        "sigma_E": (1.0, 0.0),
-        "peaks": {"Po210": {"centroid_adc": 10}},
-    }
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -339,12 +351,13 @@ def test_baseline_range_iso_strings(tmp_path, monkeypatch, start, end):
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {
-        "a": (1.0, 0.0),
-        "c": (0.0, 0.0),
-        "sigma_E": (1.0, 0.0),
-        "peaks": {"Po210": {"centroid_adc": 10}},
-    }
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -422,7 +435,13 @@ def test_unified_filter_combined_windows(tmp_path, monkeypatch):
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        [0.0, 1.0],
+        np.zeros((2, 2)),
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+        peaks={"Po210": {"centroid_adc": 10}},
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)


### PR DESCRIPTION
## Summary
- update mocks patching derive_calibration_constants to use CalibrationResult objects
- import CalibrationResult in affected test modules
- ensure mocked calibration results provide proper coefficient arrays

## Testing
- `pytest tests/test_noise_cutoff.py::test_noise_cutoff_filters_events -q` *(fails: Package 'numpy' is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_685a73b016fc832b8b54b9e9a060a38a