### PR TITLE
Rename helper for UTC datetimes

### DIFF
--- a/baseline.py
+++ b/baseline.py
@@ -8,8 +8,8 @@ from baseline_utils import subtract_baseline_dataframe
 __all__ = ["rate_histogram", "subtract_baseline", "subtract_baseline_dataframe"]
 
 
-def _seconds(col):
-    """Return timestamp column as ``numpy.datetime64`` values."""
+def _to_datetime64(col):
+    """Return timestamp column as ``numpy.datetime64`` values in UTC."""
 
     if pd.api.types.is_datetime64_any_dtype(col):
         ser = col
@@ -25,7 +25,7 @@ def rate_histogram(df, bins):
     """Return (histogram in counts/s, live_time_s)."""
     if df.empty:
         return np.zeros(len(bins) - 1, dtype=float), 0.0
-    ts = _seconds(df["timestamp"])
+    ts = _to_datetime64(df["timestamp"])
     live = float((ts[-1] - ts[0]) / np.timedelta64(1, "s"))
     hist_src = df.get("subtracted_adc_hist", df["adc"]).to_numpy()
     hist, _ = np.histogram(hist_src, bins=bins)

--- a/tests/test_baseline_datetime.py
+++ b/tests/test_baseline_datetime.py
@@ -16,6 +16,7 @@ def test_rate_histogram_datetime_column():
     rate, live = baseline.rate_histogram(df, bins)
     assert live == pytest.approx(4.0)
     assert np.allclose(rate, np.histogram(df["adc"], bins=bins)[0] / live)
+    assert df["timestamp"].dtype == "datetime64[ns, UTC]"
 
 
 def test_subtract_baseline_datetime_column():
@@ -35,4 +36,5 @@ def test_subtract_baseline_datetime_column():
     )
     integral = out["subtracted_adc_hist"].iloc[0].sum()
     assert integral == pytest.approx(0.0, rel=1e-6)
+    assert out["timestamp"].dtype == "datetime64[ns, UTC]"
 


### PR DESCRIPTION
## Summary
- rename helper `_seconds` to `_to_datetime64`
- preserve UTC dtype in baseline utilities
- test UTC dtype preservation

## Testing
- `pytest -q tests/test_baseline_datetime.py::test_rate_histogram_datetime_column tests/test_baseline_datetime.py::test_subtract_baseline_datetime_column tests/test_baseline_subtract.py::test_baseline_none tests/test_baseline_subtract.py::test_baseline_time_norm tests/test_baseline_subtract.py::test_baseline_none_datetime tests/test_baseline_subtract.py::test_baseline_time_norm_datetime`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b06b5069c832bb6eef93d720dcff2