### PR TITLE
Add covariance dimension checks

### DIFF
--- a/fitting.py
+++ b/fitting.py
@@ -89,6 +89,17 @@ class FitResult:
             self.param_index = {name: i for i, name in enumerate(ordered)}
         if self.cov is not None:
             self.cov = np.asarray(self.cov, dtype=float)
+            if (
+                self.param_index is not None
+                and (
+                    self.cov.ndim != 2
+                    or self.cov.shape[0] != self.cov.shape[1]
+                    or self.cov.shape[0] != len(self.param_index)
+                )
+            ):
+                raise ValueError(
+                    "Covariance matrix shape inconsistent with parameters"
+                )
 
     def get_cov(self, name1: str, name2: str) -> float:
         """Return covariance entry for two parameters."""

--- a/tests/test_cov_entry.py
+++ b/tests/test_cov_entry.py
@@ -46,3 +46,17 @@ def test_cov_entry_missing_params():
 
     fr_none = FitResult(params, None, 0)
     assert fr_none.get_cov("A", "B") == 0.0
+
+
+def test_cov_entry_dimension_mismatch():
+    params = {"A": 1.0, "B": 2.0, "C": 3.0}
+    cov = np.eye(2)
+    with pytest.raises(ValueError):
+        FitResult(params, cov, 0)
+
+
+def test_cov_entry_non_square():
+    params = {"A": 1.0, "B": 2.0}
+    cov = np.ones((2, 3))
+    with pytest.raises(ValueError):
+        FitResult(params, cov, 0)


### PR DESCRIPTION
## Summary
- validate covariance matrix size in `FitResult.__post_init__`
- raise a `ValueError` when covariance shape mismatches parameters
- test invalid covariance shapes

## Testing
- `pytest tests/test_cov_entry.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685b09407628832b9a77b0047f163032