### PR TITLE
Store datetime objects in analysis config

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -104,6 +104,7 @@ from utils import (
     adc_hist_edges,
     parse_timestamp,
     parse_time_arg,
+    to_utc_datetime,
 )
 from utils import parse_datetime
 from radmon.baseline import subtract_baseline
@@ -696,33 +697,33 @@ def main(argv=None):
 
     if args.analysis_end_time is not None:
         _log_override("analysis", "analysis_end_time", args.analysis_end_time)
-        cfg.setdefault("analysis", {})["analysis_end_time"] = args.analysis_end_time.timestamp()
+        cfg.setdefault("analysis", {})["analysis_end_time"] = args.analysis_end_time
 
     if args.analysis_start_time is not None:
         _log_override("analysis", "analysis_start_time", args.analysis_start_time)
-        cfg.setdefault("analysis", {})["analysis_start_time"] = args.analysis_start_time.timestamp()
+        cfg.setdefault("analysis", {})["analysis_start_time"] = args.analysis_start_time
 
     if args.spike_end_time is not None:
         _log_override("analysis", "spike_end_time", args.spike_end_time)
-        cfg.setdefault("analysis", {})["spike_end_time"] = args.spike_end_time.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        cfg.setdefault("analysis", {})["spike_end_time"] = args.spike_end_time
 
     if args.spike_period:
         _log_override("analysis", "spike_periods", args.spike_period)
         cfg.setdefault("analysis", {})["spike_periods"] = [
-            [s.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"), e.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")] for s, e in args.spike_period
+            [s, e] for s, e in args.spike_period
         ]
 
     if args.run_period:
         _log_override("analysis", "run_periods", args.run_period)
         cfg.setdefault("analysis", {})["run_periods"] = [
-            [s.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"), e.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")] for s, e in args.run_period
+            [s, e] for s, e in args.run_period
         ]
 
     if args.radon_interval:
         _log_override("analysis", "radon_interval", args.radon_interval)
         cfg.setdefault("analysis", {})["radon_interval"] = [
-            args.radon_interval[0].astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
-            args.radon_interval[1].astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            args.radon_interval[0],
+            args.radon_interval[1],
         ]
 
     if args.settle_s is not None:
@@ -905,8 +906,9 @@ def main(argv=None):
     t0_cfg = cfg.get("analysis", {}).get("analysis_start_time")
     if t0_cfg is not None:
         try:
