### PR TITLE
Add cov lookup to FitResult

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -128,23 +128,10 @@ def _cov_entry(fit: FitResult | dict, p1: str, p2: str) -> float:
         If either ``p1`` or ``p2`` is not present in the covariance matrix.
     """
 
-    if not isinstance(fit, FitResult) or fit.cov is None:
+    if not isinstance(fit, FitResult):
         return 0.0
 
-    ordered = [
-        k for k in fit.params.keys() if k != "fit_valid" and not k.startswith("d")
-    ]
-
-    if p1 not in ordered or p2 not in ordered:
-        raise KeyError(f"Parameter(s) missing in covariance: {p1}, {p2}")
-
-    i1 = ordered.index(p1)
-    i2 = ordered.index(p2)
-    cov = np.asarray(fit.cov, dtype=float)
-    if cov.ndim >= 2 and i1 < cov.shape[0] and i2 < cov.shape[1]:
-        return float(cov[i1, i2])
-
-    raise KeyError(f"Parameter(s) missing in covariance: {p1}, {p2}")
+    return fit.get_cov(p1, p2)
 
 
 def _ensure_events(events: pd.DataFrame, stage: str) -> None:

--- a/tests/test_cov_entry.py
+++ b/tests/test_cov_entry.py
@@ -23,8 +23,9 @@ def test_cov_entry_valid_params():
             [0.2, 0.3, 9.0],
         ]
     )
-    fr = FitResult(params, cov, 0)
-    assert analyze._cov_entry(fr, "A", "B") == pytest.approx(0.1)
+    index = {"A": 0, "B": 1, "C": 2}
+    fr = FitResult(params, cov, 0, index)
+    assert fr.get_cov("A", "B") == pytest.approx(0.1)
     assert analyze._cov_entry(fr, "C", "A") == pytest.approx(0.2)
     assert analyze._cov_entry(fr, "B", "C") == pytest.approx(0.3)
 
@@ -32,7 +33,7 @@ def test_cov_entry_valid_params():
 def test_cov_entry_missing_params():
     params = {"A": 1.0, "B": 2.0}
     cov = np.eye(2)
-    fr = FitResult(params, cov, 0)
+    fr = FitResult(params, cov, 0, {"A": 0, "B": 1})
 
     # One missing
     with pytest.raises(KeyError):
@@ -42,5 +43,5 @@ def test_cov_entry_missing_params():
     with pytest.raises(KeyError):
         analyze._cov_entry(fr, "C", "D")
 
-    fr_none = FitResult(params, None, 0)
+    fr_none = FitResult(params, None, 0, {"A": 0, "B": 1})
     assert analyze._cov_entry(fr_none, "A", "B") == 0.0

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -548,7 +548,7 @@ def test_fit_time_series_covariance_output():
     }
     res = fit_time_series(times_dict, 0.0, T, cfg)
     assert "cov_E_Po214_N0_Po214" in res.params
-    cov_exp = analyze._cov_entry(res, "E_Po214", "N0_Po214")
+    cov_exp = res.get_cov("E_Po214", "N0_Po214")
     assert res.params["cov_E_Po214_N0_Po214"] == pytest.approx(cov_exp)
 
 


### PR DESCRIPTION
## Summary
- keep track of parameter ordering in `FitResult`
- expose `FitResult.get_cov` helper method
- populate `param_index` in `fit_spectrum` and `fit_time_series`
- use `fit.get_cov` inside `_cov_entry`
- update unit tests for new API

## Testing
- `pytest tests/test_cov_entry.py::test_cov_entry_valid_params -q`
- `pytest tests/test_cov_entry.py::test_cov_entry_missing_params -q`
- `pytest tests/test_fitting.py::test_fit_time_series_covariance_output -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b0368911c832bb0f47fb4bfd600bf