### PR TITLE
Update tests to use CalibrationResult

### DIFF
--- a/tests/test_analyze_noise_cutoff.py
+++ b/tests/test_analyze_noise_cutoff.py
@@ -7,6 +7,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import numpy as np
 from fitting import FitResult
+from calibration import CalibrationResult
 
 
 def test_analyze_noise_cutoff(tmp_path, monkeypatch):
@@ -38,7 +39,13 @@ def test_analyze_noise_cutoff(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {}}
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_analyze_systematics.py
+++ b/tests/test_analyze_systematics.py
@@ -7,6 +7,7 @@ import numpy as np
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 from fitting import FitResult
+from calibration import CalibrationResult
 
 
 def test_analyze_systematics_runs(tmp_path, monkeypatch):
@@ -38,7 +39,13 @@ def test_analyze_systematics_runs(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {}}
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -11,6 +11,7 @@ import baseline_noise
 import baseline
 from radon.baseline import subtract_baseline_counts
 from fitting import FitResult
+from calibration import CalibrationResult
 
 
 def test_simple_baseline_subtraction(tmp_path, monkeypatch):
@@ -43,7 +44,13 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0,0.0), "c": (0.0,0.0), "sigma_E": (1.0,0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     captured = {}
@@ -134,7 +141,13 @@ def test_baseline_scaling_factor(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({"E_Po214": 1.0}, np.zeros((1,1)), 0))
@@ -216,7 +229,13 @@ def test_n0_prior_from_baseline(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
 
@@ -300,7 +319,13 @@ def test_isotopes_to_subtract_control(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({"E_Po214": 1.0}, np.zeros((1,1)), 0))
@@ -380,12 +405,13 @@ def test_baseline_scaling_multiple_isotopes(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {
-        "a": (1.0, 0.0),
-        "c": (0.0, 0.0),
-        "sigma_E": (1.0, 0.0),
-        "peaks": {"Po210": {"centroid_adc": 10}},
-    }
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
 
@@ -494,7 +520,13 @@ def test_noise_level_none_not_recorded(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({"E_Po214": 1.0}, np.zeros((1,1)), 0))
@@ -559,7 +591,13 @@ def test_sigma_rate_uses_weighted_counts(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({"E_Po214": 1.0}, np.zeros((1,1)), 0))

--- a/tests/test_baseline_flow.py
+++ b/tests/test_baseline_flow.py
@@ -6,6 +6,7 @@ import pandas as pd
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
+from calibration import CalibrationResult
 
 
 def test_baseline_event_from_unfiltered_data(tmp_path, monkeypatch):
@@ -32,7 +33,13 @@ def test_baseline_event_from_unfiltered_data(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_baseline_noise_propagation.py
+++ b/tests/test_baseline_noise_propagation.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
 from fitting import FitResult
+from calibration import CalibrationResult
 
 
 def test_baseline_noise_propagation(tmp_path, monkeypatch):
@@ -40,7 +41,13 @@ def test_baseline_noise_propagation(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_baseline_range_cli.py
+++ b/tests/test_baseline_range_cli.py
@@ -9,6 +9,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
 from fitting import FitResult
+from calibration import CalibrationResult
 
 
 def test_baseline_range_cli_overrides_config(tmp_path, monkeypatch):
@@ -41,7 +42,13 @@ def test_baseline_range_cli_overrides_config(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_baseline_range_empty.py
+++ b/tests/test_baseline_range_empty.py
@@ -9,6 +9,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
 from fitting import FitResult
+from calibration import CalibrationResult
 
 
 def test_cli_baseline_range_empty(tmp_path, monkeypatch):
@@ -43,7 +44,13 @@ def test_cli_baseline_range_empty(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_cli_baseline_range.py
+++ b/tests/test_cli_baseline_range.py
@@ -9,6 +9,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
 from fitting import FitResult
+from calibration import CalibrationResult
 
 
 def test_cli_baseline_range_overrides_config(tmp_path, monkeypatch):
@@ -43,7 +44,13 @@ def test_cli_baseline_range_overrides_config(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_cli_baseline_range_iso.py
+++ b/tests/test_cli_baseline_range_iso.py
@@ -9,6 +9,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
 from fitting import FitResult
+from calibration import CalibrationResult
 
 
 def test_cli_baseline_range_iso_strings(tmp_path, monkeypatch):
@@ -43,7 +44,13 @@ def test_cli_baseline_range_iso_strings(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -159,7 +166,13 @@ def test_cli_baseline_range_timezone(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "write_summary", fake_write)
     monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_cli_baseline_range_override2.py
+++ b/tests/test_cli_baseline_range_override2.py
@@ -9,6 +9,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
 from fitting import FitResult
+from calibration import CalibrationResult
 
 
 def test_cli_baseline_range_overrides_config_again(tmp_path, monkeypatch):
@@ -43,7 +44,13 @@ def test_cli_baseline_range_overrides_config_again(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_noise_cut.py
+++ b/tests/test_noise_cut.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from calibration import CalibrationResult
 
 
 def test_noise_cutoff_cli_overrides(tmp_path, monkeypatch):
@@ -42,7 +43,13 @@ def test_noise_cutoff_cli_overrides(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {}}
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_noise_cutoff.py
+++ b/tests/test_noise_cutoff.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import numpy as np
 from fitting import FitResult
+from calibration import CalibrationResult
 
 
 def test_noise_cutoff_filters_events(tmp_path, monkeypatch):
@@ -39,7 +40,13 @@ def test_noise_cutoff_filters_events(tmp_path, monkeypatch):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {}}
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -107,7 +114,13 @@ def test_invalid_noise_cutoff_skips_cut(tmp_path, monkeypatch, caplog):
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {}}
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)

--- a/tests/test_sample_radon.py
+++ b/tests/test_sample_radon.py
@@ -9,6 +9,7 @@ import analyze
 import radon_activity
 import numpy as np
 from fitting import FitResult
+from calibration import CalibrationResult
 
 
 def test_total_radon_uses_sample_volume(tmp_path, monkeypatch):
@@ -36,7 +37,13 @@ def test_total_radon_uses_sample_volume(tmp_path, monkeypatch):
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -6,6 +6,7 @@ import pytest
 import numpy as np
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from fitting import FitResult
+from calibration import CalibrationResult
 
 import analyze
 import baseline_noise
@@ -41,12 +42,13 @@ def test_time_window_filters_events(tmp_path, monkeypatch):
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {
-        "a": (1.0, 0.0),
-        "c": (0.0, 0.0),
-        "sigma_E": (1.0, 0.0),
-        "peaks": {"Po210": {"centroid_adc": 10}},
-    }
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -173,12 +175,13 @@ def test_time_window_filters_events_config(tmp_path, monkeypatch):
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {
-        "a": (1.0, 0.0),
-        "c": (0.0, 0.0),
-        "sigma_E": (1.0, 0.0),
-        "peaks": {"Po210": {"centroid_adc": 10}},
-    }
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -252,12 +255,13 @@ def test_run_period_filters_events(tmp_path, monkeypatch):
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {
-        "a": (1.0, 0.0),
-        "c": (0.0, 0.0),
-        "sigma_E": (1.0, 0.0),
-        "peaks": {"Po210": {"centroid_adc": 10}},
-    }
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -339,12 +343,13 @@ def test_baseline_range_iso_strings(tmp_path, monkeypatch, start, end):
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {
-        "a": (1.0, 0.0),
-        "c": (0.0, 0.0),
-        "sigma_E": (1.0, 0.0),
-        "peaks": {"Po210": {"centroid_adc": 10}},
-    }
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -422,7 +427,13 @@ def test_unified_filter_combined_windows(tmp_path, monkeypatch):
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
-    cal_mock = {"a": (1.0, 0.0), "c": (0.0, 0.0), "sigma_E": (1.0, 0.0), "peaks": {"Po210": {"centroid_adc": 10}}}
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)


### PR DESCRIPTION
## Summary
- switch cal_mock dicts to CalibrationResult instances
- import CalibrationResult where needed
- ensure calibration mocks return proper dataclass instances

## Testing
- `pytest -k baseline_range_cli -q`

------
https://chatgpt.com/codex/tasks/task_e_685aebb80980832bbea5a7bb7d227855