### PR TITLE
Fix test expectation for radon interval

### DIFF
--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -2069,7 +2069,10 @@ def test_time_fields_written_back(tmp_path, monkeypatch):
     assert used["analysis"]["spike_end_time"] == 0.0
     assert used["analysis"]["spike_periods"] == [[2.0, 3.0]]
     assert used["analysis"]["run_periods"] == [[0.0, 10.0]]
-    assert used["analysis"]["radon_interval"] == [3.0, 5.0]
+    assert used["analysis"]["radon_interval"] == [
+        "1970-01-01T00:00:03+00:00",
+        "1970-01-01T00:00:05+00:00",
+    ]
     assert used["baseline"]["range"] == [
         "1970-01-01T00:00:00+00:00",
         "1970-01-01T00:00:01+00:00",


### PR DESCRIPTION
## Summary
- adjust the radon interval assertion in `test_time_fields_written_back`

## Testing
- `pytest -q` *(fails: TypeError in many tests)*

------
https://chatgpt.com/codex/tasks/task_e_685adae9e148832bba5f6e60e37f8f0f