### PR TITLE
Rename baseline helpers

### DIFF
--- a/baseline.py
+++ b/baseline.py
@@ -5,7 +5,7 @@ from utils import parse_datetime
 
 from baseline_utils import subtract_baseline_dataframe
 
-__all__ = ["rate_histogram", "subtract_baseline", "subtract_baseline_dataframe"]
+__all__ = ["compute_rate_histogram", "subtract_baseline_df", "subtract_baseline_dataframe"]
 
 
 def _seconds(col):
@@ -21,7 +21,7 @@ def _seconds(col):
     return np.asarray(ts)
 
 
-def rate_histogram(df, bins):
+def compute_rate_histogram(df, bins):
     """Return (histogram in counts/s, live_time_s)."""
     if df.empty:
         return np.zeros(len(bins) - 1, dtype=float), 0.0
@@ -34,8 +34,8 @@ def rate_histogram(df, bins):
     return hist / live, live
 
 
-def subtract_baseline(df_analysis, df_full, bins, t_base0, t_base1,
-                      mode="all", live_time_analysis=None):
+def subtract_baseline_df(df_analysis, df_full, bins, t_base0, t_base1,
+                         mode="all", live_time_analysis=None):
     """Wrapper for :func:`baseline_utils.subtract_baseline_dataframe`."""
 
     return subtract_baseline_dataframe(

--- a/radmon/__init__.py
+++ b/radmon/__init__.py
@@ -1,3 +1,3 @@
 """Helper package exposing baseline utilities."""
-from baseline import subtract_baseline
-__all__ = ["subtract_baseline"]
+from baseline import subtract_baseline_df
+__all__ = ["subtract_baseline_df"]

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -644,6 +644,6 @@ def test_sigma_rate_uses_weighted_counts(tmp_path, monkeypatch):
 def test_rate_histogram_single_event():
     df = pd.DataFrame({"timestamp": [1.0], "adc": [10.0]})
     bins = np.array([0, 20])
-    rate, live = baseline.rate_histogram(df, bins)
+    rate, live = baseline.compute_rate_histogram(df, bins)
     assert live == 0.0
     assert np.all(rate == 0.0)

--- a/tests/test_baseline_datetime.py
+++ b/tests/test_baseline_datetime.py
@@ -13,7 +13,7 @@ def test_rate_histogram_datetime_column():
     ts = pd.date_range("1970-01-01", periods=5, freq="s", tz="UTC")
     df = pd.DataFrame({"timestamp": ts, "adc": np.arange(5)})
     bins = np.arange(0, 7)
-    rate, live = baseline.rate_histogram(df, bins)
+    rate, live = baseline.compute_rate_histogram(df, bins)
     assert live == pytest.approx(4.0)
     assert np.allclose(rate, np.histogram(df["adc"], bins=bins)[0] / live)
 
@@ -25,7 +25,7 @@ def test_subtract_baseline_datetime_column():
     df_bl = pd.DataFrame({"timestamp": ts_bl, "adc": np.tile([1,2,3,4,5],10)})
     df_full = pd.concat([df_an, df_bl], ignore_index=True)
     bins = np.arange(0, 7)
-    out = baseline.subtract_baseline(
+    out = baseline.subtract_baseline_df(
         df_an,
         df_full,
         bins=bins,

--- a/tests/test_baseline_subtract.py
+++ b/tests/test_baseline_subtract.py
@@ -25,8 +25,8 @@ def test_baseline_none():
         t_base1=pd.Timestamp(5, unit="s", tz="UTC"),
         mode="none",
     )
-    hist_before, _ = baseline.rate_histogram(df, bins)
-    hist_after, _ = baseline.rate_histogram(out, bins)
+    hist_before, _ = baseline.compute_rate_histogram(df, bins)
+    hist_after, _ = baseline.compute_rate_histogram(out, bins)
     assert np.allclose(hist_before, hist_after)
 
 
@@ -67,8 +67,8 @@ def test_baseline_none_datetime():
         t_base1=datetime.fromtimestamp(5, tz=timezone.utc),
         mode="none",
     )
-    hist_before, _ = baseline.rate_histogram(df, bins)
-    hist_after, _ = baseline.rate_histogram(out, bins)
+    hist_before, _ = baseline.compute_rate_histogram(df, bins)
+    hist_after, _ = baseline.compute_rate_histogram(out, bins)
     assert np.allclose(hist_before, hist_after)
 
 


### PR DESCRIPTION
## Summary
- rename `rate_histogram` to `compute_rate_histogram`
- rename `subtract_baseline` to `subtract_baseline_df`
- update radmon and tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b069c8568832b8b9329518821ae67