### PR TITLE
Simplify CSV timestamp parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ This repository provides a complete pipeline to analyze electrostatic radon moni
 - `efficiency.py`: Efficiency calculations and BLUE combination helpers.
 - `systematics.py`: Scan for systematic uncertainties (optional).
 - `plot_utils.py`: Plotting routines for spectrum and time-series.
-- `utils.py`: Miscellaneous utilities providing `parse_timestamp` and
-  `parse_datetime` for time conversion, JSON validation, and count-rate
+- `utils.py`: Miscellaneous utilities providing `parse_datetime` for time
+  conversion, JSON validation, and count-rate
   conversions.
 - `tests/`: `pytest` unit tests for calibration, fitting, and I/O.
 
@@ -58,7 +58,7 @@ The input file must be a comma-separated table with these columns:
 - `fBits` – status bits or flags
 - `timestamp` – event timestamp in seconds
   (either numeric Unix seconds or an ISO‑8601 string; parsed with
-  `parse_timestamp` and converted to `numpy.datetime64[ns, UTC]` by `parse_datetime`)
+  `parse_datetime` to ``numpy.datetime64[ns]``)
 - `adc` – raw ADC value
 - `fchannel` – acquisition channel
 

--- a/analyze.py
+++ b/analyze.py
@@ -824,12 +824,11 @@ def main(argv=None):
         if not pd.api.types.is_datetime64_any_dtype(events_all["timestamp"]):
             events_all["timestamp"] = events_all["timestamp"].map(parse_datetime)
 
-        # 2) Localize naive datetimes, or convert existing tz to target
-        #    Assume tzinfo is a pytz timezone or dateutil tzinfo
+        # 2) Ensure timestamps are interpreted as UTC
         if events_all["timestamp"].dt.tz is None:
-            events_all["timestamp"] = events_all["timestamp"].dt.tz_localize(tzinfo)
+            events_all["timestamp"] = events_all["timestamp"].dt.tz_localize("UTC")
         else:
-            events_all["timestamp"] = events_all["timestamp"].dt.tz_convert(tzinfo)
+            events_all["timestamp"] = events_all["timestamp"].dt.tz_convert("UTC")
 
         # 3) Convert to epoch seconds (float)
         #    astype(int) gives nanoseconds since epoch, so divide by 1e9
@@ -843,7 +842,7 @@ def main(argv=None):
         print("No events found in the input CSV. Exiting.")
         sys.exit(0)
 
-    # ``load_events()`` now returns timezone-aware datetimes; convert to epoch
+    # ``load_events()`` now returns ``datetime64`` values; convert to epoch
     # seconds for internal calculations.
 
     # ───────────────────────────────────────────────
@@ -997,8 +996,8 @@ def main(argv=None):
                 raise ValueError("end <= start")
             radon_interval = (start_r_dt, end_r_dt)
             radon_interval_cfg = [
-                start_r_dt.isoformat(),
-                end_r_dt.isoformat(),
+                float(start_r_dt.timestamp()),
+                float(end_r_dt.timestamp()),
             ]
             cfg.setdefault("analysis", {})["radon_interval"] = radon_interval_cfg
         except Exception as e:

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -81,7 +81,7 @@ def test_load_events(tmp_path, caplog):
     df.to_csv(p, index=False)
     with caplog.at_level(logging.INFO):
         loaded = load_events(p)
-    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
+    assert loaded["timestamp"].dtype == "datetime64[ns]"
     expected_ts = np.array(
         [parse_datetime(t) for t in (1000, 1005, 1010)], dtype="datetime64[ns]"
     )
@@ -105,7 +105,7 @@ def test_load_events_drop_bad_rows(tmp_path, caplog):
     with caplog.at_level(logging.INFO):
         loaded = load_events(p)
     # Expect rows with NaN/inf removed and duplicate dropped
-    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
+    assert loaded["timestamp"].dtype == "datetime64[ns]"
     expected_ts = np.array(
         [parse_datetime(t) for t in (1000, 1005, 1020)], dtype="datetime64[ns]"
     )
@@ -126,8 +126,8 @@ def test_load_events_column_aliases(tmp_path):
     p = tmp_path / "alias.csv"
     df.to_csv(p, index=False)
     loaded = load_events(p)
-    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
-    assert list(loaded["timestamp"])[0] == pd.Timestamp(parse_datetime(1000)).tz_localize("UTC")
+    assert loaded["timestamp"].dtype == "datetime64[ns]"
+    assert list(loaded["timestamp"])[0] == parse_datetime(1000)
     assert list(loaded["adc"])[0] == 1250
     assert "time" not in loaded.columns
     assert "adc_ch" not in loaded.columns
@@ -153,7 +153,7 @@ def test_load_events_custom_columns(tmp_path):
         "fchannel": "chan",
     }
     loaded = load_events(p, column_map=column_map)
-    assert list(loaded["timestamp"])[0] == pd.Timestamp(parse_datetime(1000)).tz_localize("UTC")
+    assert list(loaded["timestamp"])[0] == parse_datetime(1000)
     assert list(loaded["adc"])[0] == 1250
     assert "ftimestamps" not in loaded.columns
 
@@ -188,7 +188,7 @@ def test_load_events_string_nan(tmp_path):
     df.to_csv(p, index=False)
     loaded = load_events(p)
     assert len(loaded) == 1
-    assert loaded["timestamp"].iloc[0] == pd.Timestamp(parse_datetime(1000)).tz_localize("UTC")
+    assert loaded["timestamp"].iloc[0] == parse_datetime(1000)
 
 
 def test_write_summary_and_copy_config(tmp_path):


### PR DESCRIPTION
## Summary
- parse CSV timestamps directly with `parse_datetime`
- keep invalid values as `NaT`
- treat loaded timestamps as UTC in analysis
- store `radon_interval` in seconds since epoch
- update tests and docs for new datetime behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ae17153ec832bb8b97157ae743924