### PR TITLE
Add helper for calibration covariance lookup

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1112,19 +1112,36 @@ def main(argv=None):
         from calibration import CalibrationResult
 
         assert isinstance(cal_params, CalibrationResult)
-        coeffs = cal_params.coeffs
-        cov = np.asarray(cal_params.cov, dtype=float)
-        c = coeffs[0]
-        a = coeffs[1]
-        a2 = coeffs[2] if len(coeffs) == 3 else 0.0
-        c_sig = float(np.sqrt(cov[0, 0]))
-        a_sig = float(np.sqrt(cov[1, 1]))
-        a2_sig = float(np.sqrt(cov[2, 2])) if cov.shape[0] == 3 else 0.0
+        idx = {exp: i for i, exp in enumerate(cal_params._exponents)}
+        c = cal_params.coeffs[idx.get(0, 0)] if 0 in idx else 0.0
+        a = cal_params.coeffs[idx.get(1, 0)] if 1 in idx else 0.0
+        a2 = cal_params.coeffs[idx.get(2, 0)] if 2 in idx else 0.0
         sigE_mean = cal_params.sigma_E
         sigE_sigma = cal_params.sigma_E_error
-        cov_ac = float(cov[1, 0])
-        cov_a_a2 = float(cov[1, 2]) if cov.shape[0] == 3 else 0.0
-        cov_a2_c = float(cov[2, 0]) if cov.shape[0] == 3 else 0.0
+        try:
+            c_sig = float(np.sqrt(cal_params.get_cov("c", "c")))
+        except KeyError:
+            c_sig = 0.0
+        try:
+            a_sig = float(np.sqrt(cal_params.get_cov("a", "a")))
+        except KeyError:
+            a_sig = 0.0
+        try:
+            a2_sig = float(np.sqrt(cal_params.get_cov("a2", "a2")))
+        except KeyError:
+            a2_sig = 0.0
+        try:
+            cov_ac = cal_params.get_cov("a", "c")
+        except KeyError:
+            cov_ac = 0.0
+        try:
+            cov_a_a2 = cal_params.get_cov("a", "a2")
+        except KeyError:
+            cov_a_a2 = 0.0
+        try:
+            cov_a2_c = cal_params.get_cov("a2", "c")
+        except KeyError:
+            cov_a2_c = 0.0
 
     # Apply calibration -> new column “energy_MeV” and its uncertainty
     energies = cal_result.predict(df_analysis["adc"])

--- a/tests/test_calibration_get_cov.py
+++ b/tests/test_calibration_get_cov.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from calibration import CalibrationResult
+
+
+def test_get_cov_by_name_and_exponent():
+    cov = np.array([
+        [1.0, 0.1, 0.2],
+        [0.1, 4.0, 0.3],
+        [0.2, 0.3, 9.0],
+    ])
+    calib = CalibrationResult(coeffs=[0.0, 1.0, 2.0], cov=cov)
+    assert calib.get_cov("c", "a") == pytest.approx(0.1)
+    assert calib.get_cov(2, "c") == pytest.approx(0.2)
+    assert calib.get_cov("a", 2) == pytest.approx(0.3)
+
+
+def test_get_cov_missing():
+    cov = np.eye(2)
+    calib = CalibrationResult(coeffs=[1.0, 2.0], cov=cov)
+    with pytest.raises(KeyError):
+        calib.get_cov("a2", "a")
+


### PR DESCRIPTION
## Summary
- introduce `CalibrationResult.get_cov` to query covariance by name or exponent
- use `get_cov` in `analyze._as_cal_result` logic
- provide tests for the new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685afcea7160832b8236cfc1e0e3a55c