### PR TITLE
Preserve datetime timestamps

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -46,7 +46,11 @@ def extract_time_series_events(events, cfg):
             continue
         lo, hi = win
         mask = (events["energy_MeV"] >= lo) & (events["energy_MeV"] <= hi)
-        out[iso] = events.loc[mask, "timestamp"].values.astype(float)
+        ts = events.loc[mask, "timestamp"].values
+        if np.issubdtype(ts.dtype, "datetime64"):
+            out[iso] = ts.view("int64") / 1e9
+        else:
+            out[iso] = ts.astype(float)
     return out
 
 logger = logging.getLogger(__name__)

--- a/utils.py
+++ b/utils.py
@@ -51,6 +51,8 @@ def to_native(obj):
             return obj.isoformat()
         elif isinstance(obj, (pd.Series, pd.Index)):
             return [to_native(x) for x in obj.tolist()]
+    if isinstance(obj, datetime):
+        return obj.isoformat()
     if isinstance(obj, np.ndarray):
         # Convert array into list of native types
         return [to_native(x) for x in obj.tolist()]


### PR DESCRIPTION
## Summary
- keep timezone-aware datetimes for `events_all['timestamp']`
- handle datetime columns in helper functions and drift correction
- support `datetime` values in `to_native`
- update time-series event extraction for datetime inputs
- adjust baseline range handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae2bcbbc4832ba89d8c2bdaefcf7b