### PR TITLE
Introduce typed summary object

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -55,6 +55,7 @@ import subprocess
 import hashlib
 import json
 from pathlib import Path
+from summary_types import Summary
 import shutil
 from typing import Any
 
@@ -2064,31 +2065,31 @@ def main(argv=None):
             "peaks": cal_params.peaks,
         }
 
-    summary = {
-        "timestamp": now_str,
-        "config_used": args.config.name,
-        "calibration": cal_summary,
-        "calibration_valid": calibration_valid,
-        "spectral_fit": spec_dict,
-        "time_fit": time_fit_serializable,
-        "systematics": systematics_results,
-        "baseline": baseline_info,
-        "radon_results": radon_results,
-        "noise_cut": {"removed_events": int(n_removed_noise)},
-        "burst_filter": {
+    summary = Summary(
+        timestamp=now_str,
+        config_used=args.config.name,
+        calibration=cal_summary,
+        calibration_valid=calibration_valid,
+        spectral_fit=spec_dict,
+        time_fit=time_fit_serializable,
+        systematics=systematics_results,
+        baseline=baseline_info,
+        radon_results=radon_results,
+        noise_cut={"removed_events": int(n_removed_noise)},
+        burst_filter={
             "removed_events": int(n_removed_burst),
             "burst_mode": burst_mode,
         },
-        "adc_drift_rate": drift_rate,
-        "adc_drift_mode": drift_mode,
-        "adc_drift_params": drift_params,
-        "efficiency": efficiency_results,
-        "random_seed": seed_used,
-        "git_commit": commit,
-        "requirements_sha256": requirements_sha256,
-        "cli_sha256": cli_sha256,
-        "cli_args": cli_args,
-        "analysis": {
+        adc_drift_rate=drift_rate,
+        adc_drift_mode=drift_mode,
+        adc_drift_params=drift_params,
+        efficiency=efficiency_results,
+        random_seed=seed_used,
+        git_commit=commit,
+        requirements_sha256=requirements_sha256,
+        cli_sha256=cli_sha256,
+        cli_args=cli_args,
+        analysis={
             "analysis_start_time": t0_cfg,
             "analysis_end_time": t_end_cfg,
             "spike_end_time": spike_end_cfg,
@@ -2100,10 +2101,10 @@ def main(argv=None):
             ),
             "settle_s": cfg.get("analysis", {}).get("settle_s"),
         },
-    }
+    )
 
     if weights is not None:
-        summary["efficiency"]["blue_weights"] = list(weights)
+        summary.efficiency["blue_weights"] = list(weights)
 
     results_dir = Path(args.output_dir) / (args.job_id or now_str)
     if results_dir.exists():

--- a/io_utils.py
+++ b/io_utils.py
@@ -463,8 +463,12 @@ def apply_burst_filter(df, cfg=None, mode="rate"):
     return out_df, removed_total
 
 
-def write_summary(output_dir, summary_dict, timestamp=None):
-    """Write ``summary_dict`` to ``summary.json`` and return the results folder."""
+def write_summary(output_dir, summary, timestamp=None):
+    """Write ``summary`` to ``summary.json`` and return the results folder.
+
+    ``summary`` may be a plain dictionary or an instance of
+    :class:`summary_types.Summary`.
+    """
 
     output_path = Path(output_dir)
 
@@ -480,7 +484,7 @@ def write_summary(output_dir, summary_dict, timestamp=None):
 
     summary_path = results_folder / "summary.json"
 
-    sanitized = to_native(summary_dict)
+    sanitized = to_native(summary)
 
     with open(summary_path, "w", encoding="utf-8") as f:
         json.dump(sanitized, f, indent=4)

--- a/summary_types.py
+++ b/summary_types.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+@dataclass
+class Summary:
+    timestamp: str
+    config_used: str
+    calibration: Dict[str, Any]
+    calibration_valid: bool
+    spectral_fit: Dict[str, Any]
+    time_fit: Dict[str, Any]
+    systematics: Dict[str, Any]
+    baseline: Dict[str, Any]
+    radon_results: Dict[str, Any]
+    noise_cut: Dict[str, Any]
+    burst_filter: Dict[str, Any]
+    adc_drift_rate: Optional[float]
+    adc_drift_mode: Optional[str]
+    adc_drift_params: Optional[Dict[str, Any]]
+    efficiency: Dict[str, Any]
+    random_seed: int
+    git_commit: str
+    requirements_sha256: Optional[str]
+    cli_sha256: Optional[str]
+    cli_args: List[str]
+    analysis: Dict[str, Any]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a dictionary representation of this summary."""
+        from dataclasses import asdict
+
+        return asdict(self)

--- a/tests/test_adc_drift.py
+++ b/tests/test_adc_drift.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 from calibration import CalibrationResult
 from fitting import FitResult
+from dataclasses import asdict
 
 
 def _write_basic(tmp_path, drift_rate, mode="linear", params=None):
@@ -69,7 +70,7 @@ def test_adc_drift_applied(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -123,7 +124,7 @@ def test_adc_drift_zero_noop(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -279,7 +280,7 @@ def test_adc_drift_warning_on_failure(tmp_path, monkeypatch, capsys):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -10,6 +10,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 from calibration import CalibrationResult
 from fitting import FitResult
+from dataclasses import asdict
 
 
 def test_plot_time_series_receives_merged_config(tmp_path, monkeypatch):
@@ -536,7 +537,7 @@ def test_spike_count_cli(tmp_path, monkeypatch):
     saved = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        saved["summary"] = summary
+        saved["summary"] = asdict(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -674,7 +675,7 @@ def test_assay_efficiency_list(tmp_path, monkeypatch):
     saved = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        saved["summary"] = summary
+        saved["summary"] = asdict(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -757,7 +758,7 @@ def test_spike_efficiency_list(tmp_path, monkeypatch):
     saved = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        saved["summary"] = summary
+        saved["summary"] = asdict(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -917,7 +918,7 @@ def test_settle_s_summary(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -1164,7 +1165,7 @@ def test_spike_period_cli(tmp_path, monkeypatch):
     saved = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        saved["summary"] = summary
+        saved["summary"] = asdict(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -1227,7 +1228,7 @@ def test_seed_cli_sets_random_seed(tmp_path, monkeypatch):
 
     captured = {}
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -1286,7 +1287,7 @@ def test_ambient_concentration_recorded(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "plot_equivalent_air", fake_plot_equivalent_air)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -1346,7 +1347,7 @@ def test_ambient_concentration_from_config(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "plot_equivalent_air", fake_plot_equivalent_air)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -1627,7 +1628,7 @@ def test_burst_mode_summary_config(tmp_path, monkeypatch):
     saved = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        saved["summary"] = summary
+        saved["summary"] = asdict(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -1746,7 +1747,7 @@ def test_ambient_concentration_default_none(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -1861,7 +1862,7 @@ def test_spike_periods_null_config(tmp_path, monkeypatch):
     saved = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        saved["summary"] = summary
+        saved["summary"] = asdict(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_analyze_noise_cutoff.py
+++ b/tests/test_analyze_noise_cutoff.py
@@ -7,6 +7,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import numpy as np
 from fitting import FitResult
+from dataclasses import asdict
 
 
 def test_analyze_noise_cutoff(tmp_path, monkeypatch):
@@ -62,7 +63,7 @@ def test_analyze_noise_cutoff(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit_time_series)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -12,6 +12,7 @@ from calibration import CalibrationResult
 import baseline
 from radon.baseline import subtract_baseline_counts
 from fitting import FitResult
+from dataclasses import asdict
 
 
 def test_simple_baseline_subtraction(tmp_path, monkeypatch):
@@ -67,7 +68,7 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
     monkeypatch.setattr(baseline_noise, "estimate_baseline_noise", lambda *a, **k: (5.0, {}))
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -160,7 +161,7 @@ def test_baseline_scaling_factor(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -262,7 +263,7 @@ def test_n0_prior_from_baseline(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "scan_systematics", fake_scan_systematics)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -338,7 +339,7 @@ def test_isotopes_to_subtract_control(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -437,7 +438,7 @@ def test_baseline_scaling_multiple_isotopes(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -539,7 +540,7 @@ def test_noise_level_none_not_recorded(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -619,7 +620,7 @@ def test_sigma_rate_uses_weighted_counts(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_baseline_flow.py
+++ b/tests/test_baseline_flow.py
@@ -8,6 +8,7 @@ import analyze
 import baseline_noise
 import numpy as np
 from calibration import CalibrationResult
+from dataclasses import asdict
 
 
 def test_baseline_event_from_unfiltered_data(tmp_path, monkeypatch):
@@ -54,7 +55,7 @@ def test_baseline_event_from_unfiltered_data(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_baseline_noise_propagation.py
+++ b/tests/test_baseline_noise_propagation.py
@@ -9,6 +9,7 @@ import analyze
 import baseline_noise
 from calibration import CalibrationResult
 from fitting import FitResult
+from dataclasses import asdict
 
 
 def test_baseline_noise_propagation(tmp_path, monkeypatch):
@@ -66,7 +67,7 @@ def test_baseline_noise_propagation(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult({"E_Po214": 1.0}, np.zeros((1,1)), 0))
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_baseline_range_cli.py
+++ b/tests/test_baseline_range_cli.py
@@ -10,6 +10,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
 from fitting import FitResult
+from dataclasses import asdict
 
 
 def test_baseline_range_cli_overrides_config(tmp_path, monkeypatch):
@@ -76,7 +77,7 @@ def test_baseline_range_cli_overrides_config(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_baseline_range_empty.py
+++ b/tests/test_baseline_range_empty.py
@@ -10,6 +10,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
 from fitting import FitResult
+from dataclasses import asdict
 
 
 def test_cli_baseline_range_empty(tmp_path, monkeypatch):
@@ -78,7 +79,7 @@ def test_cli_baseline_range_empty(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_blue_weights.py
+++ b/tests/test_blue_weights.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 from calibration import CalibrationResult
 from fitting import FitResult
+from dataclasses import asdict
 
 
 def test_blue_weights_summary(tmp_path, monkeypatch):
@@ -62,7 +63,7 @@ def test_blue_weights_summary(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_cli_baseline_range.py
+++ b/tests/test_cli_baseline_range.py
@@ -10,6 +10,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
 from fitting import FitResult
+from dataclasses import asdict
 
 
 def test_cli_baseline_range_overrides_config(tmp_path, monkeypatch):
@@ -78,7 +79,7 @@ def test_cli_baseline_range_overrides_config(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_cli_baseline_range_iso.py
+++ b/tests/test_cli_baseline_range_iso.py
@@ -10,6 +10,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
 from fitting import FitResult
+from dataclasses import asdict
 
 
 def test_cli_baseline_range_iso_strings(tmp_path, monkeypatch):
@@ -78,7 +79,7 @@ def test_cli_baseline_range_iso_strings(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -158,7 +159,7 @@ def test_cli_baseline_range_timezone(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_cli_baseline_range_override2.py
+++ b/tests/test_cli_baseline_range_override2.py
@@ -10,6 +10,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
 from fitting import FitResult
+from dataclasses import asdict
 
 
 def test_cli_baseline_range_overrides_config_again(tmp_path, monkeypatch):
@@ -78,7 +79,7 @@ def test_cli_baseline_range_overrides_config_again(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_cli_metadata.py
+++ b/tests/test_cli_metadata.py
@@ -8,6 +8,7 @@ import analyze
 import numpy as np
 from calibration import CalibrationResult
 from fitting import FitResult
+from dataclasses import asdict
 
 
 def test_summary_includes_git_and_cli(tmp_path, monkeypatch):
@@ -51,7 +52,7 @@ def test_summary_includes_git_and_cli(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write_summary(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_hierarchical_summary.py
+++ b/tests/test_hierarchical_summary.py
@@ -9,6 +9,7 @@ import analyze
 from calibration import CalibrationResult
 from fitting import FitResult
 import numpy as np
+from dataclasses import asdict
 
 
 def test_hierarchical_summary(tmp_path, monkeypatch):

--- a/tests/test_noise_cut.py
+++ b/tests/test_noise_cut.py
@@ -7,6 +7,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import numpy as np
 from calibration import CalibrationResult
+from dataclasses import asdict
 
 
 def test_noise_cutoff_cli_overrides(tmp_path, monkeypatch):
@@ -68,7 +69,7 @@ def test_noise_cutoff_cli_overrides(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_noise_cutoff.py
+++ b/tests/test_noise_cutoff.py
@@ -9,6 +9,7 @@ import analyze
 import numpy as np
 from calibration import CalibrationResult
 from fitting import FitResult
+from dataclasses import asdict
 
 
 def test_noise_cutoff_filters_events(tmp_path, monkeypatch):
@@ -64,7 +65,7 @@ def test_noise_cutoff_filters_events(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -138,7 +139,7 @@ def test_invalid_noise_cutoff_skips_cut(tmp_path, monkeypatch, caplog):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_pipeline_after_fix.py
+++ b/tests/test_pipeline_after_fix.py
@@ -6,6 +6,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import analyze
+from dataclasses import asdict
 
 
 def test_pipeline_calibrates_after_fix(tmp_path, monkeypatch):
@@ -43,7 +44,7 @@ def test_pipeline_calibrates_after_fix(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_sample_radon.py
+++ b/tests/test_sample_radon.py
@@ -10,6 +10,7 @@ import radon_activity
 import numpy as np
 from calibration import CalibrationResult
 from fitting import FitResult
+from dataclasses import asdict
 
 
 def test_total_radon_uses_sample_volume(tmp_path, monkeypatch):
@@ -57,7 +58,7 @@ def test_total_radon_uses_sample_volume(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -10,6 +10,7 @@ from fitting import FitResult
 import analyze
 import baseline_noise
 from calibration import CalibrationResult
+from dataclasses import asdict
 
 
 def test_time_window_filters_events(tmp_path, monkeypatch):
@@ -66,7 +67,7 @@ def test_time_window_filters_events(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -206,7 +207,7 @@ def test_time_window_filters_events_config(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -286,7 +287,7 @@ def test_run_period_filters_events(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -374,7 +375,7 @@ def test_baseline_range_iso_strings(tmp_path, monkeypatch, start, end):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -458,7 +459,7 @@ def test_unified_filter_combined_windows(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_to_native.py
+++ b/tests/test_to_native.py
@@ -8,6 +8,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from utils import to_native
+from dataclasses import asdict
 
 
 def test_to_native_numpy_scalar_and_array():


### PR DESCRIPTION
## Summary
- define `Summary` dataclass capturing the summary structure
- use `Summary` in `analyze.py`
- allow `write_summary` to serialize dataclasses
- adapt unit tests to convert Summary via `asdict`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685afe568e88832bbeeca16055f84645