### PR TITLE
Handle config times as datetime objects

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -102,7 +102,6 @@ from visualize import cov_heatmap, efficiency_bar
 from utils import (
     find_adc_bin_peaks,
     adc_hist_edges,
-    parse_timestamp,
     parse_time_arg,
     to_utc_datetime,
 )
@@ -216,7 +215,7 @@ def prepare_analysis_df(
     run_periods: list[tuple[pd.Timestamp, pd.Timestamp]],
     analysis_end: pd.Timestamp | int | float | None,
     *,
-    t0_global: float,
+    t0_global: datetime,
     cfg: dict,
     args,
 ) -> tuple[
@@ -224,10 +223,9 @@ def prepare_analysis_df(
     datetime,
     datetime,
     float,
-    float,
     str | None,
     Any,
-    pd.Timestamp | int | float | None,
+    datetime,
 ]:
     """Apply time window cuts and derive drift parameters."""
 
@@ -257,15 +255,14 @@ def prepare_analysis_df(
     else:
         analysis_end = df_analysis["timestamp"].max()
 
-    if not isinstance(analysis_end, (int, float)):
-        t_end_global_ts = parse_timestamp(analysis_end)
+    if isinstance(analysis_end, (int, float)):
+        analysis_end_dt = datetime.fromtimestamp(float(analysis_end), tz=timezone.utc)
     else:
-        t_end_global_ts = float(analysis_end)
+        analysis_end_dt = to_utc_datetime(analysis_end)
 
     _ensure_events(df_analysis, "time-window selection")
 
-    analysis_start = datetime.fromtimestamp(t0_global, tz=timezone.utc)
-    analysis_end_dt = datetime.fromtimestamp(t_end_global_ts, tz=timezone.utc)
+    analysis_start = to_utc_datetime(t0_global)
 
     drift_cfg = cfg.get("systematics", {})
     drift_rate = (
@@ -282,11 +279,10 @@ def prepare_analysis_df(
         df_analysis,
         analysis_start,
         analysis_end_dt,
-        t_end_global_ts,
         drift_rate,
         drift_mode,
         drift_params,
-        analysis_end,
+        analysis_end_dt,
     )
 
 
@@ -908,43 +904,34 @@ def main(argv=None):
     t0_cfg = cfg.get("analysis", {}).get("analysis_start_time")
     if t0_cfg is not None:
         try:
-            t0_dt = to_utc_datetime(t0_cfg)
-            t0_global = t0_dt.timestamp()
-            cfg.setdefault("analysis", {})["analysis_start_time"] = t0_dt
+            t0_global = to_utc_datetime(t0_cfg)
+            cfg.setdefault("analysis", {})["analysis_start_time"] = t0_global
         except Exception:
             logging.warning(
                 f"Invalid analysis_start_time '{t0_cfg}' - using first event"
             )
-            t0_global = events_filtered["timestamp"].min()
+            t0_global = to_utc_datetime(events_filtered["timestamp"].min())
     else:
-        t0_global = events_filtered["timestamp"].min()
-
-    if not isinstance(t0_global, (int, float)):
-        t0_global = to_utc_datetime(t0_global).timestamp()
+        t0_global = to_utc_datetime(events_filtered["timestamp"].min())
 
     t_end_cfg = cfg.get("analysis", {}).get("analysis_end_time")
     t_end_global = None
-    t_end_global_ts = None
     if t_end_cfg is not None:
         try:
-            t_end_dt = to_utc_datetime(t_end_cfg)
-            t_end_global = t_end_dt
-            t_end_global_ts = t_end_dt.timestamp()
-            cfg.setdefault("analysis", {})["analysis_end_time"] = t_end_dt
+            t_end_global = to_utc_datetime(t_end_cfg)
+            cfg.setdefault("analysis", {})["analysis_end_time"] = t_end_global
         except Exception:
             logging.warning(
                 f"Invalid analysis_end_time '{t_end_cfg}' - using last event"
             )
             t_end_global = None
-            t_end_global_ts = None
 
     spike_end_cfg = cfg.get("analysis", {}).get("spike_end_time")
     t_spike_end = None
     if spike_end_cfg is not None:
         try:
-            t_spike_end_dt = to_utc_datetime(spike_end_cfg)
-            t_spike_end = t_spike_end_dt
-            cfg.setdefault("analysis", {})["spike_end_time"] = t_spike_end_dt
+            t_spike_end = to_utc_datetime(spike_end_cfg)
+            cfg.setdefault("analysis", {})["spike_end_time"] = t_spike_end
         except Exception:
             logging.warning(f"Invalid spike_end_time '{spike_end_cfg}' - ignoring")
             t_spike_end = None
@@ -1014,7 +1001,6 @@ def main(argv=None):
         df_analysis,
         analysis_start,
         analysis_end,
-        t_end_global_ts,
         drift_rate,
         drift_mode,
         drift_params,
@@ -1037,7 +1023,7 @@ def main(argv=None):
                 df_analysis["adc"].values,
                 ts_seconds,
                 float(drift_rate),
-                t_ref=t0_global,
+                t_ref=t0_global.timestamp(),
                 mode=drift_mode,
                 params=drift_params,
             )
@@ -1465,7 +1451,7 @@ def main(argv=None):
                 continue
 
             first_ts = pd.to_datetime(iso_events["timestamp"].iloc[0], utc=True)
-            t0_dt = datetime.fromtimestamp(t0_global, tz=timezone.utc)
+            t0_dt = t0_global
             settle = timedelta(seconds=float(args.settle_s or 0))
             t_start_fit_dt = max(first_ts, t0_dt + settle)
             t_start_map[iso] = t_start_fit_dt
@@ -1587,8 +1573,7 @@ def main(argv=None):
 
         # Build configuration for fit_time_series
         if args.settle_s is not None:
-            t0_dt = datetime.fromtimestamp(t0_global, tz=timezone.utc)
-            cut = t0_dt + timedelta(seconds=float(args.settle_s))
+            cut = t0_global + timedelta(seconds=float(args.settle_s))
             iso_events = iso_events[iso_events["timestamp"] >= cut]
         ts_vals = iso_events["timestamp"]
         if pd.api.types.is_datetime64_any_dtype(ts_vals):
@@ -1623,12 +1608,12 @@ def main(argv=None):
             if isinstance(t_start_val, datetime):
                 t_start_fit = t_start_val.timestamp()
             else:
-                t_start_fit = float(t_start_val if t_start_val is not None else t0_global)
+                t_start_fit = (t_start_val or t0_global).timestamp()
             try:
                 decay_out = fit_time_series(
                     times_dict,
                     t_start_fit,
-                    t_end_global_ts,
+                    analysis_end.timestamp(),
                     fit_cfg,
                     weights=weights_map,
                     strict=args.strict_covariance,
@@ -1637,7 +1622,7 @@ def main(argv=None):
                 decay_out = fit_time_series(
                     times_dict,
                     t_start_fit,
-                    t_end_global_ts,
+                    analysis_end.timestamp(),
                     fit_cfg,
                     strict=args.strict_covariance,
                 )
@@ -1659,7 +1644,7 @@ def main(argv=None):
         mask210 = (
             (df_analysis["energy_MeV"] >= lo)
             & (df_analysis["energy_MeV"] <= hi)
-            & (df_analysis["timestamp"] >= pd.to_datetime(t0_global, unit="s", utc=True))
+            & (df_analysis["timestamp"] >= t0_global)
             & (df_analysis["timestamp"] <= t_end_global)
         )
         events_p210 = df_analysis[mask210]
@@ -1727,8 +1712,8 @@ def main(argv=None):
                 try:
                     out = fit_time_series(
                         times_dict,
-                        t0_global,
-                        t_end_global_ts,
+                        t0_global.timestamp(),
+                        analysis_end.timestamp(),
                         cfg_fit,
                         weights=weights_local,
                         strict=args.strict_covariance,
@@ -1736,8 +1721,8 @@ def main(argv=None):
                 except TypeError:
                     out = fit_time_series(
                         times_dict,
-                        t0_global,
-                        t_end_global_ts,
+                        t0_global.timestamp(),
+                        analysis_end.timestamp(),
                         cfg_fit,
                         strict=args.strict_covariance,
                     )
@@ -2140,7 +2125,10 @@ def main(argv=None):
                         fit_dict.update(_fit_params(obj))
 
             centers, widths = _ts_bin_centers_widths(
-                ts_times, plot_cfg, t0_global, t_end_global_ts
+                ts_times,
+                plot_cfg,
+                t0_global.timestamp(),
+                analysis_end.timestamp(),
             )
             normalise = bool(plot_cfg.get("plot_time_normalise_rate", False))
             model_errs = {}
@@ -2160,8 +2148,8 @@ def main(argv=None):
                 all_timestamps=ts_times,
                 all_energies=ts_energy,
                 fit_results=fit_dict,
-                t_start=t0_global,
-                t_end=t_end_global_ts,
+                t_start=t0_global.timestamp(),
+                t_end=analysis_end.timestamp(),
                 config=plot_cfg,
                 out_png=Path(out_dir) / f"time_series_{iso}.png",
                 model_errors=model_errs,
@@ -2194,7 +2182,7 @@ def main(argv=None):
     try:
         from radon_activity import radon_activity_curve
 
-        times = np.linspace(t0_global, t_end_global_ts, 100)
+        times = np.linspace(t0_global.timestamp(), analysis_end.timestamp(), 100)
         times_dt = pd.to_datetime(times, unit="s", utc=True)
         t_rel = (times_dt - analysis_start).total_seconds()
 


### PR DESCRIPTION
## Summary
- keep analysis time settings as `datetime` objects
- remove unused `parse_timestamp` import and use `to_utc_datetime`
- adjust `prepare_analysis_df` to work with datetimes
- convert to epoch seconds only where required

## Testing
- `python -m py_compile analyze.py`
- `pytest -q` *(fails: Package 'numpy' is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_685af0487a2c832b9fcc16543b34bb90