-            t0_global = parse_timestamp(t0_cfg)
-            cfg.setdefault("analysis", {})["analysis_start_time"] = t0_global
+            t0_dt = to_utc_datetime(t0_cfg)
+            t0_global = t0_dt.timestamp()
+            cfg.setdefault("analysis", {})["analysis_start_time"] = t0_dt
         except Exception:
             logging.warning(
                 f"Invalid analysis_start_time '{t0_cfg}' - using first event"
@@ -923,9 +925,10 @@ def main(argv=None):
     t_end_global_ts = None
     if t_end_cfg is not None:
         try:
-            t_end_global_ts = parse_timestamp(t_end_cfg)
-            t_end_global = pd.to_datetime(t_end_global_ts, unit="s", utc=True)
-            cfg.setdefault("analysis", {})["analysis_end_time"] = t_end_global_ts
+            t_end_dt = to_utc_datetime(t_end_cfg)
+            t_end_global_ts = t_end_dt.timestamp()
+            t_end_global = pd.to_datetime(t_end_dt)
+            cfg.setdefault("analysis", {})["analysis_end_time"] = t_end_dt
         except Exception:
             logging.warning(
                 f"Invalid analysis_end_time '{t_end_cfg}' - using last event"
@@ -937,9 +940,9 @@ def main(argv=None):
     t_spike_end = None
     if spike_end_cfg is not None:
         try:
-            t_spike_end_ts = parse_timestamp(spike_end_cfg)
-            t_spike_end = pd.to_datetime(t_spike_end_ts, unit="s", utc=True)
-            cfg.setdefault("analysis", {})["spike_end_time"] = t_spike_end_ts
+            t_spike_dt = to_utc_datetime(spike_end_cfg)
+            t_spike_end = pd.Timestamp(t_spike_dt)
+            cfg.setdefault("analysis", {})["spike_end_time"] = t_spike_dt
         except Exception:
             logging.warning(f"Invalid spike_end_time '{spike_end_cfg}' - ignoring")
             t_spike_end = None
@@ -948,57 +951,59 @@ def main(argv=None):
     if spike_periods_cfg is None:
         spike_periods_cfg = []
     spike_periods = []
-    spike_secs = []
+    spike_dts = []
     for period in spike_periods_cfg:
         try:
             start, end = period
-            start_sec = parse_timestamp(start)
-            end_sec = parse_timestamp(end)
-            start_ts = pd.to_datetime(start_sec, unit="s", utc=True)
-            end_ts = pd.to_datetime(end_sec, unit="s", utc=True)
+            start_dt = to_utc_datetime(start)
+            end_dt = to_utc_datetime(end)
+            start_ts = pd.Timestamp(start_dt)
+            end_ts = pd.Timestamp(end_dt)
             if end_ts <= start_ts:
                 raise ValueError("end <= start")
             spike_periods.append((start_ts, end_ts))
-            spike_secs.append((start_sec, end_sec))
+            spike_dts.append((start_dt, end_dt))
         except Exception as e:
             logging.warning(f"Invalid spike_period {period} -> {e}")
     if spike_periods:
-        cfg.setdefault("analysis", {})["spike_periods"] = [list(p) for p in spike_secs]
+        cfg.setdefault("analysis", {})["spike_periods"] = [list(p) for p in spike_dts]
 
     run_periods_cfg = cfg.get("analysis", {}).get("run_periods", [])
     if run_periods_cfg is None:
         run_periods_cfg = []
     run_periods = []
-    run_secs = []
+    run_dts = []
     for period in run_periods_cfg:
         try:
             start, end = period
-            start_sec = parse_timestamp(start)
-            end_sec = parse_timestamp(end)
-            start_ts = pd.to_datetime(start_sec, unit="s", utc=True)
-            end_ts = pd.to_datetime(end_sec, unit="s", utc=True)
+            start_dt = to_utc_datetime(start)
+            end_dt = to_utc_datetime(end)
+            start_ts = pd.Timestamp(start_dt)
+            end_ts = pd.Timestamp(end_dt)
             if end_ts <= start_ts:
                 raise ValueError("end <= start")
             run_periods.append((start_ts, end_ts))
-            run_secs.append((start_sec, end_sec))
+            run_dts.append((start_dt, end_dt))
         except Exception as e:
             logging.warning(f"Invalid run_period {period} -> {e}")
     if run_periods:
-        cfg.setdefault("analysis", {})["run_periods"] = [list(p) for p in run_secs]
+        cfg.setdefault("analysis", {})["run_periods"] = [list(p) for p in run_dts]
 
     radon_interval_cfg = cfg.get("analysis", {}).get("radon_interval")
     radon_interval = None
     if radon_interval_cfg:
         try:
             start_r, end_r = radon_interval_cfg
-            start_r_dt = pd.to_datetime(parse_datetime(start_r), utc=True)
-            end_r_dt = pd.to_datetime(parse_datetime(end_r), utc=True)
-            if end_r_dt <= start_r_dt:
+            start_r_dt = to_utc_datetime(start_r)
+            end_r_dt = to_utc_datetime(end_r)
+            start_r_ts = pd.Timestamp(start_r_dt)
+            end_r_ts = pd.Timestamp(end_r_dt)
+            if end_r_ts <= start_r_ts:
                 raise ValueError("end <= start")
-            radon_interval = (start_r_dt, end_r_dt)
+            radon_interval = (start_r_ts, end_r_ts)
             cfg.setdefault("analysis", {})["radon_interval"] = [
-                parse_timestamp(start_r_dt),
-                parse_timestamp(end_r_dt),
+                start_r_dt,
+                end_r_dt,
             ]
         except Exception as e:
             logging.warning(f"Invalid radon_interval {radon_interval_cfg} -> {e}")


### PR DESCRIPTION
## Summary
- preserve datetime objects for parsed analysis fields
- keep config values as datetimes instead of timestamps

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: CalibrationResult.__init__() got an unexpected keyword argument 'covariance')*

------
https://chatgpt.com/codex/tasks/task_e_685adad31c34832b962651a79a2f2983