### PR TITLE
Use datetime objects for analysis timing

### DIFF
--- a/calibration.py
+++ b/calibration.py
@@ -13,7 +13,7 @@ from constants import (
 )
 
 
-@dataclass
+@dataclass(init=False)
 class CalibrationResult:
     """Polynomial calibration coefficients and covariance."""
 
@@ -22,6 +22,27 @@ class CalibrationResult:
     peaks: dict | None = None
     sigma_E: float = 0.0
     sigma_E_error: float = 0.0
+
+    def __init__(
+        self,
+        coeffs: Sequence[float] | Mapping[int, float],
+        cov: np.ndarray | None = None,
+        *,
+        covariance: np.ndarray | None = None,
+        peaks: dict | None = None,
+        sigma_E: float = 0.0,
+        sigma_E_error: float = 0.0,
+    ):
+        if cov is None:
+            cov = covariance
+        if cov is None:
+            raise TypeError("covariance matrix required")
+        self.coeffs = coeffs
+        self.cov = cov
+        self.peaks = peaks
+        self.sigma_E = sigma_E
+        self.sigma_E_error = sigma_E_error
+        self.__post_init__()
 
     def __post_init__(self):
         if isinstance(self.coeffs, Mapping):


### PR DESCRIPTION
## Summary
- switch config time parsing in `analyze.py` to `to_utc_datetime`
- retain parsed times as `datetime` objects
- adapt downstream calculations and plotting to convert to numeric seconds only when needed
- allow `CalibrationResult` to accept `covariance` or `cov`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685adad3b658832b92dfb739f4dc457a