### PR TITLE
Use timezone-aware datetimes

### DIFF
--- a/tests/test_baseline_datetime.py
+++ b/tests/test_baseline_datetime.py
@@ -35,4 +35,5 @@ def test_subtract_baseline_datetime_column():
     )
     integral = out["subtracted_adc_hist"].iloc[0].sum()
     assert integral == pytest.approx(0.0, rel=1e-6)
+    assert out["timestamp"].dtype == "datetime64[ns, UTC]"
 

--- a/tests/test_baseline_subtract.py
+++ b/tests/test_baseline_subtract.py
@@ -27,6 +27,7 @@ def test_baseline_none():
     hist_before, _ = baseline.rate_histogram(df, bins)
     hist_after, _ = baseline.rate_histogram(out, bins)
     assert np.allclose(hist_before, hist_after)
+    assert out["timestamp"].dtype == "datetime64[ns, UTC]"
 
 
 def test_baseline_time_norm():
@@ -50,6 +51,7 @@ def test_baseline_time_norm():
     )
     integral = out["subtracted_adc_hist"].iloc[0].sum()
     assert integral == pytest.approx(0.0, rel=1e-6)
+    assert out["timestamp"].dtype == "datetime64[ns, UTC]"
 
 
 def test_baseline_none_datetime():
@@ -69,6 +71,7 @@ def test_baseline_none_datetime():
     hist_before, _ = baseline.rate_histogram(df, bins)
     hist_after, _ = baseline.rate_histogram(out, bins)
     assert np.allclose(hist_before, hist_after)
+    assert out["timestamp"].dtype == "datetime64[ns, UTC]"
 
 
 def test_baseline_time_norm_datetime():
@@ -92,4 +95,5 @@ def test_baseline_time_norm_datetime():
     )
     integral = out["subtracted_adc_hist"].iloc[0].sum()
     assert integral == pytest.approx(0.0, rel=1e-6)
+    assert out["timestamp"].dtype == "datetime64[ns, UTC]"
 

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -81,11 +81,9 @@ def test_load_events(tmp_path, caplog):
     df.to_csv(p, index=False)
     with caplog.at_level(logging.INFO):
         loaded = load_events(p)
-    assert loaded["timestamp"].dtype == "datetime64[ns]"
-    expected_ts = np.array(
-        [parse_datetime(t) for t in (1000, 1005, 1010)], dtype="datetime64[ns]"
-    )
-    assert np.array_equal(loaded["timestamp"].values, expected_ts)
+    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
+    expected_ts = [parse_datetime(t) for t in (1000, 1005, 1010)]
+    assert list(loaded["timestamp"]) == expected_ts
     assert np.array_equal(loaded["adc"].values, np.array([1200, 1300, 1250]))
     assert "0 discarded" in caplog.text
 
@@ -105,11 +103,9 @@ def test_load_events_drop_bad_rows(tmp_path, caplog):
     with caplog.at_level(logging.INFO):
         loaded = load_events(p)
     # Expect rows with NaN/inf removed and duplicate dropped
-    assert loaded["timestamp"].dtype == "datetime64[ns]"
-    expected_ts = np.array(
-        [parse_datetime(t) for t in (1000, 1005, 1020)], dtype="datetime64[ns]"
-    )
-    assert np.array_equal(loaded["timestamp"].values, expected_ts)
+    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
+    expected_ts = [parse_datetime(t) for t in (1000, 1005, 1020)]
+    assert list(loaded["timestamp"]) == expected_ts
     assert "3 discarded" in caplog.text
 
 
@@ -126,7 +122,7 @@ def test_load_events_column_aliases(tmp_path):
     p = tmp_path / "alias.csv"
     df.to_csv(p, index=False)
     loaded = load_events(p)
-    assert loaded["timestamp"].dtype == "datetime64[ns]"
+    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
     assert list(loaded["timestamp"])[0] == pd.Timestamp(parse_datetime(1000))
     assert list(loaded["adc"])[0] == 1250
     assert "time" not in loaded.columns

--- a/tests/test_parse_datetime.py
+++ b/tests/test_parse_datetime.py
@@ -5,55 +5,56 @@ import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+import pandas as pd
 from utils import parse_datetime
 
 
 def test_parse_datetime_iso_string():
     ts = parse_datetime("1970-01-01T00:00:00Z")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_numeric():
     ts = parse_datetime(42)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64(42, "s")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp(42, unit="s", tz="UTC")
 
 
 def test_parse_datetime_numeric_str():
     ts = parse_datetime("42")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64(42, "s")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp(42, unit="s", tz="UTC")
 
 
 def test_parse_datetime_naive_datetime():
     dt = datetime(1970, 1, 1)
     ts = parse_datetime(dt)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_float():
     ts = parse_datetime(42.5)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:42.500000000")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp(42.5, unit="s", tz="UTC")
 
 
 def test_parse_datetime_iso_without_tz():
     ts = parse_datetime("1970-01-01T00:00:00")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_iso_with_offset():
     ts = parse_datetime("1970-01-01T01:00:00+01:00")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_datetime_with_tz():
     dt = datetime(1970, 1, 1, 1, tzinfo=timezone(timedelta(hours=1)))
     ts = parse_datetime(dt)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 

--- a/utils.py
+++ b/utils.py
@@ -252,13 +252,13 @@ def to_utc_datetime(value, tz="UTC") -> datetime:
 
 
 def parse_datetime(value):
-    """Parse an ISO-8601 string or numeric epoch value to ``numpy.datetime64``.
+    """Parse an ISO-8601 string or numeric epoch value to ``datetime64[ns, UTC]``.
 
-    The function accepts strings like ``"2023-09-28T13:45:00-04:00"`` or
-    numeric Unix timestamps (as ``int``, ``float`` or numeric ``str``). Any
-    parsed time lacking a timezone is interpreted as UTC. On success a
-    ``numpy.datetime64`` object in UTC (nanosecond resolution) is returned.
-    ``ValueError`` is raised if the input cannot be parsed.
+    The function accepts strings like ``"2023-09-28T13:45:00-04:00"`` or numeric
+    Unix timestamps (as ``int``, ``float`` or numeric ``str``). Any parsed time
+    lacking a timezone is interpreted as UTC.  The returned value is a
+    timezone-aware :class:`pandas.Timestamp` which preserves nanosecond
+    precision. ``ValueError`` is raised if the input cannot be parsed.
     """
 
     try:
@@ -269,7 +269,8 @@ def parse_datetime(value):
     if pd is None:
         raise RuntimeError("pandas is required for parse_datetime")
 
-    return pd.Timestamp(dt).to_datetime64()
+    # Retain timezone information so callers receive ``datetime64[ns, UTC]``
+    return pd.Timestamp(dt)
 
 
 def parse_time(s, tz="UTC") -> float:


### PR DESCRIPTION
## Summary
- keep timestamps as `datetime64[ns, UTC]`
- rename `_seconds` to `_to_datetime64`
- return timezone-aware values from `parse_datetime`
- update baseline subtraction to normalise timestamp types
- adjust tests for timezone-aware datetimes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685afe301930832bba39887e923a0059