### PR TITLE
Avoid timestamp conversions for baseline masks

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1175,16 +1175,12 @@ def main(argv=None):
     mask_base = None
 
     if baseline_range:
-        t_start_base_sec = baseline_range[0].timestamp()
-        t_end_base_sec = baseline_range[1].timestamp()
-        t_start_base = pd.to_datetime(t_start_base_sec, unit="s", utc=True)
-        t_end_base = pd.to_datetime(t_end_base_sec, unit="s", utc=True)
+        t_start_base = baseline_range[0]
+        t_end_base = baseline_range[1]
         if t_end_base <= t_start_base:
             raise ValueError("baseline_range end time must be greater than start time")
         events_all_ts = pd.to_datetime(events_all["timestamp"], unit="s", utc=True)
-        mask_base_full = (events_all_ts >= t_start_base) & (
-            events_all_ts < t_end_base
-        )
+        mask_base_full = (events_all_ts >= t_start_base) & (events_all_ts < t_end_base)
         mask_base = (df_analysis["timestamp"] >= t_start_base) & (
             df_analysis["timestamp"] < t_end_base
         )
@@ -1202,10 +1198,10 @@ def main(argv=None):
             )
             baseline_live_time = 0.0
         else:
-            baseline_live_time = float((t_end_base - t_start_base) / np.timedelta64(1, "s"))
+            baseline_live_time = float((t_end_base - t_start_base).total_seconds())
         cfg.setdefault("baseline", {})["range"] = [
-            t_start_base.to_pydatetime(),
-            t_end_base.to_pydatetime(),
+            t_start_base,
+            t_end_base,
         ]
         baseline_info = {
             "start": t_start_base,


### PR DESCRIPTION
## Summary
- refactor baseline range handling to avoid timestamp round-trips

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ae9b56a98832b9f943c0a20cd2918