### PR TITLE
Remove redundant radmon baseline wrapper

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -106,7 +106,7 @@ from utils import (
     to_utc_datetime,
 )
 from utils import parse_datetime
-from radmon.baseline import subtract_baseline
+from baseline import subtract_baseline
 from radon.baseline import subtract_baseline_counts, subtract_baseline_rate
 
 

--- a/radmon/__init__.py
+++ b/radmon/__init__.py
@@ -1,3 +1,3 @@
 """Helper package exposing baseline utilities."""
-from .baseline import subtract_baseline
+from baseline import subtract_baseline
 __all__ = ["subtract_baseline"]

--- a/radmon/baseline.py
+++ b/radmon/baseline.py
@@ -1,2 +1,0 @@
-from baseline import subtract_baseline
-__all__ = ["subtract_baseline"]


### PR DESCRIPTION
## Summary
- drop `radmon/baseline.py`
- import `baseline.subtract_baseline` directly in `analyze.py`
- update `radmon/__init__` to import from `baseline`

## Testing
- `bash scripts/setup_tests.sh`
- `pytest -k baseline -q`

------
https://chatgpt.com/codex/tasks/task_e_685afcf5ff3c832ba3953f0ce58d3117