### PR TITLE
Add timezone checks to event helpers

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -330,8 +330,9 @@ def load_events(csv_path, *, column_map=None):
     # Convert types
     df["adc"] = df["adc"].astype(float)
 
-    # Sort by timestamp
+    # Sort by timestamp and ensure timezone-aware timestamps
     df = df.sort_values("timestamp").reset_index(drop=True)
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
 
     logger.info(
         f"Loaded {len(df)} events from {csv_path} ({discarded} discarded)."

--- a/tests/test_baseline_datetime.py
+++ b/tests/test_baseline_datetime.py
@@ -7,11 +7,13 @@ import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import baseline
+from io_utils import load_events
 
 
 def test_rate_histogram_datetime_column():
     ts = pd.date_range("1970-01-01", periods=5, freq="s", tz="UTC")
     df = pd.DataFrame({"timestamp": ts, "adc": np.arange(5)})
+    assert df["timestamp"].dtype == "datetime64[ns, UTC]"
     bins = np.arange(0, 7)
     rate, live = baseline.rate_histogram(df, bins)
     assert live == pytest.approx(4.0)
@@ -21,6 +23,7 @@ def test_rate_histogram_datetime_column():
 def test_subtract_baseline_datetime_column():
     ts_an = pd.date_range("1970-01-01", periods=5, freq="s", tz="UTC")
     df_an = pd.DataFrame({"timestamp": ts_an, "adc": [1, 2, 3, 4, 5]})
+    assert df_an["timestamp"].dtype == "datetime64[ns, UTC]"
     ts_bl = pd.to_datetime(np.linspace(86400, 86440, 50), unit="s", utc=True)
     df_bl = pd.DataFrame({"timestamp": ts_bl, "adc": np.tile([1,2,3,4,5],10)})
     df_full = pd.concat([df_an, df_bl], ignore_index=True)
@@ -35,4 +38,69 @@ def test_subtract_baseline_datetime_column():
     )
     integral = out["subtracted_adc_hist"].iloc[0].sum()
     assert integral == pytest.approx(0.0, rel=1e-6)
+    assert out["timestamp"].dtype == "datetime64[ns, UTC]"
+
+
+def test_subtract_baseline_loaded_from_csv(tmp_path):
+    df_an = pd.DataFrame(
+        {
+            "fUniqueID": [1, 2, 3],
+            "fBits": [0, 0, 0],
+            "timestamp": [0.0, 1.0, 2.0],
+            "adc": [1, 2, 3],
+            "fchannel": [1, 1, 1],
+        }
+    )
+    df_full = pd.DataFrame(
+        {
+            "fUniqueID": [4, 5, 6, 7],
+            "fBits": [0, 0, 0, 0],
+            "timestamp": [100.0, 110.0, 120.0, 130.0],
+            "adc": [1, 2, 3, 4],
+            "fchannel": [1, 1, 1, 1],
+        }
+    )
+    p_an = tmp_path / "an.csv"
+    p_full = tmp_path / "full.csv"
+    df_an.to_csv(p_an, index=False)
+    df_full.to_csv(p_full, index=False)
+
+    an_loaded = load_events(p_an)
+    full_loaded = load_events(p_full)
+
+    out = baseline.subtract_baseline(
+        an_loaded,
+        pd.concat([an_loaded, full_loaded], ignore_index=True),
+        bins=np.arange(0, 7),
+        t_base0=100.0,
+        t_base1=130.0,
+    )
+
+    assert out["timestamp"].dtype == "datetime64[ns, UTC]"
+
+
+def test_subtract_baseline_string_times(tmp_path):
+    df = pd.DataFrame(
+        {
+            "fUniqueID": [1, 2],
+            "fBits": [0, 0],
+            "timestamp": ["1970-01-01T00:00:00Z", "1970-01-01T00:00:01Z"],
+            "adc": [1, 2],
+            "fchannel": [1, 1],
+        }
+    )
+    p = tmp_path / "str.csv"
+    df.to_csv(p, index=False)
+    loaded = load_events(p)
+
+    out = baseline.subtract_baseline(
+        loaded,
+        loaded,
+        bins=np.arange(0, 3),
+        t_base0="1970-01-01T00:00:00Z",
+        t_base1="1970-01-01T00:00:01Z",
+        mode="none",
+    )
+
+    assert out["timestamp"].dtype == "datetime64[ns, UTC]"
 

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -81,11 +81,11 @@ def test_load_events(tmp_path, caplog):
     df.to_csv(p, index=False)
     with caplog.at_level(logging.INFO):
         loaded = load_events(p)
