### PR TITLE
Update baseline datetime handling

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -997,8 +997,8 @@ def main(argv=None):
                 raise ValueError("end <= start")
             radon_interval = (start_r_dt, end_r_dt)
             radon_interval_cfg = [
-                start_r_dt.isoformat(),
-                end_r_dt.isoformat(),
+                start_r_dt.timestamp(),
+                end_r_dt.timestamp(),
             ]
             cfg.setdefault("analysis", {})["radon_interval"] = radon_interval_cfg
         except Exception as e:
@@ -1171,10 +1171,8 @@ def main(argv=None):
     mask_base = None
 
     if baseline_range:
-        t_start_base_sec = baseline_range[0].timestamp()
-        t_end_base_sec = baseline_range[1].timestamp()
-        t_start_base = pd.to_datetime(t_start_base_sec, unit="s", utc=True)
-        t_end_base = pd.to_datetime(t_end_base_sec, unit="s", utc=True)
+        t_start_base = baseline_range[0]
+        t_end_base = baseline_range[1]
         if t_end_base <= t_start_base:
             raise ValueError("baseline_range end time must be greater than start time")
         events_all_ts = pd.to_datetime(events_all["timestamp"], unit="s", utc=True)
@@ -1198,14 +1196,14 @@ def main(argv=None):
             )
             baseline_live_time = 0.0
         else:
-            baseline_live_time = float((t_end_base - t_start_base) / np.timedelta64(1, "s"))
+            baseline_live_time = float((t_end_base - t_start_base).total_seconds())
         cfg.setdefault("baseline", {})["range"] = [
-            t_start_base.to_pydatetime(),
-            t_end_base.to_pydatetime(),
+            pd.Timestamp(t_start_base).tz_convert("UTC"),
+            pd.Timestamp(t_end_base).tz_convert("UTC"),
         ]
         baseline_info = {
-            "start": t_start_base,
-            "end": t_end_base,
+            "start": pd.Timestamp(t_start_base).tz_convert("UTC"),
+            "end": pd.Timestamp(t_end_base).tz_convert("UTC"),
             "n_events": len(base_events),
             "live_time": baseline_live_time,
         }


### PR DESCRIPTION
## Summary
- remove `timestamp()` conversions for baseline comparison
- store baseline range as pandas timestamps for serialization
- keep radon interval numeric in config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae2bc9344832bb73ec549698ff783