### PR TITLE
Fix timestamp parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ The input file must be a comma-separated table with these columns:
 - `fUniqueID` – unique event number
 - `fBits` – status bits or flags
 - `timestamp` – event timestamp in seconds
-  (either numeric Unix seconds or an ISO‑8601 string; parsed with
-  `parse_timestamp` and converted to `numpy.datetime64[ns, UTC]` by `parse_datetime`)
+  (either numeric Unix seconds or an ISO‑8601 string; parsed to
+  `numpy.datetime64[ns, UTC]` by `parse_datetime`)
 - `adc` – raw ADC value
 - `fchannel` – acquisition channel
 

--- a/io_utils.py
+++ b/io_utils.py
@@ -296,10 +296,12 @@ def load_events(csv_path, *, column_map=None):
 
     df = df.rename(columns=rename, errors="ignore")
 
-    # Parse timestamps (epoch seconds) into timezone-aware datetimes
+    # Parse timestamps into timezone-aware datetimes in one step
     if "timestamp" in df.columns:
-        df["timestamp"] = df["timestamp"].map(parse_timestamp)
-        df["timestamp"] = pd.to_datetime(df["timestamp"], unit="s", utc=True)
+        ts = df["timestamp"].map(
+            lambda v: parse_datetime(v) if pd.notna(v) else pd.NaT
+        )
+        df["timestamp"] = ts.dt.tz_localize("UTC")
 
     # Check required columns after renaming
     required_cols = ["fUniqueID", "fBits", "timestamp", "adc", "fchannel"]


### PR DESCRIPTION
## Summary
- parse timestamps directly to timezone-aware datetimes
- update documentation for timestamp parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae9a1897c832ba4a1fbd00935715a