### PR TITLE
Preserve UTC timestamps

### DIFF
--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -81,11 +81,11 @@ def test_load_events(tmp_path, caplog):
     df.to_csv(p, index=False)
     with caplog.at_level(logging.INFO):
         loaded = load_events(p)
-    assert loaded["timestamp"].dtype == "datetime64[ns]"
-    expected_ts = np.array(
-        [parse_datetime(t) for t in (1000, 1005, 1010)], dtype="datetime64[ns]"
+    assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
+    expected_ts = pd.to_datetime([1000, 1005, 1010], unit="s", utc=True)
+    assert np.array_equal(
+        loaded["timestamp"].view("int64"), expected_ts.view("int64")
     )
-    assert np.array_equal(loaded["timestamp"].values, expected_ts)
     assert np.array_equal(loaded["adc"].values, np.array([1200, 1300, 1250]))
     assert "0 discarded" in caplog.text
 
@@ -105,11 +105,11 @@ def test_load_events_drop_bad_rows(tmp_path, caplog):
     with caplog.at_level(logging.INFO):
         loaded = load_events(p)
     # Expect rows with NaN/inf removed and duplicate dropped
-    assert loaded["timestamp"].dtype == "datetime64[ns]"
-    expected_ts = np.array(
-        [parse_datetime(t) for t in (1000, 1005, 1020)], dtype="datetime64[ns]"
+    assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
+    expected_ts = pd.to_datetime([1000, 1005, 1020], unit="s", utc=True)
+    assert np.array_equal(
+        loaded["timestamp"].view("int64"), expected_ts.view("int64")
     )
-    assert np.array_equal(loaded["timestamp"].values, expected_ts)
     assert "3 discarded" in caplog.text
 
 
@@ -126,8 +126,8 @@ def test_load_events_column_aliases(tmp_path):
     p = tmp_path / "alias.csv"
     df.to_csv(p, index=False)
     loaded = load_events(p)
-    assert loaded["timestamp"].dtype == "datetime64[ns]"
-    assert list(loaded["timestamp"])[0] == pd.Timestamp(parse_datetime(1000))
+    assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
+    assert list(loaded["timestamp"])[0] == pd.to_datetime(parse_datetime(1000), utc=True)
     assert list(loaded["adc"])[0] == 1250
     assert "time" not in loaded.columns
     assert "adc_ch" not in loaded.columns
@@ -153,7 +153,8 @@ def test_load_events_custom_columns(tmp_path):
         "fchannel": "chan",
     }
     loaded = load_events(p, column_map=column_map)
-    assert list(loaded["timestamp"])[0] == pd.Timestamp(parse_datetime(1000))
+    assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
+    assert list(loaded["timestamp"])[0] == pd.to_datetime(parse_datetime(1000), utc=True)
     assert list(loaded["adc"])[0] == 1250
     assert "ftimestamps" not in loaded.columns
 
@@ -188,7 +189,7 @@ def test_load_events_string_nan(tmp_path):
     df.to_csv(p, index=False)
     loaded = load_events(p)
     assert len(loaded) == 1
-    assert loaded["timestamp"].iloc[0] == pd.Timestamp(parse_datetime(1000))
+    assert loaded["timestamp"].iloc[0] == pd.to_datetime(parse_datetime(1000), utc=True)
 
 
 def test_write_summary_and_copy_config(tmp_path):

--- a/tests/test_timestamp_dtype.py
+++ b/tests/test_timestamp_dtype.py
@@ -1,0 +1,58 @@
+import pandas as pd
+import numpy as np
+import argparse
+from datetime import datetime, timezone
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import baseline
+import analyze
+from io_utils import load_events
+
+
+def test_load_events_returns_timezone(tmp_path):
+    df = pd.DataFrame({
+        "fUniqueID": [1],
+        "fBits": [0],
+        "timestamp": [1000],
+        "adc": [1200],
+        "fchannel": [1],
+    })
+    p = tmp_path / "data.csv"
+    df.to_csv(p, index=False)
+    loaded = load_events(p)
+    assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
+
+
+def test_subtract_baseline_preserves_dtype():
+    ts = pd.date_range("1970-01-01", periods=3, freq="s", tz="UTC")
+    df = pd.DataFrame({"timestamp": ts, "adc": [1, 2, 3]})
+    bins = np.arange(0, 5)
+    out = baseline.subtract_baseline(
+        df,
+        df,
+        bins=bins,
+        t_base0=datetime(1970, 1, 1, tzinfo=timezone.utc),
+        t_base1=datetime(1970, 1, 1, 0, 2, tzinfo=timezone.utc),
+        mode="none",
+    )
+    assert str(out["timestamp"].dtype) == "datetime64[ns, UTC]"
+
+
+def test_prepare_analysis_df_preserves_dtype():
+    ts = pd.date_range("1970-01-01", periods=5, freq="s", tz="UTC")
+    df = pd.DataFrame({"timestamp": ts, "adc": np.arange(5)})
+    args = argparse.Namespace(slope=None)
+    out_df, *_ = analyze.prepare_analysis_df(
+        df,
+        spike_end=None,
+        spike_periods=[],
+        run_periods=[],
+        analysis_end=None,
+        t0_global=datetime(1970, 1, 1, tzinfo=timezone.utc),
+        cfg={},
+        args=args,
+    )
+    assert str(out_df["timestamp"].dtype) == "datetime64[ns, UTC]"


### PR DESCRIPTION
## Summary
- keep `timestamp` column in UTC when parsing events
- ensure burst filter normalizes timestamps to UTC
- add regression tests for timestamp dtypes
- update existing tests for timezone-aware timestamps

## Testing
- `pytest tests/test_io_utils.py::test_load_events tests/test_io_utils.py::test_load_events_drop_bad_rows tests/test_io_utils.py::test_load_events_column_aliases tests/test_io_utils.py::test_load_events_custom_columns tests/test_io_utils.py::test_load_events_string_nan -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b06b5663c832b8fb83dd7bd26e79e