### PR TITLE
Store baseline range as datetimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--j
 - `summary.json` – calibration and fit summary.
 - `config_used.json` – copy of the configuration used.
   Any timestamps overridden on the command line are written
-  back to this file in Unix seconds.
+  back to this file as ISO timestamps.
 - `spectrum.png` – spectrum plot with fitted peaks.
 - `time_series_Po214.png` and `time_series_Po218.png` – decay time-series plots.
 - `time_series_Po210.png` when `window_po210` is set.

--- a/analyze.py
+++ b/analyze.py
@@ -1090,7 +1090,7 @@ def main(argv=None):
 
         return CalibrationResult(
             coeffs=coeffs,
-            covariance=cov,
+            cov=cov,
             sigma_E=obj.get("sigma_E", (0.0, 0.0))[0],
             sigma_E_error=obj.get("sigma_E", (0.0, 0.0))[1],
             peaks=obj.get("peaks"),
@@ -1148,15 +1148,16 @@ def main(argv=None):
             baseline_range[1].isoformat(),
         )
         cfg.setdefault("baseline", {})["range"] = [
-            baseline_range[0].isoformat(),
-            baseline_range[1].isoformat(),
+            baseline_range[0],
+            baseline_range[1],
         ]
     elif "range" in baseline_cfg:
         try:
             b0, b1 = baseline_cfg.get("range")
-            start_dt = pd.to_datetime(parse_datetime(b0), utc=True)
-            end_dt = pd.to_datetime(parse_datetime(b1), utc=True)
+            start_dt = pd.to_datetime(parse_datetime(b0), utc=True).to_pydatetime()
+            end_dt = pd.to_datetime(parse_datetime(b1), utc=True).to_pydatetime()
             baseline_range = (start_dt, end_dt)
+            baseline_cfg["range"] = [start_dt, end_dt]
         except Exception as e:
             logging.warning(
                 "Invalid baseline.range %r -> %s", baseline_cfg.get("range"), e
@@ -1198,8 +1199,8 @@ def main(argv=None):
         else:
             baseline_live_time = float((t_end_base - t_start_base) / np.timedelta64(1, "s"))
         cfg.setdefault("baseline", {})["range"] = [
-            t_start_base.isoformat(),
-            t_end_base.isoformat(),
+            t_start_base.to_pydatetime(),
+            t_end_base.to_pydatetime(),
         ]
         baseline_info = {
             "start": t_start_base,

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -1,6 +1,7 @@
 import json
 import sys
 from pathlib import Path
+from datetime import datetime, timezone
 import pandas as pd
 import numpy as np
 import logging
@@ -2070,9 +2071,11 @@ def test_time_fields_written_back(tmp_path, monkeypatch):
     assert used["analysis"]["spike_periods"] == [[2.0, 3.0]]
     assert used["analysis"]["run_periods"] == [[0.0, 10.0]]
     assert used["analysis"]["radon_interval"] == [3.0, 5.0]
+    exp_start = datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    exp_end = datetime(1970, 1, 1, 0, 0, 1, tzinfo=timezone.utc)
     assert used["baseline"]["range"] == [
-        "1970-01-01T00:00:00+00:00",
-        "1970-01-01T00:00:01+00:00",
+        exp_start,
+        exp_end,
     ]
 
 

--- a/tests/test_baseline_range_cli.py
+++ b/tests/test_baseline_range_cli.py
@@ -94,6 +94,6 @@ def test_baseline_range_cli_overrides_config(tmp_path, monkeypatch):
     assert summary["baseline"]["end"] == exp_end
     assert summary["baseline"]["n_events"] == 1
     assert captured.get("cfg", {}).get("baseline", {}).get("range") == [
-        "1970-01-01T00:00:10+00:00",
-        "1970-01-01T00:00:20+00:00",
+        exp_start,
+        exp_end,
     ]

--- a/tests/test_baseline_range_empty.py
+++ b/tests/test_baseline_range_empty.py
@@ -97,6 +97,6 @@ def test_cli_baseline_range_empty(tmp_path, monkeypatch):
     assert summary.get("baseline", {}).get("n_events") == 0
     assert summary.get("baseline", {}).get("live_time") == 0.0
     assert captured.get("cfg", {}).get("baseline", {}).get("range") == [
-        "1970-01-01T00:00:10+00:00",
-        "1970-01-01T00:00:20+00:00",
+        exp_start,
+        exp_end,
     ]

--- a/tests/test_cli_baseline_range.py
+++ b/tests/test_cli_baseline_range.py
@@ -96,6 +96,6 @@ def test_cli_baseline_range_overrides_config(tmp_path, monkeypatch):
     assert summary.get("baseline", {}).get("end") == exp_end
     assert summary.get("baseline", {}).get("n_events") == 1
     assert captured.get("cfg", {}).get("baseline", {}).get("range") == [
-        "1970-01-01T00:00:01+00:00",
-        "1970-01-01T00:00:02+00:00",
+        exp_start,
+        exp_end,
     ]

--- a/tests/test_cli_baseline_range_iso.py
+++ b/tests/test_cli_baseline_range_iso.py
@@ -96,8 +96,8 @@ def test_cli_baseline_range_iso_strings(tmp_path, monkeypatch):
     assert summary.get("baseline", {}).get("end") == exp_end
     assert summary.get("baseline", {}).get("n_events") == 1
     assert captured.get("cfg", {}).get("baseline", {}).get("range") == [
-        "1970-01-01T00:00:01+00:00",
-        "1970-01-01T00:00:02+00:00",
+        exp_start,
+        exp_end,
     ]
 
 
@@ -188,6 +188,6 @@ def test_cli_baseline_range_timezone(tmp_path, monkeypatch):
     assert summary.get("baseline", {}).get("end") == exp_end
     assert summary.get("baseline", {}).get("n_events") == 1
     assert captured.get("cfg", {}).get("baseline", {}).get("range") == [
-        "1970-01-01T00:00:01+00:00",
-        "1970-01-01T00:00:02+00:00",
+        exp_start,
+        exp_end,
     ]

--- a/tests/test_cli_baseline_range_override2.py
+++ b/tests/test_cli_baseline_range_override2.py
@@ -96,6 +96,6 @@ def test_cli_baseline_range_overrides_config_again(tmp_path, monkeypatch):
     assert summary.get("baseline", {}).get("end") == exp_end
     assert summary.get("baseline", {}).get("n_events") == 1
     assert captured.get("cfg", {}).get("baseline", {}).get("range") == [
-        "1970-01-01T00:00:02+00:00",
-        "1970-01-01T00:00:03+00:00",
+        exp_start,
+        exp_end,
     ]


### PR DESCRIPTION
## Summary
- update docs to mention ISO timestamp output
- store baseline range datetimes in the config
- adjust baseline range tests for datetime objects

## Testing
- `bash scripts/setup_tests.sh`
- `pytest tests/test_cli_baseline_range.py tests/test_cli_baseline_range_iso.py tests/test_baseline_range_cli.py tests/test_baseline_range_empty.py tests/test_cli_baseline_range_override2.py tests/test_analyze_config_merge.py::test_time_fields_written_back -q`

------
https://chatgpt.com/codex/tasks/task_e_685adad4feac832bb739b4181d99b8de