### PR TITLE
Handle radon interval timestamps as datetimes

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -996,10 +996,8 @@ def main(argv=None):
             if end_r_dt <= start_r_dt:
                 raise ValueError("end <= start")
             radon_interval = (start_r_dt, end_r_dt)
-            cfg.setdefault("analysis", {})["radon_interval"] = [
-                parse_timestamp(start_r_dt),
-                parse_timestamp(end_r_dt),
-            ]
+            radon_interval_cfg = [start_r_dt.isoformat(), end_r_dt.isoformat()]
+            cfg.setdefault("analysis", {})["radon_interval"] = radon_interval_cfg
         except Exception as e:
             logging.warning(f"Invalid radon_interval {radon_interval_cfg} -> {e}")
             radon_interval = None
@@ -1090,7 +1088,7 @@ def main(argv=None):
 
         return CalibrationResult(
             coeffs=coeffs,
-            covariance=cov,
+            cov=cov,
             sigma_E=obj.get("sigma_E", (0.0, 0.0))[0],
             sigma_E_error=obj.get("sigma_E", (0.0, 0.0))[1],
             peaks=obj.get("peaks"),

--- a/calibration.py
+++ b/calibration.py
@@ -13,7 +13,7 @@ from constants import (
 )
 
 
-@dataclass
+@dataclass(init=False)
 class CalibrationResult:
     """Polynomial calibration coefficients and covariance."""
 
@@ -22,6 +22,27 @@ class CalibrationResult:
     peaks: dict | None = None
     sigma_E: float = 0.0
     sigma_E_error: float = 0.0
+
+    def __init__(
+        self,
+        coeffs,
+        cov=None,
+        *,
+        covariance=None,
+        peaks=None,
+        sigma_E=0.0,
+        sigma_E_error=0.0,
+    ):
+        if cov is None:
+            cov = covariance
+        elif covariance is not None:
+            raise TypeError("Specify at most one of cov or covariance")
+        self.coeffs = coeffs
+        self.cov = cov
+        self.peaks = peaks
+        self.sigma_E = sigma_E
+        self.sigma_E_error = sigma_E_error
+        self.__post_init__()
 
     def __post_init__(self):
         if isinstance(self.coeffs, Mapping):

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -2069,7 +2069,10 @@ def test_time_fields_written_back(tmp_path, monkeypatch):
     assert used["analysis"]["spike_end_time"] == 0.0
     assert used["analysis"]["spike_periods"] == [[2.0, 3.0]]
     assert used["analysis"]["run_periods"] == [[0.0, 10.0]]
-    assert used["analysis"]["radon_interval"] == [3.0, 5.0]
+    assert used["analysis"]["radon_interval"] == [
+        "1970-01-01T00:00:03+00:00",
+        "1970-01-01T00:00:05+00:00",
+    ]
     assert used["baseline"]["range"] == [
         "1970-01-01T00:00:00+00:00",
         "1970-01-01T00:00:01+00:00",


### PR DESCRIPTION
## Summary
- store `radon_interval` as ISO-8601 strings and keep the tuple of datetimes
- update calibration helper to use `cov` and allow `covariance` in `CalibrationResult`
- adjust test expecting numeric radon interval

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685adae9a528832b90437aff86e3dc91