### PR TITLE
Store analysis times as datetime objects

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -696,33 +696,33 @@ def main(argv=None):
 
     if args.analysis_end_time is not None:
         _log_override("analysis", "analysis_end_time", args.analysis_end_time)
-        cfg.setdefault("analysis", {})["analysis_end_time"] = args.analysis_end_time.timestamp()
+        cfg.setdefault("analysis", {})["analysis_end_time"] = args.analysis_end_time
 
     if args.analysis_start_time is not None:
         _log_override("analysis", "analysis_start_time", args.analysis_start_time)
-        cfg.setdefault("analysis", {})["analysis_start_time"] = args.analysis_start_time.timestamp()
+        cfg.setdefault("analysis", {})["analysis_start_time"] = args.analysis_start_time
 
     if args.spike_end_time is not None:
         _log_override("analysis", "spike_end_time", args.spike_end_time)
-        cfg.setdefault("analysis", {})["spike_end_time"] = args.spike_end_time.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        cfg.setdefault("analysis", {})["spike_end_time"] = args.spike_end_time
 
     if args.spike_period:
         _log_override("analysis", "spike_periods", args.spike_period)
         cfg.setdefault("analysis", {})["spike_periods"] = [
-            [s.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"), e.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")] for s, e in args.spike_period
+            [s, e] for s, e in args.spike_period
         ]
 
     if args.run_period:
         _log_override("analysis", "run_periods", args.run_period)
         cfg.setdefault("analysis", {})["run_periods"] = [
-            [s.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"), e.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")] for s, e in args.run_period
+            [s, e] for s, e in args.run_period
         ]
 
     if args.radon_interval:
         _log_override("analysis", "radon_interval", args.radon_interval)
         cfg.setdefault("analysis", {})["radon_interval"] = [
-            args.radon_interval[0].astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
-            args.radon_interval[1].astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            args.radon_interval[0],
+            args.radon_interval[1],
         ]
 
     if args.settle_s is not None:

--- a/tests/test_to_native.py
+++ b/tests/test_to_native.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 from dataclasses import dataclass
+from datetime import datetime, timezone
 import numpy as np
 import pandas as pd
 import pytest
@@ -23,6 +24,11 @@ def test_to_native_pandas_objects():
     assert to_native(ts) == ts.isoformat()
     assert to_native(td) == td.isoformat()
     assert to_native(pd.NA) is None
+
+
+def test_to_native_datetime_object():
+    dt = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert to_native(dt) == dt.isoformat()
 
 
 @dataclass

--- a/utils.py
+++ b/utils.py
@@ -51,6 +51,8 @@ def to_native(obj):
             return obj.isoformat()
         elif isinstance(obj, (pd.Series, pd.Index)):
             return [to_native(x) for x in obj.tolist()]
+    if isinstance(obj, datetime):
+        return obj.isoformat()
     if isinstance(obj, np.ndarray):
         # Convert array into list of native types
         return [to_native(x) for x in obj.tolist()]


### PR DESCRIPTION
## Summary
- avoid timestamp conversions when overriding analysis times
- convert Python datetime objects to ISO strings in `to_native`
- cover datetime handling in `to_native` tests

## Testing
- `pytest tests/test_to_native.py::test_to_native_datetime_object -q`
- `pytest -q` *(fails: CalibrationResult.__init__() got an unexpected keyword argument 'covariance')*

------
https://chatgpt.com/codex/tasks/task_e_685ad92cebc0832b822524023d4cb9ed