### PR TITLE
Store analysis intervals as datetimes

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -953,7 +953,6 @@ def main(argv=None):
     if spike_periods_cfg is None:
         spike_periods_cfg = []
     spike_periods = []
-    spike_iso = []
     for period in spike_periods_cfg:
         try:
             start, end = period
@@ -961,20 +960,17 @@ def main(argv=None):
             end_ts = pd.to_datetime(parse_datetime(end), utc=True)
             if end_ts <= start_ts:
                 raise ValueError("end <= start")
-            spike_periods.append((start_ts, end_ts))
-            spike_iso.append((start_ts, end_ts))
+            spike_periods.append([start_ts, end_ts])
         except Exception as e:
             logging.warning(f"Invalid spike_period {period} -> {e}")
     if spike_periods:
-        cfg.setdefault("analysis", {})["spike_periods"] = [
-            [s.isoformat(), e.isoformat()] for s, e in spike_iso
-        ]
+        cfg.setdefault("analysis", {})["spike_periods"] = spike_periods
+        spike_periods_cfg = spike_periods
 
     run_periods_cfg = cfg.get("analysis", {}).get("run_periods", [])
     if run_periods_cfg is None:
         run_periods_cfg = []
     run_periods = []
-    run_iso = []
     for period in run_periods_cfg:
         try:
             start, end = period
@@ -982,14 +978,12 @@ def main(argv=None):
             end_ts = pd.to_datetime(parse_datetime(end), utc=True)
             if end_ts <= start_ts:
                 raise ValueError("end <= start")
-            run_periods.append((start_ts, end_ts))
-            run_iso.append((start_ts, end_ts))
+            run_periods.append([start_ts, end_ts])
         except Exception as e:
             logging.warning(f"Invalid run_period {period} -> {e}")
     if run_periods:
-        cfg.setdefault("analysis", {})["run_periods"] = [
-            [s.isoformat(), e.isoformat()] for s, e in run_iso
-        ]
+        cfg.setdefault("analysis", {})["run_periods"] = run_periods
+        run_periods_cfg = run_periods
 
     radon_interval_cfg = cfg.get("analysis", {}).get("radon_interval")
     radon_interval = None
@@ -1000,12 +994,9 @@ def main(argv=None):
             end_r_dt = pd.to_datetime(parse_datetime(end_r), utc=True)
             if end_r_dt <= start_r_dt:
                 raise ValueError("end <= start")
-            radon_interval = (start_r_dt, end_r_dt)
-            radon_interval_cfg = [
-                start_r_dt.isoformat(),
-                end_r_dt.isoformat(),
-            ]
-            cfg.setdefault("analysis", {})["radon_interval"] = radon_interval_cfg
+            radon_interval = [start_r_dt, end_r_dt]
+            cfg.setdefault("analysis", {})["radon_interval"] = radon_interval
+            radon_interval_cfg = radon_interval
         except Exception as e:
             logging.warning(f"Invalid radon_interval {radon_interval_cfg} -> {e}")
             radon_interval = None

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -2074,15 +2074,21 @@ def test_time_fields_written_back(tmp_path, monkeypatch):
     assert used["analysis"]["analysis_end_time"] == exp_end_time
     assert used["analysis"]["spike_end_time"] == exp_spike_end
     assert used["analysis"]["spike_periods"] == [
-        ["1970-01-01T00:00:02+00:00", "1970-01-01T00:00:03+00:00"]
+        [
+            datetime(1970, 1, 1, 0, 0, 2, tzinfo=timezone.utc),
+            datetime(1970, 1, 1, 0, 0, 3, tzinfo=timezone.utc),
+        ]
     ]
     assert used["analysis"]["run_periods"] == [
-        ["1970-01-01T00:00:00+00:00", "1970-01-01T00:00:10+00:00"]
+        [
+            datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            datetime(1970, 1, 1, 0, 0, 10, tzinfo=timezone.utc),
+        ]
     ]
 
     assert used["analysis"]["radon_interval"] == [
-        "1970-01-01T00:00:03+00:00",
-        "1970-01-01T00:00:05+00:00",
+        datetime(1970, 1, 1, 0, 0, 3, tzinfo=timezone.utc),
+        datetime(1970, 1, 1, 0, 0, 5, tzinfo=timezone.utc),
     ]
     exp_start = datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     exp_end = datetime(1970, 1, 1, 0, 0, 1, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
- keep spike/run periods and radon interval as `datetime` objects
- update tests for datetime storage

## Testing
- `pytest -k "analyze_config_merge and time_fields_written_back" -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685af042c24c832bbd02567c3d0652c0