### PR TITLE
Add Summary dataclass and refactor summary handling

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -112,6 +112,7 @@ from baseline_utils import (
     subtract_baseline_rate,
     compute_dilution_factor,
 )
+from summary import Summary
 
 
 def _fit_params(obj: FitResult | Mapping[str, float] | None) -> FitParams:
@@ -2055,7 +2056,7 @@ def main(argv=None):
             "peaks": cal_params.peaks,
         }
 
-    summary = {
+    summary_dict = {
         "timestamp": now_str,
         "config_used": args.config.name,
         "calibration": cal_summary,
@@ -2094,7 +2095,7 @@ def main(argv=None):
     }
 
     if weights is not None:
-        summary["efficiency"]["blue_weights"] = list(weights)
+        summary_dict["efficiency"]["blue_weights"] = list(weights)
 
     results_dir = Path(args.output_dir) / (args.job_id or now_str)
     if results_dir.exists():
@@ -2104,6 +2105,7 @@ def main(argv=None):
             raise FileExistsError(f"Results folder already exists: {results_dir}")
 
     copy_config(results_dir, cfg, exist_ok=args.overwrite)
+    summary = Summary(**summary_dict)
     out_dir = write_summary(results_dir, summary)
 
     # Generate plots now that the output directory exists

--- a/io_utils.py
+++ b/io_utils.py
@@ -463,8 +463,13 @@ def apply_burst_filter(df, cfg=None, mode="rate"):
     return out_df, removed_total
 
 
-def write_summary(output_dir, summary_dict, timestamp=None):
-    """Write ``summary_dict`` to ``summary.json`` and return the results folder."""
+from typing import Mapping, Any
+from dataclasses import is_dataclass
+from summary import Summary
+
+
+def write_summary(output_dir, summary: Summary | Mapping[str, Any], timestamp=None):
+    """Write ``summary`` to ``summary.json`` and return the results folder."""
 
     output_path = Path(output_dir)
 
@@ -480,7 +485,7 @@ def write_summary(output_dir, summary_dict, timestamp=None):
 
     summary_path = results_folder / "summary.json"
 
-    sanitized = to_native(summary_dict)
+    sanitized = to_native(summary)
 
     with open(summary_path, "w", encoding="utf-8") as f:
         json.dump(sanitized, f, indent=4)

--- a/summary.py
+++ b/summary.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass, field, asdict
+from typing import Any, Mapping, MutableMapping
+
+@dataclass
+class Summary:
+    timestamp: str
+    config_used: str
+    calibration: Any
+    calibration_valid: Any
+    spectral_fit: Mapping[str, Any]
+    time_fit: Mapping[str, Mapping[str, Any]]
+    systematics: Mapping[str, Any] | None
+    baseline: Mapping[str, Any] | None
+    radon_results: Mapping[str, Any] | None
+    noise_cut: Mapping[str, Any]
+    burst_filter: Mapping[str, Any]
+    adc_drift_rate: Any
+    adc_drift_mode: Any
+    adc_drift_params: Any
+    efficiency: Mapping[str, Any] | None
+    random_seed: Any
+    git_commit: str | None
+    requirements_sha256: str | None
+    cli_sha256: str | None
+    cli_args: list[str]
+    analysis: Mapping[str, Any]
+
+    def __getitem__(self, key: str) -> Any:
+        return getattr(self, key)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return getattr(self, key, default)
+

--- a/tests/test_adc_drift.py
+++ b/tests/test_adc_drift.py
@@ -6,6 +6,7 @@ import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from utils import to_native
 from calibration import CalibrationResult
 from fitting import FitResult, FitParams
 
@@ -69,7 +70,7 @@ def test_adc_drift_applied(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -123,7 +124,7 @@ def test_adc_drift_zero_noop(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -279,7 +280,7 @@ def test_adc_drift_warning_on_failure(tmp_path, monkeypatch, capsys):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -8,6 +8,7 @@ import logging
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from utils import to_native
 from calibration import CalibrationResult
 from fitting import FitResult, FitParams
 
@@ -937,7 +938,7 @@ def test_settle_s_summary(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -1247,7 +1248,7 @@ def test_seed_cli_sets_random_seed(tmp_path, monkeypatch):
 
     captured = {}
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -1306,7 +1307,7 @@ def test_ambient_concentration_recorded(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "plot_equivalent_air", fake_plot_equivalent_air)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -1366,7 +1367,7 @@ def test_ambient_concentration_from_config(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "plot_equivalent_air", fake_plot_equivalent_air)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -1766,7 +1767,7 @@ def test_ambient_concentration_default_none(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_analyze_noise_cutoff.py
+++ b/tests/test_analyze_noise_cutoff.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from utils import to_native
 import numpy as np
 from fitting import FitResult, FitParams
 
@@ -62,7 +63,7 @@ def test_analyze_noise_cutoff(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit_time_series)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -8,6 +8,7 @@ import numpy as np
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
+from utils import to_native
 from calibration import CalibrationResult
 import baseline
 from baseline_utils import subtract_baseline_counts
@@ -68,7 +69,7 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
     monkeypatch.setattr(baseline_noise, "estimate_baseline_noise", lambda *a, **k: (5.0, {}))
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -161,7 +162,7 @@ def test_baseline_scaling_factor(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -263,7 +264,7 @@ def test_n0_prior_from_baseline(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "scan_systematics", fake_scan_systematics)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -339,7 +340,7 @@ def test_isotopes_to_subtract_control(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -438,7 +439,7 @@ def test_baseline_scaling_multiple_isotopes(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -540,7 +541,7 @@ def test_noise_level_none_not_recorded(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -620,7 +621,7 @@ def test_sigma_rate_uses_weighted_counts(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_baseline_flow.py
+++ b/tests/test_baseline_flow.py
@@ -6,6 +6,7 @@ import pandas as pd
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
+from utils import to_native
 import numpy as np
 from calibration import CalibrationResult
 
@@ -54,7 +55,7 @@ def test_baseline_event_from_unfiltered_data(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_baseline_noise_propagation.py
+++ b/tests/test_baseline_noise_propagation.py
@@ -7,6 +7,7 @@ import numpy as np
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
+from utils import to_native
 from calibration import CalibrationResult
 from fitting import FitResult, FitParams
 
@@ -66,7 +67,7 @@ def test_baseline_noise_propagation(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1,1)), 0))
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_baseline_range_empty.py
+++ b/tests/test_baseline_range_empty.py
@@ -3,10 +3,11 @@ import sys
 from pathlib import Path
 import pandas as pd
 import numpy as np
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from calibration import CalibrationResult
+from utils import to_native, parse_datetime
 from datetime import datetime, timezone
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
 from fitting import FitResult, FitParams
@@ -78,7 +79,7 @@ def test_cli_baseline_range_empty(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -99,8 +100,8 @@ def test_cli_baseline_range_empty(tmp_path, monkeypatch):
     summary = captured.get("summary", {})
     exp_start = datetime(1970, 1, 1, 0, 0, 10, tzinfo=timezone.utc)
     exp_end = datetime(1970, 1, 1, 0, 0, 20, tzinfo=timezone.utc)
-    assert summary.get("baseline", {}).get("start") == exp_start
-    assert summary.get("baseline", {}).get("end") == exp_end
+    assert pd.to_datetime(parse_datetime(summary.get("baseline", {}).get("start"))).tz_localize(timezone.utc) == exp_start
+    assert pd.to_datetime(parse_datetime(summary.get("baseline", {}).get("end"))).tz_localize(timezone.utc) == exp_end
     assert summary.get("baseline", {}).get("n_events") == 0
     assert summary.get("baseline", {}).get("live_time") == 0.0
     assert captured.get("cfg", {}).get("baseline", {}).get("range") == [

--- a/tests/test_blue_weights.py
+++ b/tests/test_blue_weights.py
@@ -6,6 +6,7 @@ import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from utils import to_native
 from calibration import CalibrationResult
 from fitting import FitResult, FitParams
 
@@ -62,7 +63,7 @@ def test_blue_weights_summary(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_cli_baseline_range.py
+++ b/tests/test_cli_baseline_range.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pandas as pd
 import numpy as np
 from calibration import CalibrationResult
+from utils import to_native, parse_datetime
 from datetime import datetime, timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -78,7 +79,7 @@ def test_cli_baseline_range_overrides_config(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -99,8 +100,8 @@ def test_cli_baseline_range_overrides_config(tmp_path, monkeypatch):
     summary = captured.get("summary", {})
     exp_start = datetime(1970, 1, 1, 0, 0, 1, tzinfo=timezone.utc)
     exp_end = datetime(1970, 1, 1, 0, 0, 2, tzinfo=timezone.utc)
-    assert summary.get("baseline", {}).get("start") == exp_start
-    assert summary.get("baseline", {}).get("end") == exp_end
+    assert pd.to_datetime(parse_datetime(summary.get("baseline", {}).get("start"))).tz_localize(timezone.utc) == exp_start
+    assert pd.to_datetime(parse_datetime(summary.get("baseline", {}).get("end"))).tz_localize(timezone.utc) == exp_end
     assert summary.get("baseline", {}).get("n_events") == 1
     assert captured.get("cfg", {}).get("baseline", {}).get("range") == [
         exp_start,

--- a/tests/test_cli_baseline_range_iso.py
+++ b/tests/test_cli_baseline_range_iso.py
@@ -3,10 +3,11 @@ import sys
 from pathlib import Path
 import pandas as pd
 import numpy as np
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from calibration import CalibrationResult
+from utils import to_native, parse_datetime
 from datetime import datetime, timezone
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
 from fitting import FitResult, FitParams
@@ -78,7 +79,7 @@ def test_cli_baseline_range_iso_strings(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -99,8 +100,8 @@ def test_cli_baseline_range_iso_strings(tmp_path, monkeypatch):
     summary = captured.get("summary", {})
     exp_start = datetime(1970, 1, 1, 0, 0, 1, tzinfo=timezone.utc)
     exp_end = datetime(1970, 1, 1, 0, 0, 2, tzinfo=timezone.utc)
-    assert summary.get("baseline", {}).get("start") == exp_start
-    assert summary.get("baseline", {}).get("end") == exp_end
+    assert pd.to_datetime(parse_datetime(summary.get("baseline", {}).get("start"))).tz_localize(timezone.utc) == exp_start
+    assert pd.to_datetime(parse_datetime(summary.get("baseline", {}).get("end"))).tz_localize(timezone.utc) == exp_end
     assert summary.get("baseline", {}).get("n_events") == 1
     assert captured.get("cfg", {}).get("baseline", {}).get("range") == [
         exp_start,
@@ -158,7 +159,7 @@ def test_cli_baseline_range_timezone(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -197,8 +198,8 @@ def test_cli_baseline_range_timezone(tmp_path, monkeypatch):
     summary = captured.get("summary", {})
     exp_start = datetime(1970, 1, 1, 0, 0, 1, tzinfo=timezone.utc)
     exp_end = datetime(1970, 1, 1, 0, 0, 2, tzinfo=timezone.utc)
-    assert summary.get("baseline", {}).get("start") == exp_start
-    assert summary.get("baseline", {}).get("end") == exp_end
+    assert pd.to_datetime(parse_datetime(summary.get("baseline", {}).get("start"))).tz_localize(timezone.utc) == exp_start
+    assert pd.to_datetime(parse_datetime(summary.get("baseline", {}).get("end"))).tz_localize(timezone.utc) == exp_end
     assert summary.get("baseline", {}).get("n_events") == 1
     assert captured.get("cfg", {}).get("baseline", {}).get("range") == [
         exp_start,

--- a/tests/test_cli_baseline_range_override2.py
+++ b/tests/test_cli_baseline_range_override2.py
@@ -3,10 +3,11 @@ import sys
 from pathlib import Path
 import pandas as pd
 import numpy as np
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from calibration import CalibrationResult
+from utils import to_native, parse_datetime
 from datetime import datetime, timezone
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
 from fitting import FitResult, FitParams
@@ -78,7 +79,7 @@ def test_cli_baseline_range_overrides_config_again(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -99,8 +100,8 @@ def test_cli_baseline_range_overrides_config_again(tmp_path, monkeypatch):
     summary = captured.get("summary", {})
     exp_start = datetime(1970, 1, 1, 0, 0, 2, tzinfo=timezone.utc)
     exp_end = datetime(1970, 1, 1, 0, 0, 3, tzinfo=timezone.utc)
-    assert summary.get("baseline", {}).get("start") == exp_start
-    assert summary.get("baseline", {}).get("end") == exp_end
+    assert pd.to_datetime(parse_datetime(summary.get("baseline", {}).get("start"))).tz_localize(timezone.utc) == exp_start
+    assert pd.to_datetime(parse_datetime(summary.get("baseline", {}).get("end"))).tz_localize(timezone.utc) == exp_end
     assert summary.get("baseline", {}).get("n_events") == 1
     assert captured.get("cfg", {}).get("baseline", {}).get("range") == [
         exp_start,

--- a/tests/test_cli_metadata.py
+++ b/tests/test_cli_metadata.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from utils import to_native
 import numpy as np
 from calibration import CalibrationResult
 from fitting import FitResult, FitParams
@@ -51,7 +52,7 @@ def test_summary_includes_git_and_cli(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write_summary(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_noise_cut.py
+++ b/tests/test_noise_cut.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from utils import to_native
 import numpy as np
 from calibration import CalibrationResult
 
@@ -68,7 +69,7 @@ def test_noise_cutoff_cli_overrides(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_noise_cutoff.py
+++ b/tests/test_noise_cutoff.py
@@ -6,6 +6,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from utils import to_native
 import numpy as np
 from calibration import CalibrationResult
 from fitting import FitResult, FitParams
@@ -64,7 +65,7 @@ def test_noise_cutoff_filters_events(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -138,7 +139,7 @@ def test_invalid_noise_cutoff_skips_cut(tmp_path, monkeypatch, caplog):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_pipeline_after_fix.py
+++ b/tests/test_pipeline_after_fix.py
@@ -6,6 +6,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import analyze
+from utils import to_native
 
 
 def test_pipeline_calibrates_after_fix(tmp_path, monkeypatch):
@@ -43,7 +44,7 @@ def test_pipeline_calibrates_after_fix(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_sample_radon.py
+++ b/tests/test_sample_radon.py
@@ -6,6 +6,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from utils import to_native
 import radon_activity
 import numpy as np
 from calibration import CalibrationResult
@@ -57,7 +58,7 @@ def test_total_radon_uses_sample_volume(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from fitting import FitResult, FitParams
 
 import analyze
+from utils import to_native
 import baseline_noise
 from calibration import CalibrationResult
 
@@ -66,7 +67,7 @@ def test_time_window_filters_events(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -206,7 +207,7 @@ def test_time_window_filters_events_config(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -286,7 +287,7 @@ def test_run_period_filters_events(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -374,7 +375,7 @@ def test_baseline_range_iso_strings(tmp_path, monkeypatch, start, end):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -458,7 +459,7 @@ def test_unified_filter_combined_windows(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = to_native(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)


### PR DESCRIPTION
## Summary
- introduce a `Summary` dataclass to represent the analysis summary structure
- use `Summary` when building the results in `analyze.py`
- allow `write_summary` to accept the dataclass directly
- update tests to convert dataclass outputs using `to_native` and handle timestamp parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b0744cb1c832bb78aa7e4f82d561a