### PR TITLE
Introduce FitParams TypedDict

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -56,7 +56,7 @@ import hashlib
 import json
 from pathlib import Path
 import shutil
-from typing import Any
+from typing import Any, Mapping
 
 import math
 import numpy as np
@@ -80,7 +80,7 @@ from calibration import (
     apply_calibration,
 )
 
-from fitting import fit_spectrum, fit_time_series, FitResult
+from fitting import fit_spectrum, fit_time_series, FitResult, FitParams
 
 from constants import (
     DEFAULT_NOISE_CUTOFF,
@@ -110,12 +110,12 @@ from radmon.baseline import subtract_baseline
 from radon.baseline import subtract_baseline_counts, subtract_baseline_rate
 
 
-def _fit_params(obj):
-    """Return fit parameters dictionary from either a FitResult or mapping."""
+def _fit_params(obj: FitResult | Mapping[str, float] | None) -> FitParams:
+    """Return fit parameters mapping from a ``FitResult`` or dictionary."""
     if isinstance(obj, FitResult):
         return obj.params
-    if isinstance(obj, dict):
-        return obj
+    if isinstance(obj, Mapping):
+        return obj  # type: ignore[return-value]
     return {}
 
 

--- a/fitting.py
+++ b/fitting.py
@@ -5,6 +5,7 @@
 import logging
 import warnings
 from dataclasses import dataclass
+from typing import TypedDict, NotRequired
 
 import numpy as np
 from iminuit import Minuit
@@ -16,11 +17,63 @@ from constants import _TAU_MIN, CURVE_FIT_MAX_EVALS, safe_exp as _safe_exp
 __all__ = ["fit_time_series", "fit_decay", "fit_spectrum"]
 
 
+class FitParams(TypedDict, total=False):
+    """Typed mapping of fit parameter names to values."""
+
+    # Time-series parameters
+    E_Po214: NotRequired[float]
+    dE_Po214: NotRequired[float]
+    B_Po214: NotRequired[float]
+    dB_Po214: NotRequired[float]
+    N0_Po214: NotRequired[float]
+    dN0_Po214: NotRequired[float]
+
+    E_Po218: NotRequired[float]
+    dE_Po218: NotRequired[float]
+    B_Po218: NotRequired[float]
+    dB_Po218: NotRequired[float]
+    N0_Po218: NotRequired[float]
+    dN0_Po218: NotRequired[float]
+
+    E_corrected: NotRequired[float]
+    dE_corrected: NotRequired[float]
+
+    cov_E_Po214_N0_Po214: NotRequired[float]
+    fit_valid: NotRequired[bool]
+
+    # Spectrum parameters
+    sigma0: NotRequired[float]
+    dsigma0: NotRequired[float]
+    F: NotRequired[float]
+    dF: NotRequired[float]
+    mu_Po210: NotRequired[float]
+    dmu_Po210: NotRequired[float]
+    S_Po210: NotRequired[float]
+    dS_Po210: NotRequired[float]
+    mu_Po218: NotRequired[float]
+    dmu_Po218: NotRequired[float]
+    S_Po218: NotRequired[float]
+    dS_Po218: NotRequired[float]
+    tau_Po218: NotRequired[float]
+    dtau_Po218: NotRequired[float]
+    mu_Po214: NotRequired[float]
+    dmu_Po214: NotRequired[float]
+    S_Po214: NotRequired[float]
+    dS_Po214: NotRequired[float]
+    tau_Po214: NotRequired[float]
+    dtau_Po214: NotRequired[float]
+    tau_Po210: NotRequired[float]
+    dtau_Po210: NotRequired[float]
+    b0: NotRequired[float]
+    db0: NotRequired[float]
+    b1: NotRequired[float]
+    db1: NotRequired[float]
+
 @dataclass
 class FitResult:
     """Container for fit output."""
 
-    params: dict[str, float]
+    params: FitParams
     cov: np.ndarray
     ndf: int
 

--- a/tests/test_adc_drift.py
+++ b/tests/test_adc_drift.py
@@ -7,7 +7,7 @@ import numpy as np
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 from calibration import CalibrationResult
-from fitting import FitResult
+from fitting import FitResult, FitParams
 
 
 def _write_basic(tmp_path, drift_rate, mode="linear", params=None):
@@ -64,7 +64,7 @@ def test_adc_drift_applied(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "apply_linear_adc_shift", fake_shift)
     monkeypatch.setattr(analyze, "derive_calibration_constants", fake_cal)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", fake_cal)
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
 
@@ -118,7 +118,7 @@ def test_adc_drift_zero_noop(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "apply_linear_adc_shift", fake_shift)
     monkeypatch.setattr(analyze, "derive_calibration_constants", fake_cal)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", fake_cal)
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
 
@@ -178,7 +178,7 @@ def test_adc_drift_quadratic_cfg(tmp_path, monkeypatch):
         "derive_calibration_constants_auto",
         lambda *a, **k: cal_mock,
     )
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "write_summary", lambda *a, **k: Path(a[0]).mkdir(exist_ok=True) or str(a[0]))
@@ -232,7 +232,7 @@ def test_adc_drift_piecewise_cfg(tmp_path, monkeypatch):
         "derive_calibration_constants_auto",
         lambda *a, **k: cal_mock,
     )
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "write_summary", lambda *a, **k: Path(a[0]).mkdir(exist_ok=True) or str(a[0]))
@@ -272,7 +272,7 @@ def test_adc_drift_warning_on_failure(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(analyze, "apply_linear_adc_shift", bad_shift)
     monkeypatch.setattr(analyze, "derive_calibration_constants", fake_cal)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", fake_cal)
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
 

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -9,7 +9,7 @@ import logging
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 from calibration import CalibrationResult
-from fitting import FitResult
+from fitting import FitResult, FitParams
 
 
 def test_plot_time_series_receives_merged_config(tmp_path, monkeypatch):
@@ -52,9 +52,29 @@ def test_plot_time_series_receives_merged_config(tmp_path, monkeypatch):
     df.to_csv(data_path, index=False)
 
     # Patch heavy functions with no-op versions
-    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants",
+        lambda *a, **k: CalibrationResult(
+            coeffs=[0.0, 1.0],
+            cov=np.zeros((2, 2)),
+            peaks={},
+            sigma_E=1.0,
+            sigma_E_error=0.0,
+        ),
+    )
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants_auto",
+        lambda *a, **k: CalibrationResult(
+            coeffs=[0.0, 1.0],
+            cov=np.zeros((2, 2)),
+            peaks={},
+            sigma_E=1.0,
+            sigma_E_error=0.0,
+        ),
+    )
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
 
     received = {}
