### PR TITLE
Fix radon_interval assertion

### DIFF
--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -2071,7 +2071,10 @@ def test_time_fields_written_back(tmp_path, monkeypatch):
     assert used["analysis"]["spike_periods"] == [[2.0, 3.0]]
     assert used["analysis"]["run_periods"] == [[0.0, 10.0]]
 
-    assert used["analysis"]["radon_interval"] == [3.0, 5.0]
+    assert used["analysis"]["radon_interval"] == [
+        "1970-01-01T00:00:03+00:00",
+        "1970-01-01T00:00:05+00:00",
+    ]
     exp_start = datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     exp_end = datetime(1970, 1, 1, 0, 0, 1, tzinfo=timezone.utc)
 


### PR DESCRIPTION
## Summary
- update `test_time_fields_written_back` to expect ISO-formatted strings for `radon_interval`

## Testing
- `pytest tests/test_analyze_config_merge.py::test_time_fields_written_back -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae15ecb50832bb6f79498a85021a5