### PR TITLE
Improve FitResult param handling

### DIFF
--- a/fitting.py
+++ b/fitting.py
@@ -84,11 +84,22 @@ class FitResult:
             ordered = [
                 k
                 for k in self.params.keys()
-                if k != "fit_valid" and not k.startswith("d")
+                if k != "fit_valid" and not k.startswith("d") and not k.startswith("cov_")
             ]
             self.param_index = {name: i for i, name in enumerate(ordered)}
         if self.cov is not None:
             self.cov = np.asarray(self.cov, dtype=float)
+            if (
+                self.param_index is not None
+                and self.cov.ndim >= 2
+                and (
+                    self.cov.shape[0] != len(self.param_index)
+                    or self.cov.shape[1] != len(self.param_index)
+                )
+            ):
+                raise ValueError(
+                    "Covariance matrix dimension does not match parameter index"
+                )
 
     def get_cov(self, name1: str, name2: str) -> float:
         """Return covariance entry for two parameters."""

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -329,7 +329,11 @@ def test_systematics_json_cli(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
     monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0))
 
-    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({"E":0.0}), np.zeros((0,0)), 0))
+    monkeypatch.setattr(
+        analyze,
+        "fit_time_series",
+        lambda *a, **k: FitResult(FitParams({"E": 0.0}), np.zeros((1, 1)), 0),
+    )
     monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
     monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())

--- a/tests/test_cov_entry.py
+++ b/tests/test_cov_entry.py
@@ -46,3 +46,15 @@ def test_cov_entry_missing_params():
 
     fr_none = FitResult(params, None, 0)
     assert fr_none.get_cov("A", "B") == 0.0
+
+
+def test_cov_entry_prefix_handled():
+    params = {
+        "A": 1.0,
+        "B": 2.0,
+        "cov_A_B": 0.1,
+    }
+    cov = np.array([[1.0, 0.1], [0.1, 4.0]])
+    fr = FitResult(params, cov, 0)
+    assert len(fr.param_index) == 2
+    assert fr.get_cov("A", "B") == pytest.approx(0.1)


### PR DESCRIPTION
## Summary
- ignore `cov_*` fields when deriving `param_index` in `FitResult`
- validate covariance matrix size matches parameters
- cover `cov_*` handling with new unit test
- adjust CLI test for new FitResult requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b093fc5f0832b971605d491686bee