### PR TITLE
Move scaling factor to shared utilities

### DIFF
--- a/baseline.py
+++ b/baseline.py
@@ -3,52 +3,8 @@ import logging
 import pandas as pd
 from utils import parse_datetime
 
+from baseline_utils import _scaling_factor
 __all__ = ["rate_histogram", "subtract_baseline"]
-
-
-def _scaling_factor(dt_window: float, dt_baseline: float,
-                    err_window: float = 0.0,
-                    err_baseline: float = 0.0) -> tuple[float, float]:
-    """Return scaling factor between analysis and baseline durations.
-
-    This helper computes ``dt_window / dt_baseline`` and propagates the
-    1-sigma uncertainty from ``err_window`` and ``err_baseline`` assuming they
-    are independent.  A ``ValueError`` is raised when ``dt_baseline`` is zero
-    to avoid division by zero.
-
-    Parameters
-    ----------
-    dt_window : float
-        Duration of the analysis window in seconds.
-    dt_baseline : float
-        Duration of the baseline interval in seconds.
-    err_window : float, optional
-        Uncertainty on ``dt_window``. Default is ``0.0``.
-    err_baseline : float, optional
-        Uncertainty on ``dt_baseline``. Default is ``0.0``.
-
-    Returns
-    -------
-    float
-        The scaling factor ``dt_window / dt_baseline``.
-    float
-        Propagated uncertainty on the scaling factor.
-
-    Examples
-    --------
-    >>> _scaling_factor(10.0, 5.0)
-    (2.0, 0.0)
-    >>> _scaling_factor(10.0, 5.0, 0.1, 0.2)
-    (2.0, 0.0894427191)
-    """
-
-    if dt_baseline == 0:
-        raise ValueError("dt_baseline must be non-zero")
-
-    scale = float(dt_window) / float(dt_baseline)
-    var = (err_window / dt_baseline) ** 2
-    var += ((dt_window * err_baseline) / dt_baseline**2) ** 2
-    return scale, float(np.sqrt(var))
 
 
 def _seconds(col):

--- a/baseline_utils.py
+++ b/baseline_utils.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+__all__ = ["_scaling_factor"]
+
+
+def _scaling_factor(dt_window: float, dt_baseline: float,
+                    err_window: float = 0.0,
+                    err_baseline: float = 0.0) -> tuple[float, float]:
+    """Return scaling factor between analysis and baseline durations.
+
+    This helper computes ``dt_window / dt_baseline`` and propagates the
+    1-sigma uncertainty from ``err_window`` and ``err_baseline`` assuming they
+    are independent.  A ``ValueError`` is raised when ``dt_baseline`` is zero
+    to avoid division by zero.
+    """
+
+    if dt_baseline == 0:
+        raise ValueError("dt_baseline must be non-zero")
+
+    scale = float(dt_window) / float(dt_baseline)
+    var = (err_window / dt_baseline) ** 2
+    var += ((dt_window * err_baseline) / dt_baseline**2) ** 2
+    return scale, float(np.sqrt(var))

--- a/radon/baseline.py
+++ b/radon/baseline.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from baseline import _scaling_factor
+from baseline_utils import _scaling_factor
 
 __all__ = ["subtract_baseline_counts", "subtract_baseline_rate"]
 

--- a/tests/test_scaling_factor.py
+++ b/tests/test_scaling_factor.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-import baseline
+import baseline_utils as baseline
 
 
 def test_scaling_factor_basic():


### PR DESCRIPTION
## Summary
- create `baseline_utils.py` with `_scaling_factor`
- use `_scaling_factor` from `baseline_utils` in `baseline.py` and `radon/baseline.py`
- update scaling factor tests to import the new module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685afcf74644832b931cfed4f9c9a844