### PR TITLE
Ensure timestamp column is UTC-aware

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -267,9 +267,9 @@ def load_events(csv_path, *, column_map=None):
     Column aliases like ``time`` or ``adc_ch`` are automatically renamed to
     their canonical form.  A mapping of canonical column names to the
     actual CSV headers may be supplied via ``column_map``. The ``timestamp``
-    column is parsed to ``datetime64[ns, UTC]`` while ``adc`` is returned as a
-    floating point number. The DataFrame is sorted by ``timestamp`` before being
-    returned.
+    column is parsed and localized to ``datetime64[ns, UTC]`` while ``adc`` is
+    returned as a floating point number. The DataFrame is sorted by
+    ``timestamp`` before being returned.
     """
     path = Path(csv_path)
     if not path.is_file():
@@ -304,7 +304,9 @@ def load_events(csv_path, *, column_map=None):
             except Exception:
                 return pd.NaT
 
-        df["timestamp"] = df["timestamp"].map(_safe_parse)
+        df["timestamp"] = (
+            pd.to_datetime(df["timestamp"].map(_safe_parse), utc=True)
+        )
 
     # Check required columns after renaming
     required_cols = ["fUniqueID", "fBits", "timestamp", "adc", "fchannel"]

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -81,11 +81,11 @@ def test_load_events(tmp_path, caplog):
     df.to_csv(p, index=False)
     with caplog.at_level(logging.INFO):
         loaded = load_events(p)
-    assert loaded["timestamp"].dtype == "datetime64[ns]"
-    expected_ts = np.array(
-        [parse_datetime(t) for t in (1000, 1005, 1010)], dtype="datetime64[ns]"
+    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
+    expected_ts = pd.to_datetime(
+        [parse_datetime(t) for t in (1000, 1005, 1010)], utc=True
     )
-    assert np.array_equal(loaded["timestamp"].values, expected_ts)
+    assert list(loaded["timestamp"]) == list(expected_ts)
     assert np.array_equal(loaded["adc"].values, np.array([1200, 1300, 1250]))
     assert "0 discarded" in caplog.text
 
@@ -105,11 +105,11 @@ def test_load_events_drop_bad_rows(tmp_path, caplog):
     with caplog.at_level(logging.INFO):
         loaded = load_events(p)
     # Expect rows with NaN/inf removed and duplicate dropped
-    assert loaded["timestamp"].dtype == "datetime64[ns]"
-    expected_ts = np.array(
-        [parse_datetime(t) for t in (1000, 1005, 1020)], dtype="datetime64[ns]"
+    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
+    expected_ts = pd.to_datetime(
+        [parse_datetime(t) for t in (1000, 1005, 1020)], utc=True
     )
-    assert np.array_equal(loaded["timestamp"].values, expected_ts)
+    assert list(loaded["timestamp"]) == list(expected_ts)
     assert "3 discarded" in caplog.text
 
 
@@ -126,8 +126,10 @@ def test_load_events_column_aliases(tmp_path):
     p = tmp_path / "alias.csv"
     df.to_csv(p, index=False)
     loaded = load_events(p)
-    assert loaded["timestamp"].dtype == "datetime64[ns]"
-    assert list(loaded["timestamp"])[0] == pd.Timestamp(parse_datetime(1000))
+    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
+    assert list(loaded["timestamp"])[0] == pd.to_datetime(
+        parse_datetime(1000), utc=True
+    )
     assert list(loaded["adc"])[0] == 1250
     assert "time" not in loaded.columns
     assert "adc_ch" not in loaded.columns
@@ -153,7 +155,9 @@ def test_load_events_custom_columns(tmp_path):
         "fchannel": "chan",
     }
     loaded = load_events(p, column_map=column_map)
-    assert list(loaded["timestamp"])[0] == pd.Timestamp(parse_datetime(1000))
+    assert list(loaded["timestamp"])[0] == pd.to_datetime(
+        parse_datetime(1000), utc=True
+    )
     assert list(loaded["adc"])[0] == 1250
     assert "ftimestamps" not in loaded.columns
 
@@ -188,7 +192,9 @@ def test_load_events_string_nan(tmp_path):
     df.to_csv(p, index=False)
     loaded = load_events(p)
     assert len(loaded) == 1
-    assert loaded["timestamp"].iloc[0] == pd.Timestamp(parse_datetime(1000))
+    assert loaded["timestamp"].iloc[0] == pd.to_datetime(
+        parse_datetime(1000), utc=True
+    )
 
 
 def test_write_summary_and_copy_config(tmp_path):


### PR DESCRIPTION
## Summary
- localize timestamps to UTC in `load_events`
- update documentation for timezone-aware timestamps
- fix tests to expect timezone aware `timestamp`

## Testing
- `pytest tests/test_io_utils.py::test_load_events tests/test_io_utils.py::test_load_events_drop_bad_rows -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b06af6da0832ba7527a260a71703b