### PR TITLE
Maintain datetimes for baseline filtering

### DIFF
--- a/baseline.py
+++ b/baseline.py
@@ -105,9 +105,12 @@ def subtract_baseline(df_analysis, df_full, bins, t_base0, t_base1,
         live_time_analysis = live_an
 
     # baseline slice
-    t0 = parse_timestamp(t_base0)
-    t1 = parse_timestamp(t_base1)
-    ts_full = _seconds(df_full["timestamp"])
+    t0 = pd.to_datetime(t_base0, utc=True)
+    t1 = pd.to_datetime(t_base1, utc=True)
+    ts_full = df_full["timestamp"]
+    if not pd.api.types.is_datetime64_any_dtype(ts_full):
+        ts_full = ts_full.map(parse_datetime)
+    ts_full = pd.to_datetime(ts_full, utc=True)
     mask = (ts_full >= t0) & (ts_full <= t1)
     if not mask.any():
         logging.warning("baseline_range matched no events – skipping subtraction")

--- a/calibration.py
+++ b/calibration.py
@@ -13,15 +13,34 @@ from constants import (
 )
 
 
-@dataclass
+@dataclass(init=False)
 class CalibrationResult:
     """Polynomial calibration coefficients and covariance."""
 
     coeffs: Sequence[float] | Mapping[int, float]
-    cov: np.ndarray
+    cov: np.ndarray | None
     peaks: dict | None = None
     sigma_E: float = 0.0
     sigma_E_error: float = 0.0
+
+    def __init__(
+        self,
+        coeffs,
+        cov=None,
+        *,
+        covariance=None,
+        peaks=None,
+        sigma_E=0.0,
+        sigma_E_error=0.0,
+    ):
+        if cov is None:
+            cov = covariance
+        self.coeffs = coeffs
+        self.cov = cov
+        self.peaks = peaks
+        self.sigma_E = sigma_E
+        self.sigma_E_error = sigma_E_error
+        self.__post_init__()
 
     def __post_init__(self):
         if isinstance(self.coeffs, Mapping):


### PR DESCRIPTION
## Summary
- keep timestamps in UTC when loading events
- compare baseline ranges using timezone aware datetimes
- let `CalibrationResult` accept `covariance` as an alias for `cov`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685adad4abc4832bb1395095a94085ab