### PR TITLE
Keep radon_interval datetimes

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -996,13 +996,16 @@ def main(argv=None):
             if end_r_dt <= start_r_dt:
                 raise ValueError("end <= start")
             radon_interval = (start_r_dt, end_r_dt)
-            cfg.setdefault("analysis", {})["radon_interval"] = [
-                parse_timestamp(start_r_dt),
-                parse_timestamp(end_r_dt),
+            iso_interval = [
+                start_r_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                end_r_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
             ]
+            cfg.setdefault("analysis", {})["radon_interval"] = iso_interval
+            radon_interval_cfg = iso_interval
         except Exception as e:
             logging.warning(f"Invalid radon_interval {radon_interval_cfg} -> {e}")
             radon_interval = None
+            radon_interval_cfg = None
 
     (
         df_analysis,

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -2069,7 +2069,10 @@ def test_time_fields_written_back(tmp_path, monkeypatch):
     assert used["analysis"]["spike_end_time"] == 0.0
     assert used["analysis"]["spike_periods"] == [[2.0, 3.0]]
     assert used["analysis"]["run_periods"] == [[0.0, 10.0]]
-    assert used["analysis"]["radon_interval"] == [3.0, 5.0]
+    assert used["analysis"]["radon_interval"] == [
+        "1970-01-01T00:00:03Z",
+        "1970-01-01T00:00:05Z",
+    ]
     assert used["baseline"]["range"] == [
         "1970-01-01T00:00:00+00:00",
         "1970-01-01T00:00:01+00:00",


### PR DESCRIPTION
## Summary
- treat `analysis.radon_interval` as UTC datetime tuples
- preserve timestamps in ISO format when updating configuration
- update tests for new `radon_interval` format

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_analyze_config_merge.py::test_time_fields_written_back -q` *(fails: CalibrationResult.__init__() got an unexpected keyword argument 'covariance')*

------
https://chatgpt.com/codex/tasks/task_e_685a824c7cdc832b8c266b07ea62e9a5