### PR TITLE
Use to_utc_datetime for config parsing

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -104,6 +104,7 @@ from utils import (
     adc_hist_edges,
     parse_timestamp,
     parse_time_arg,
+    to_utc_datetime,
 )
 from utils import parse_datetime
 from radmon.baseline import subtract_baseline
@@ -909,8 +910,9 @@ def main(argv=None):
     t0_cfg = cfg.get("analysis", {}).get("analysis_start_time")
     if t0_cfg is not None:
         try:
-            t0_global = parse_timestamp(t0_cfg)
-            cfg.setdefault("analysis", {})["analysis_start_time"] = t0_global
+            t0_dt = to_utc_datetime(t0_cfg)
+            t0_global = t0_dt.timestamp()
+            cfg.setdefault("analysis", {})["analysis_start_time"] = t0_dt
         except Exception:
             logging.warning(
                 f"Invalid analysis_start_time '{t0_cfg}' - using first event"
@@ -920,16 +922,17 @@ def main(argv=None):
         t0_global = events_filtered["timestamp"].min()
 
     if not isinstance(t0_global, (int, float)):
-        t0_global = parse_timestamp(t0_global)
+        t0_global = to_utc_datetime(t0_global).timestamp()
 
     t_end_cfg = cfg.get("analysis", {}).get("analysis_end_time")
     t_end_global = None
     t_end_global_ts = None
     if t_end_cfg is not None:
         try:
-            t_end_global_ts = parse_timestamp(t_end_cfg)
-            t_end_global = pd.to_datetime(t_end_global_ts, unit="s", utc=True)
-            cfg.setdefault("analysis", {})["analysis_end_time"] = t_end_global_ts
+            t_end_dt = to_utc_datetime(t_end_cfg)
+            t_end_global = t_end_dt
+            t_end_global_ts = t_end_dt.timestamp()
+            cfg.setdefault("analysis", {})["analysis_end_time"] = t_end_dt
         except Exception:
             logging.warning(
                 f"Invalid analysis_end_time '{t_end_cfg}' - using last event"
@@ -941,9 +944,9 @@ def main(argv=None):
     t_spike_end = None
     if spike_end_cfg is not None:
         try:
-            t_spike_end_ts = parse_timestamp(spike_end_cfg)
-            t_spike_end = pd.to_datetime(t_spike_end_ts, unit="s", utc=True)
-            cfg.setdefault("analysis", {})["spike_end_time"] = t_spike_end_ts
+            t_spike_end_dt = to_utc_datetime(spike_end_cfg)
+            t_spike_end = t_spike_end_dt
+            cfg.setdefault("analysis", {})["spike_end_time"] = t_spike_end_dt
         except Exception:
             logging.warning(f"Invalid spike_end_time '{spike_end_cfg}' - ignoring")
             t_spike_end = None

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -2069,8 +2069,10 @@ def test_time_fields_written_back(tmp_path, monkeypatch):
     analyze.main()
 
     used = captured.get("cfg", {})
-    assert used["analysis"]["analysis_end_time"] == 5.0
-    assert used["analysis"]["spike_end_time"] == 0.0
+    exp_end_time = datetime(1970, 1, 1, 0, 0, 5, tzinfo=timezone.utc)
+    exp_spike_end = datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    assert used["analysis"]["analysis_end_time"] == exp_end_time
+    assert used["analysis"]["spike_end_time"] == exp_spike_end
     assert used["analysis"]["spike_periods"] == [
         ["1970-01-01T00:00:02+00:00", "1970-01-01T00:00:03+00:00"]
     ]


### PR DESCRIPTION
## Summary
- parse analysis times with `to_utc_datetime` instead of `parse_timestamp`
- store parsed times as timezone-aware `datetime` objects
- update test expectations for new datetime-based config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aebb0b400832bb70249772c7d415e