### PR TITLE
Update tests for UTC-aware datetime handling

### DIFF
--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -81,11 +81,11 @@ def test_load_events(tmp_path, caplog):
     df.to_csv(p, index=False)
     with caplog.at_level(logging.INFO):
         loaded = load_events(p)
-    assert loaded["timestamp"].dtype == "datetime64[ns]"
+    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
     expected_ts = np.array(
-        [parse_datetime(t) for t in (1000, 1005, 1010)], dtype="datetime64[ns]"
+        [pd.Timestamp(parse_datetime(t), tz="UTC") for t in (1000, 1005, 1010)]
     )
-    assert np.array_equal(loaded["timestamp"].values, expected_ts)
+    assert list(loaded["timestamp"]) == list(expected_ts)
     assert np.array_equal(loaded["adc"].values, np.array([1200, 1300, 1250]))
     assert "0 discarded" in caplog.text
 
@@ -105,11 +105,11 @@ def test_load_events_drop_bad_rows(tmp_path, caplog):
     with caplog.at_level(logging.INFO):
         loaded = load_events(p)
     # Expect rows with NaN/inf removed and duplicate dropped
-    assert loaded["timestamp"].dtype == "datetime64[ns]"
+    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
     expected_ts = np.array(
-        [parse_datetime(t) for t in (1000, 1005, 1020)], dtype="datetime64[ns]"
+        [pd.Timestamp(parse_datetime(t), tz="UTC") for t in (1000, 1005, 1020)]
     )
-    assert np.array_equal(loaded["timestamp"].values, expected_ts)
+    assert list(loaded["timestamp"]) == list(expected_ts)
     assert "3 discarded" in caplog.text
 
 
@@ -126,8 +126,8 @@ def test_load_events_column_aliases(tmp_path):
     p = tmp_path / "alias.csv"
     df.to_csv(p, index=False)
     loaded = load_events(p)
-    assert loaded["timestamp"].dtype == "datetime64[ns]"
-    assert list(loaded["timestamp"])[0] == pd.Timestamp(parse_datetime(1000))
+    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
+    assert list(loaded["timestamp"])[0] == pd.Timestamp(parse_datetime(1000), tz="UTC")
     assert list(loaded["adc"])[0] == 1250
     assert "time" not in loaded.columns
     assert "adc_ch" not in loaded.columns
@@ -153,7 +153,7 @@ def test_load_events_custom_columns(tmp_path):
         "fchannel": "chan",
     }
     loaded = load_events(p, column_map=column_map)
-    assert list(loaded["timestamp"])[0] == pd.Timestamp(parse_datetime(1000))
+    assert list(loaded["timestamp"])[0] == pd.Timestamp(parse_datetime(1000), tz="UTC")
     assert list(loaded["adc"])[0] == 1250
     assert "ftimestamps" not in loaded.columns
 
@@ -188,7 +188,7 @@ def test_load_events_string_nan(tmp_path):
     df.to_csv(p, index=False)
     loaded = load_events(p)
     assert len(loaded) == 1
-    assert loaded["timestamp"].iloc[0] == pd.Timestamp(parse_datetime(1000))
+    assert loaded["timestamp"].iloc[0] == pd.Timestamp(parse_datetime(1000), tz="UTC")
 
 
 def test_write_summary_and_copy_config(tmp_path):

--- a/tests/test_parse_datetime.py
+++ b/tests/test_parse_datetime.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 from datetime import datetime, timezone, timedelta
 import numpy as np
+import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -10,50 +11,58 @@ from utils import parse_datetime
 
 def test_parse_datetime_iso_string():
     ts = parse_datetime("1970-01-01T00:00:00Z")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts.tzinfo == timezone.utc
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_numeric():
     ts = parse_datetime(42)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64(42, "s")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts.tzinfo == timezone.utc
+    assert ts == pd.Timestamp(42, unit="s", tz="UTC")
 
 
 def test_parse_datetime_numeric_str():
     ts = parse_datetime("42")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64(42, "s")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts.tzinfo == timezone.utc
+    assert ts == pd.Timestamp(42, unit="s", tz="UTC")
 
 
 def test_parse_datetime_naive_datetime():
     dt = datetime(1970, 1, 1)
     ts = parse_datetime(dt)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts.tzinfo == timezone.utc
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_float():
     ts = parse_datetime(42.5)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:42.500000000")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts.tzinfo == timezone.utc
+    assert ts == pd.Timestamp(42.5, unit="s", tz="UTC")
 
 
 def test_parse_datetime_iso_without_tz():
     ts = parse_datetime("1970-01-01T00:00:00")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts.tzinfo == timezone.utc
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_iso_with_offset():
     ts = parse_datetime("1970-01-01T01:00:00+01:00")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts.tzinfo == timezone.utc
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_datetime_with_tz():
     dt = datetime(1970, 1, 1, 1, tzinfo=timezone(timedelta(hours=1)))
     ts = parse_datetime(dt)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts.tzinfo == timezone.utc
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 


### PR DESCRIPTION
## Summary
- adjust `tests/test_io_utils.py` to expect UTC-aware timestamps
- update `tests/test_parse_datetime.py` to check `pd.Timestamp` with UTC tzinfo

## Testing
- `pytest tests/test_parse_datetime.py tests/test_io_utils.py::test_load_events -q` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_685b069e9cfc832ba99a2060b85be45b