### PR TITLE
Fix time series timestamp dtype

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -46,7 +46,7 @@ def extract_time_series_events(events, cfg):
             continue
         lo, hi = win
         mask = (events["energy_MeV"] >= lo) & (events["energy_MeV"] <= hi)
-        out[iso] = events.loc[mask, "timestamp"].values.astype(float)
+        out[iso] = events.loc[mask, "timestamp"].to_numpy()
     return out
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- keep timestamps dtype intact when extracting time series events

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b069d8ab8832bb3b0096606c00e2d