### PR TITLE
Improve datetime handling for analysis periods

### DIFF
--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -2068,10 +2068,17 @@ def test_time_fields_written_back(tmp_path, monkeypatch):
     used = captured.get("cfg", {})
     assert used["analysis"]["analysis_end_time"] == 5.0
     assert used["analysis"]["spike_end_time"] == 0.0
-    assert used["analysis"]["spike_periods"] == [[2.0, 3.0]]
-    assert used["analysis"]["run_periods"] == [[0.0, 10.0]]
+    assert used["analysis"]["spike_periods"] == [
+        ["1970-01-01T00:00:02+00:00", "1970-01-01T00:00:03+00:00"]
+    ]
+    assert used["analysis"]["run_periods"] == [
+        ["1970-01-01T00:00:00+00:00", "1970-01-01T00:00:10+00:00"]
+    ]
 
-    assert used["analysis"]["radon_interval"] == [3.0, 5.0]
+    assert used["analysis"]["radon_interval"] == [
+        "1970-01-01T00:00:03+00:00",
+        "1970-01-01T00:00:05+00:00",
+    ]
     exp_start = datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     exp_end = datetime(1970, 1, 1, 0, 0, 1, tzinfo=timezone.utc)
 

--- a/tests/test_analyze_noise_cutoff.py
+++ b/tests/test_analyze_noise_cutoff.py
@@ -80,4 +80,4 @@ def test_analyze_noise_cutoff(tmp_path, monkeypatch):
     analyze.main()
 
     assert captured.get("fit_times") == [2.0]
-    assert captured.get("plot_times") == [2.0]
+    assert captured.get("plot_times") == [np.datetime64("1970-01-01T00:00:02Z")]


### PR DESCRIPTION
## Summary
- parse spike and run intervals to datetime without converting to seconds
- support datetime arrays in `_ts_bin_centers_widths`
- use datetime logic for fit start times and plotting
- adjust tests for updated datetime behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae2bd1ebc832ba6fd4f880e22276a