### PR TITLE
Update radon interval parsing

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -996,10 +996,11 @@ def main(argv=None):
             if end_r_dt <= start_r_dt:
                 raise ValueError("end <= start")
             radon_interval = (start_r_dt, end_r_dt)
-            cfg.setdefault("analysis", {})["radon_interval"] = [
-                parse_timestamp(start_r_dt),
-                parse_timestamp(end_r_dt),
+            radon_interval_cfg = [
+                start_r_dt.isoformat(),
+                end_r_dt.isoformat(),
             ]
+            cfg.setdefault("analysis", {})["radon_interval"] = radon_interval_cfg
         except Exception as e:
             logging.warning(f"Invalid radon_interval {radon_interval_cfg} -> {e}")
             radon_interval = None

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -2069,7 +2069,10 @@ def test_time_fields_written_back(tmp_path, monkeypatch):
     assert used["analysis"]["spike_end_time"] == 0.0
     assert used["analysis"]["spike_periods"] == [[2.0, 3.0]]
     assert used["analysis"]["run_periods"] == [[0.0, 10.0]]
-    assert used["analysis"]["radon_interval"] == [3.0, 5.0]
+    assert used["analysis"]["radon_interval"] == [
+        "1970-01-01T00:00:03+00:00",
+        "1970-01-01T00:00:05+00:00",
+    ]
     assert used["baseline"]["range"] == [
         "1970-01-01T00:00:00+00:00",
         "1970-01-01T00:00:01+00:00",


### PR DESCRIPTION
## Summary
- keep radon interval timestamps as datetimes in memory
- store radon interval back to config as ISO strings
- fix config merge test to expect ISO strings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685add1c8c14832ba6a904e16af9dbf9