### PR TITLE
Avoid baseline timestamp round-trips

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1169,10 +1169,7 @@ def main(argv=None):
     mask_base = None
 
     if baseline_range:
-        t_start_base_sec = baseline_range[0].timestamp()
-        t_end_base_sec = baseline_range[1].timestamp()
-        t_start_base = pd.to_datetime(t_start_base_sec, unit="s", utc=True)
-        t_end_base = pd.to_datetime(t_end_base_sec, unit="s", utc=True)
+        t_start_base, t_end_base = baseline_range
         if t_end_base <= t_start_base:
             raise ValueError("baseline_range end time must be greater than start time")
         events_all_ts = pd.to_datetime(events_all["timestamp"], unit="s", utc=True)


### PR DESCRIPTION
## Summary
- remove unnecessary timestamp and to_datetime conversions

## Testing
- `pytest -q` *(fails: KeyboardInterrupt with many ImportErrors)*

------
https://chatgpt.com/codex/tasks/task_e_685ad92de600832b87b1fe4500c0ae88