@@ -126,7 +146,7 @@ def test_analysis_start_time_applied(tmp_path, monkeypatch):
 
     def fake_fit_time_series(times_dict, t_start, t_end, config, **kwargs):
         captured["t_start"] = t_start
-        return FitResult({}, np.zeros((0, 0)), 0)
+        return FitResult(FitParams({}), np.zeros((0, 0)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit_time_series)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -188,7 +208,7 @@ def test_job_id_overrides_results_folder(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "apply_burst_filter", lambda df, cfg, mode="rate": (df, 0))
@@ -252,7 +272,7 @@ def test_efficiency_json_cli(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
 
@@ -309,7 +329,7 @@ def test_systematics_json_cli(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
 
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({"E":0.0}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({"E":0.0}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -364,7 +384,7 @@ def test_time_bin_cli(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
 
     captured = {}
@@ -470,7 +490,7 @@ def test_po210_time_series_plot_generated(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
 
     outputs = []
@@ -519,7 +539,7 @@ def test_spike_count_cli(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
 
@@ -586,7 +606,7 @@ def test_spike_count_single_call(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
 
@@ -645,7 +665,7 @@ def test_assay_efficiency_list(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -726,7 +746,7 @@ def test_spike_efficiency_list(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -803,7 +823,7 @@ def test_debug_flag_sets_log_level(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
 
@@ -868,7 +888,7 @@ def test_settle_s_cli(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, config, **kwargs):
         captured["times"] = ts_dict["Po214"].tolist()
-        return FitResult({}, np.zeros((0, 0)), 0)
+        return FitResult(FitParams({}), np.zeros((0, 0)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
@@ -908,7 +928,7 @@ def test_settle_s_summary(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -980,7 +1000,7 @@ def test_analysis_end_time_cli(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, config, **kwargs):
         captured["times"] = ts_dict["Po214"].tolist()
-        return FitResult({}, np.zeros((0, 0)), 0)
+        return FitResult(FitParams({}), np.zeros((0, 0)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
@@ -1039,7 +1059,7 @@ def test_analysis_start_time_cli(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, config, **kwargs):
         captured["t_start"] = t_start
-        return FitResult({}, np.zeros((0, 0)), 0)
+        return FitResult(FitParams({}), np.zeros((0, 0)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
@@ -1098,7 +1118,7 @@ def test_spike_end_time_cli(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, config, **kwargs):
         captured["times"] = ts_dict["Po214"].tolist()
-        return FitResult({}, np.zeros((0, 0)), 0)
+        return FitResult(FitParams({}), np.zeros((0, 0)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
@@ -1157,7 +1177,7 @@ def test_spike_period_cli(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, config, **kwargs):
         captured["times"] = ts_dict["Po214"].tolist()
-        return FitResult({}, np.zeros((0, 0)), 0)
+        return FitResult(FitParams({}), np.zeros((0, 0)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
@@ -1219,7 +1239,7 @@ def test_seed_cli_sets_random_seed(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -1272,7 +1292,7 @@ def test_ambient_concentration_recorded(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -1332,7 +1352,7 @@ def test_ambient_concentration_from_config(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -1398,7 +1418,7 @@ def test_ambient_file_interpolation(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -1479,7 +1499,7 @@ def test_burst_mode_from_config(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "apply_burst_filter", fake_burst)
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -1527,7 +1547,7 @@ def test_burst_mode_micro_config(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "apply_burst_filter", fake_burst)
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -1575,7 +1595,7 @@ def test_burst_mode_cli_overrides(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "apply_burst_filter", fake_burst)
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -1618,7 +1638,7 @@ def test_burst_mode_summary_config(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "apply_burst_filter", lambda df, cfg, mode="rate": (df, 0))
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -1696,7 +1716,7 @@ def test_burst_filter_auto_disabled(tmp_path, monkeypatch):
         lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0),
     )
     monkeypatch.setattr(
-        analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0, 0)), 0)
+        analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0, 0)), 0)
     )
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
@@ -1737,7 +1757,7 @@ def test_ambient_concentration_default_none(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -1789,7 +1809,7 @@ def test_ambient_concentration_written_to_summary_file(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -1854,7 +1874,7 @@ def test_spike_periods_null_config(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
 
@@ -1922,7 +1942,7 @@ def test_hl_po214_cli_overrides(tmp_path, monkeypatch):
     def fake_fit(ts_dict, t_start, t_end, config, **kwargs):
         iso = list(ts_dict.keys())[0]
         calls.append((iso, config))
-        return FitResult({}, np.zeros((0, 0)), 0)
+        return FitResult(FitParams({}), np.zeros((0, 0)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
@@ -1979,7 +1999,7 @@ def test_hl_po210_default_used(tmp_path, monkeypatch):
         return None
 
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0, 0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0, 0)), 0))
     monkeypatch.setattr(analyze, "plot_time_series", fake_plot_time_series)
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
     monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
@@ -2048,7 +2068,7 @@ def test_time_fields_written_back(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0, 0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0, 0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())

--- a/tests/test_analyze_noise_cutoff.py
+++ b/tests/test_analyze_noise_cutoff.py
@@ -6,7 +6,7 @@ import pandas as pd
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import numpy as np
-from fitting import FitResult
+from fitting import FitResult, FitParams
 
 
 def test_analyze_noise_cutoff(tmp_path, monkeypatch):
@@ -57,7 +57,7 @@ def test_analyze_noise_cutoff(tmp_path, monkeypatch):
 
     def fake_fit_time_series(times_dict, t_start, t_end, cfg, weights=None, **kwargs):
         captured["fit_times"] = list(times_dict.get("Po214", []))
-        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
+        return FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit_time_series)
 

--- a/tests/test_analyze_systematics.py
+++ b/tests/test_analyze_systematics.py
@@ -6,7 +6,7 @@ import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
-from fitting import FitResult
+from fitting import FitResult, FitParams
 
 
 def test_analyze_systematics_runs(tmp_path, monkeypatch):
@@ -50,7 +50,7 @@ def test_analyze_systematics_runs(tmp_path, monkeypatch):
     monkeypatch.setattr(
         analyze,
         "fit_time_series",
-        lambda *a, **k: FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0),
+        lambda *a, **k: FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1, 1)), 0),
     )
 
     called = {}

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -11,7 +11,7 @@ import baseline_noise
 from calibration import CalibrationResult
 import baseline
 from radon.baseline import subtract_baseline_counts
-from fitting import FitResult
+from fitting import FitResult, FitParams
 
 
 def test_simple_baseline_subtraction(tmp_path, monkeypatch):
@@ -57,7 +57,7 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
 
     def fake_fit_time_series(times_dict, t_start, t_end, cfg, **kwargs):
         captured["times"] = times_dict.get("Po214")
-        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
+        return FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit_time_series)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -150,7 +150,7 @@ def test_baseline_scaling_factor(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({"E_Po214": 1.0}, np.zeros((1,1)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1,1)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -242,7 +242,7 @@ def test_n0_prior_from_baseline(tmp_path, monkeypatch):
     captured = {}
 
     def fake_fit_time_series(times_dict, t_start, t_end, cfg, **kwargs):
-        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
+        return FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit_time_series)
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
@@ -328,7 +328,7 @@ def test_isotopes_to_subtract_control(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({"E_Po214": 1.0}, np.zeros((1,1)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1,1)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -529,7 +529,7 @@ def test_noise_level_none_not_recorded(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({"E_Po214": 1.0}, np.zeros((1,1)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1,1)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -600,7 +600,7 @@ def test_sigma_rate_uses_weighted_counts(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({"E_Po214": 1.0}, np.zeros((1,1)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1,1)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())

--- a/tests/test_baseline_noise_propagation.py
+++ b/tests/test_baseline_noise_propagation.py
@@ -8,7 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
 from calibration import CalibrationResult
-from fitting import FitResult
+from fitting import FitResult, FitParams
 
 
 def test_baseline_noise_propagation(tmp_path, monkeypatch):
@@ -63,7 +63,7 @@ def test_baseline_noise_propagation(tmp_path, monkeypatch):
         return None, {}
 
     monkeypatch.setattr(baseline_noise, "estimate_baseline_noise", fake_baseline_noise)
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({"E_Po214": 1.0}, np.zeros((1,1)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1,1)), 0))
 
     def fake_write(out_dir, summary, timestamp=None):
         captured["summary"] = summary

--- a/tests/test_baseline_range_cli.py
+++ b/tests/test_baseline_range_cli.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
-from fitting import FitResult
+from fitting import FitResult, FitParams
 
 
 def test_baseline_range_cli_overrides_config(tmp_path, monkeypatch):
@@ -71,7 +71,7 @@ def test_baseline_range_cli_overrides_config(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, cfg):
         captured["times"] = ts_dict.get("Po214", []).tolist()
-        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
+        return FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 

--- a/tests/test_baseline_range_empty.py
+++ b/tests/test_baseline_range_empty.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
-from fitting import FitResult
+from fitting import FitResult, FitParams
 
 
 def test_cli_baseline_range_empty(tmp_path, monkeypatch):
@@ -73,7 +73,7 @@ def test_cli_baseline_range_empty(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, cfg):
         captured["times"] = ts_dict.get("Po214", []).tolist()
-        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
+        return FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 

--- a/tests/test_blue_weights.py
+++ b/tests/test_blue_weights.py
@@ -7,7 +7,7 @@ import numpy as np
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 from calibration import CalibrationResult
-from fitting import FitResult
+from fitting import FitResult, FitParams
 
 
 def test_blue_weights_summary(tmp_path, monkeypatch):
@@ -42,7 +42,7 @@ def test_blue_weights_summary(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0, 0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0, 0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())

--- a/tests/test_cli_baseline_range.py
+++ b/tests/test_cli_baseline_range.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
-from fitting import FitResult
+from fitting import FitResult, FitParams
 
 
 def test_cli_baseline_range_overrides_config(tmp_path, monkeypatch):
@@ -73,7 +73,7 @@ def test_cli_baseline_range_overrides_config(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, cfg):
         captured["times"] = ts_dict.get("Po214", []).tolist()
-        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
+        return FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 

--- a/tests/test_cli_baseline_range_iso.py
+++ b/tests/test_cli_baseline_range_iso.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
-from fitting import FitResult
+from fitting import FitResult, FitParams
 
 
 def test_cli_baseline_range_iso_strings(tmp_path, monkeypatch):
@@ -73,7 +73,7 @@ def test_cli_baseline_range_iso_strings(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, cfg):
         captured["times"] = ts_dict.get("Po214", []).tolist()
-        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
+        return FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
@@ -153,7 +153,7 @@ def test_cli_baseline_range_timezone(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, cfg):
         captured["times"] = ts_dict.get("Po214", []).tolist()
-        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
+        return FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 

--- a/tests/test_cli_baseline_range_override2.py
+++ b/tests/test_cli_baseline_range_override2.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
-from fitting import FitResult
+from fitting import FitResult, FitParams
 
 
 def test_cli_baseline_range_overrides_config_again(tmp_path, monkeypatch):
@@ -73,7 +73,7 @@ def test_cli_baseline_range_overrides_config_again(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, cfg, **kwargs):
         captured["times"] = ts_dict.get("Po214", []).tolist()
-        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
+        return FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 

--- a/tests/test_cli_metadata.py
+++ b/tests/test_cli_metadata.py
@@ -7,7 +7,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import numpy as np
 from calibration import CalibrationResult
-from fitting import FitResult
+from fitting import FitResult, FitParams
 
 
 def test_summary_includes_git_and_cli(tmp_path, monkeypatch):
@@ -42,7 +42,7 @@ def test_summary_includes_git_and_cli(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())

--- a/tests/test_cov_entry.py
+++ b/tests/test_cov_entry.py
@@ -5,7 +5,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
-from fitting import FitResult
+from fitting import FitResult, FitParams
 
 
 def test_cov_entry_valid_params():

--- a/tests/test_expected_peaks_default.py
+++ b/tests/test_expected_peaks_default.py
@@ -11,7 +11,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 from constants import DEFAULT_ADC_CENTROIDS
 from io_utils import load_config
-from fitting import FitResult
+from fitting import FitResult, FitParams
 
 
 def test_expected_peaks_default(tmp_path, monkeypatch):
@@ -65,7 +65,7 @@ def test_expected_peaks_default(tmp_path, monkeypatch):
         "derive_calibration_constants_auto",
         lambda *a, **k: cal_mock,
     )
-    monkeypatch.setattr(analyze, "fit_spectrum", lambda *a, **k: FitResult({}, np.zeros((0, 0)), 0))
+    monkeypatch.setattr(analyze, "fit_spectrum", lambda *a, **k: FitResult(FitParams({}), np.zeros((0, 0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
     monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())

--- a/tests/test_hierarchical_summary.py
+++ b/tests/test_hierarchical_summary.py
@@ -7,7 +7,7 @@ import pandas as pd
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 from calibration import CalibrationResult
-from fitting import FitResult
+from fitting import FitResult, FitParams
 import numpy as np
 
 
@@ -54,7 +54,7 @@ def test_hierarchical_summary(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, None, 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), None, 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())

--- a/tests/test_job_id_duplicate.py
+++ b/tests/test_job_id_duplicate.py
@@ -11,7 +11,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import analyze
 from calibration import CalibrationResult
-from fitting import FitResult
+from fitting import FitResult, FitParams
 
 
 def test_duplicate_job_id_raises(tmp_path, monkeypatch):
@@ -47,7 +47,7 @@ def test_duplicate_job_id_raises(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0, 0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0, 0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
@@ -112,7 +112,7 @@ def test_job_id_overwrite_allows_rerun(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0, 0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0, 0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())

--- a/tests/test_linear_background.py
+++ b/tests/test_linear_background.py
@@ -11,7 +11,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from background import estimate_linear_background
 import analyze
 from calibration import CalibrationResult
-from fitting import FitResult
+from fitting import FitResult, FitParams
 
 
 def generate_spectrum():
@@ -89,7 +89,7 @@ def test_auto_background_priors(monkeypatch, tmp_path):
 
     def fake_fit_spectrum(energies, priors, **kw):
         captured.update(priors)
-        return FitResult({}, np.zeros((0, 0)), 0)
+        return FitResult(FitParams({}), np.zeros((0, 0)), 0)
 
     monkeypatch.setattr(analyze, "fit_spectrum", fake_fit_spectrum)
     cal_mock = CalibrationResult(
@@ -107,7 +107,7 @@ def test_auto_background_priors(monkeypatch, tmp_path):
     monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "write_summary", lambda *a, **k: str(tmp_path))
     monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
 
     args = [
         "analyze.py",

--- a/tests/test_noise_cutoff.py
+++ b/tests/test_noise_cutoff.py
@@ -8,7 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import numpy as np
 from calibration import CalibrationResult
-from fitting import FitResult
+from fitting import FitResult, FitParams
 
 
 def test_noise_cutoff_filters_events(tmp_path, monkeypatch):
@@ -59,7 +59,7 @@ def test_noise_cutoff_filters_events(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, cfg, weights=None, **kwargs):
         captured["times"] = ts_dict.get("Po214", []).tolist()
-        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
+        return FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
@@ -133,7 +133,7 @@ def test_invalid_noise_cutoff_skips_cut(tmp_path, monkeypatch, caplog):
 
     def fake_fit(ts_dict, t_start, t_end, cfg, weights=None, **kwargs):
         captured["times"] = ts_dict.get("Po214", []).tolist()
-        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
+        return FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 

--- a/tests/test_override_logging.py
+++ b/tests/test_override_logging.py
@@ -8,7 +8,7 @@ import numpy as np
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 from calibration import CalibrationResult
-from fitting import FitResult
+from fitting import FitResult, FitParams
 
 
 def _minimal_patches(monkeypatch):
@@ -21,7 +21,7 @@ def _minimal_patches(monkeypatch):
     )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0, 0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0, 0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())

--- a/tests/test_sample_radon.py
+++ b/tests/test_sample_radon.py
@@ -9,7 +9,7 @@ import analyze
 import radon_activity
 import numpy as np
 from calibration import CalibrationResult
-from fitting import FitResult
+from fitting import FitResult, FitParams
 
 
 def test_total_radon_uses_sample_volume(tmp_path, monkeypatch):
@@ -46,7 +46,7 @@ def test_total_radon_uses_sample_volume(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({}, np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())

--- a/tests/test_systematics.py
+++ b/tests/test_systematics.py
@@ -9,7 +9,7 @@ import json
 import pandas as pd
 import analyze
 from calibration import CalibrationResult
-from fitting import FitResult
+from fitting import FitResult, FitParams
 from systematics import scan_systematics, apply_linear_adc_shift
 
 
@@ -164,7 +164,7 @@ def test_analyze_systematics_skip_unknown(tmp_path, monkeypatch):
     monkeypatch.setattr(
         analyze,
         "fit_time_series",
-        lambda *a, **k: FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0),
+        lambda *a, **k: FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1, 1)), 0),
     )
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 import numpy as np
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from fitting import FitResult
+from fitting import FitResult, FitParams
 
 import analyze
 import baseline_noise
@@ -61,7 +61,7 @@ def test_time_window_filters_events(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, config, **kwargs):
         captured["times"] = ts_dict.get("Po214", []).tolist()
-        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
+        return FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
@@ -201,7 +201,7 @@ def test_time_window_filters_events_config(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, config, **kwargs):
         captured["times"] = ts_dict.get("Po214", []).tolist()
-        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
+        return FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
@@ -281,7 +281,7 @@ def test_run_period_filters_events(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, config, **kwargs):
         captured["times"] = ts_dict.get("Po214", []).tolist()
-        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
+        return FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
@@ -369,7 +369,7 @@ def test_baseline_range_iso_strings(tmp_path, monkeypatch, start, end):
 
     def fake_fit(ts_dict, t_start, t_end, config, **kwargs):
         captured["times"] = ts_dict.get("Po214", []).tolist()
-        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
+        return FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
@@ -453,7 +453,7 @@ def test_unified_filter_combined_windows(tmp_path, monkeypatch):
 
     def fake_fit(ts_dict, t_start, t_end, cfg, **kwargs):
         captured["times"] = ts_dict.get("Po214", []).tolist()
-        return FitResult({"E_Po214": 1.0}, np.zeros((1, 1)), 0)
+        return FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1, 1)), 0)
 
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 


### PR DESCRIPTION
## Summary
- add `FitParams` TypedDict in `fitting.py`
- type `FitResult.params` as `FitParams`
- update `analyze._fit_params` to return `FitParams`
- adjust tests to create `FitParams` when building `FitResult`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685afe5661f4832b9388098118a3b8df