### PR TITLE
Fix baseline range handling

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1175,10 +1175,8 @@ def main(argv=None):
     mask_base = None
 
     if baseline_range:
-        t_start_base_sec = baseline_range[0].timestamp()
-        t_end_base_sec = baseline_range[1].timestamp()
-        t_start_base = pd.to_datetime(t_start_base_sec, unit="s", utc=True)
-        t_end_base = pd.to_datetime(t_end_base_sec, unit="s", utc=True)
+        t_start_base = baseline_range[0]
+        t_end_base = baseline_range[1]
         if t_end_base <= t_start_base:
             raise ValueError("baseline_range end time must be greater than start time")
         events_all_ts = pd.to_datetime(events_all["timestamp"], unit="s", utc=True)
@@ -1202,10 +1200,10 @@ def main(argv=None):
             )
             baseline_live_time = 0.0
         else:
-            baseline_live_time = float((t_end_base - t_start_base) / np.timedelta64(1, "s"))
+            baseline_live_time = float((t_end_base - t_start_base).total_seconds())
         cfg.setdefault("baseline", {})["range"] = [
-            t_start_base.to_pydatetime(),
-            t_end_base.to_pydatetime(),
+            t_start_base,
+            t_end_base,
         ]
         baseline_info = {
             "start": t_start_base,


### PR DESCRIPTION
## Summary
- remove timestamp conversions in baseline range logic
- store baseline datetimes directly
- compute baseline live time with `total_seconds`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae97c7a30832b8d45e82d7674d726