### PR TITLE
Update time handling to keep datetime objects

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -696,33 +696,33 @@ def main(argv=None):
 
     if args.analysis_end_time is not None:
         _log_override("analysis", "analysis_end_time", args.analysis_end_time)
-        cfg.setdefault("analysis", {})["analysis_end_time"] = args.analysis_end_time.timestamp()
+        cfg.setdefault("analysis", {})["analysis_end_time"] = args.analysis_end_time
 
     if args.analysis_start_time is not None:
         _log_override("analysis", "analysis_start_time", args.analysis_start_time)
-        cfg.setdefault("analysis", {})["analysis_start_time"] = args.analysis_start_time.timestamp()
+        cfg.setdefault("analysis", {})["analysis_start_time"] = args.analysis_start_time
 
     if args.spike_end_time is not None:
         _log_override("analysis", "spike_end_time", args.spike_end_time)
-        cfg.setdefault("analysis", {})["spike_end_time"] = args.spike_end_time.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        cfg.setdefault("analysis", {})["spike_end_time"] = args.spike_end_time
 
     if args.spike_period:
         _log_override("analysis", "spike_periods", args.spike_period)
         cfg.setdefault("analysis", {})["spike_periods"] = [
-            [s.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"), e.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")] for s, e in args.spike_period
+            [s, e] for s, e in args.spike_period
         ]
 
     if args.run_period:
         _log_override("analysis", "run_periods", args.run_period)
         cfg.setdefault("analysis", {})["run_periods"] = [
-            [s.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"), e.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")] for s, e in args.run_period
+            [s, e] for s, e in args.run_period
         ]
 
     if args.radon_interval:
         _log_override("analysis", "radon_interval", args.radon_interval)
         cfg.setdefault("analysis", {})["radon_interval"] = [
-            args.radon_interval[0].astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
-            args.radon_interval[1].astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            args.radon_interval[0],
+            args.radon_interval[1],
         ]
 
     if args.settle_s is not None:

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -1190,10 +1190,13 @@ def test_spike_period_cli(tmp_path, monkeypatch):
     analyze.main()
 
     assert captured["times"] == [6.0]
-    assert saved["summary"]["analysis"]["spike_periods"] == [
-        ["1970-01-01T00:00:00Z", "1970-01-01T00:00:05Z"],
-        ["1970-01-01T00:00:10Z", "1970-01-01T00:00:13Z"],
+    exp = [
+        [datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+         datetime(1970, 1, 1, 0, 0, 5, tzinfo=timezone.utc)],
+        [datetime(1970, 1, 1, 0, 0, 10, tzinfo=timezone.utc),
+         datetime(1970, 1, 1, 0, 0, 13, tzinfo=timezone.utc)],
     ]
+    assert saved["summary"]["analysis"]["spike_periods"] == exp
 
 
 def test_seed_cli_sets_random_seed(tmp_path, monkeypatch):
@@ -2071,7 +2074,10 @@ def test_time_fields_written_back(tmp_path, monkeypatch):
     assert used["analysis"]["spike_periods"] == [[2.0, 3.0]]
     assert used["analysis"]["run_periods"] == [[0.0, 10.0]]
 
-    assert used["analysis"]["radon_interval"] == [3.0, 5.0]
+    assert used["analysis"]["radon_interval"] == [
+        "1970-01-01T00:00:03+00:00",
+        "1970-01-01T00:00:05+00:00",
+    ]
     exp_start = datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     exp_end = datetime(1970, 1, 1, 0, 0, 1, tzinfo=timezone.utc)
 

--- a/utils.py
+++ b/utils.py
@@ -5,7 +5,7 @@ from scipy.signal import find_peaks
 import math
 from dataclasses import is_dataclass, asdict
 import argparse
-from datetime import datetime, timezone, tzinfo
+from datetime import datetime, timezone, tzinfo, timedelta
 from dateutil import parser as date_parser
 from dateutil.tz import gettz
 
@@ -51,6 +51,10 @@ def to_native(obj):
             return obj.isoformat()
         elif isinstance(obj, (pd.Series, pd.Index)):
             return [to_native(x) for x in obj.tolist()]
+    if isinstance(obj, datetime):
+        if obj.tzinfo is not None and obj.tzinfo.utcoffset(obj) == timedelta(0):
+            return obj.strftime("%Y-%m-%dT%H:%M:%SZ")
+        return obj.isoformat()
     if isinstance(obj, np.ndarray):
         # Convert array into list of native types
         return [to_native(x) for x in obj.tolist()]


### PR DESCRIPTION
## Summary
- keep parsed datetime objects when applying CLI overrides
- convert datetime objects to ISO strings via `to_native`
- adjust tests for new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae157d028832b9a1768d57ea87057