-    assert loaded["timestamp"].dtype == "datetime64[ns]"
-    expected_ts = np.array(
-        [parse_datetime(t) for t in (1000, 1005, 1010)], dtype="datetime64[ns]"
+    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
+    expected_ts = pd.to_datetime(
+        [parse_datetime(t) for t in (1000, 1005, 1010)], utc=True
     )
-    assert np.array_equal(loaded["timestamp"].values, expected_ts)
+    assert np.array_equal(loaded["timestamp"].to_numpy(), expected_ts.to_numpy())
     assert np.array_equal(loaded["adc"].values, np.array([1200, 1300, 1250]))
     assert "0 discarded" in caplog.text
 
@@ -105,11 +105,11 @@ def test_load_events_drop_bad_rows(tmp_path, caplog):
     with caplog.at_level(logging.INFO):
         loaded = load_events(p)
     # Expect rows with NaN/inf removed and duplicate dropped
-    assert loaded["timestamp"].dtype == "datetime64[ns]"
-    expected_ts = np.array(
-        [parse_datetime(t) for t in (1000, 1005, 1020)], dtype="datetime64[ns]"
+    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
+    expected_ts = pd.to_datetime(
+        [parse_datetime(t) for t in (1000, 1005, 1020)], utc=True
     )
-    assert np.array_equal(loaded["timestamp"].values, expected_ts)
+    assert np.array_equal(loaded["timestamp"].to_numpy(), expected_ts.to_numpy())
     assert "3 discarded" in caplog.text
 
 
@@ -126,8 +126,8 @@ def test_load_events_column_aliases(tmp_path):
     p = tmp_path / "alias.csv"
     df.to_csv(p, index=False)
     loaded = load_events(p)
-    assert loaded["timestamp"].dtype == "datetime64[ns]"
-    assert list(loaded["timestamp"])[0] == pd.Timestamp(parse_datetime(1000))
+    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
+    assert list(loaded["timestamp"])[0] == pd.to_datetime(parse_datetime(1000), utc=True)
     assert list(loaded["adc"])[0] == 1250
     assert "time" not in loaded.columns
     assert "adc_ch" not in loaded.columns
@@ -153,7 +153,7 @@ def test_load_events_custom_columns(tmp_path):
         "fchannel": "chan",
     }
     loaded = load_events(p, column_map=column_map)
-    assert list(loaded["timestamp"])[0] == pd.Timestamp(parse_datetime(1000))
+    assert list(loaded["timestamp"])[0] == pd.to_datetime(parse_datetime(1000), utc=True)
     assert list(loaded["adc"])[0] == 1250
     assert "ftimestamps" not in loaded.columns
 
@@ -188,7 +188,8 @@ def test_load_events_string_nan(tmp_path):
     df.to_csv(p, index=False)
     loaded = load_events(p)
     assert len(loaded) == 1
-    assert loaded["timestamp"].iloc[0] == pd.Timestamp(parse_datetime(1000))
+    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
+    assert loaded["timestamp"].iloc[0] == pd.to_datetime(parse_datetime(1000), utc=True)
 
 
 def test_write_summary_and_copy_config(tmp_path):


### PR DESCRIPTION
## Summary
- ensure `load_events` returns timezone-aware timestamps
- verify timezone information in `test_io_utils` and `test_baseline_datetime`
- add regression tests for loading/subtracting baseline from CSV data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b06a80aec832bb8a60001a1bf186d