### PR TITLE
Ensure UTC-aware datetimes

### DIFF
--- a/baseline_utils.py
+++ b/baseline_utils.py
@@ -95,8 +95,8 @@ def subtract_baseline_dataframe(
     if live_time_analysis is None:
         live_time_analysis = live_an
 
-    t0 = parse_datetime(t_base0)
-    t1 = parse_datetime(t_base1)
+    t0 = parse_datetime(t_base0).to_datetime64()
+    t1 = parse_datetime(t_base1).to_datetime64()
     ts_full = _seconds(df_full["timestamp"])
     mask = (ts_full >= t0) & (ts_full <= t1)
     if not mask.any():

--- a/tests/test_interval_parsing.py
+++ b/tests/test_interval_parsing.py
@@ -31,10 +31,10 @@ def test_config_interval_parsing_to_datetime():
         "baseline": {"range": ["1970-01-01T00:00:01Z", "1970-01-01T00:00:02Z"]},
         "analysis": {"radon_interval": ["1970-01-01T00:00:03Z", "1970-01-01T00:00:04Z"]},
     }
-    b_start = pd.to_datetime(parse_datetime(cfg["baseline"]["range"][0]), utc=True)
-    b_end = pd.to_datetime(parse_datetime(cfg["baseline"]["range"][1]), utc=True)
-    r_start = pd.to_datetime(parse_datetime(cfg["analysis"]["radon_interval"][0]), utc=True)
-    r_end = pd.to_datetime(parse_datetime(cfg["analysis"]["radon_interval"][1]), utc=True)
+    b_start = parse_datetime(cfg["baseline"]["range"][0])
+    b_end = parse_datetime(cfg["baseline"]["range"][1])
+    r_start = parse_datetime(cfg["analysis"]["radon_interval"][0])
+    r_end = parse_datetime(cfg["analysis"]["radon_interval"][1])
     for dt in (b_start, b_end, r_start, r_end):
         assert dt.tzinfo is not None
         assert dt.tzinfo.utcoffset(dt) == timedelta(0)

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -81,11 +81,9 @@ def test_load_events(tmp_path, caplog):
     df.to_csv(p, index=False)
     with caplog.at_level(logging.INFO):
         loaded = load_events(p)
-    assert loaded["timestamp"].dtype == "datetime64[ns]"
-    expected_ts = np.array(
-        [parse_datetime(t) for t in (1000, 1005, 1010)], dtype="datetime64[ns]"
-    )
-    assert np.array_equal(loaded["timestamp"].values, expected_ts)
+    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
+    expected_ts = [parse_datetime(t) for t in (1000, 1005, 1010)]
+    assert list(loaded["timestamp"]) == expected_ts
     assert np.array_equal(loaded["adc"].values, np.array([1200, 1300, 1250]))
     assert "0 discarded" in caplog.text
 
@@ -105,11 +103,9 @@ def test_load_events_drop_bad_rows(tmp_path, caplog):
     with caplog.at_level(logging.INFO):
         loaded = load_events(p)
     # Expect rows with NaN/inf removed and duplicate dropped
-    assert loaded["timestamp"].dtype == "datetime64[ns]"
-    expected_ts = np.array(
-        [parse_datetime(t) for t in (1000, 1005, 1020)], dtype="datetime64[ns]"
-    )
-    assert np.array_equal(loaded["timestamp"].values, expected_ts)
+    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
+    expected_ts = [parse_datetime(t) for t in (1000, 1005, 1020)]
+    assert list(loaded["timestamp"]) == expected_ts
     assert "3 discarded" in caplog.text
 
 
@@ -126,7 +122,7 @@ def test_load_events_column_aliases(tmp_path):
     p = tmp_path / "alias.csv"
     df.to_csv(p, index=False)
     loaded = load_events(p)
-    assert loaded["timestamp"].dtype == "datetime64[ns]"
+    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
     assert list(loaded["timestamp"])[0] == pd.Timestamp(parse_datetime(1000))
     assert list(loaded["adc"])[0] == 1250
     assert "time" not in loaded.columns

--- a/tests/test_parse_datetime.py
+++ b/tests/test_parse_datetime.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 from datetime import datetime, timezone, timedelta
 import numpy as np
+import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -10,50 +11,50 @@ from utils import parse_datetime
 
 def test_parse_datetime_iso_string():
     ts = parse_datetime("1970-01-01T00:00:00Z")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_numeric():
     ts = parse_datetime(42)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64(42, "s")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp(42, unit="s", tz="UTC")
 
 
 def test_parse_datetime_numeric_str():
     ts = parse_datetime("42")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64(42, "s")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp(42, unit="s", tz="UTC")
 
 
 def test_parse_datetime_naive_datetime():
     dt = datetime(1970, 1, 1)
     ts = parse_datetime(dt)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_float():
     ts = parse_datetime(42.5)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:42.500000000")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp(42.5, unit="s", tz="UTC")
 
 
 def test_parse_datetime_iso_without_tz():
     ts = parse_datetime("1970-01-01T00:00:00")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_iso_with_offset():
     ts = parse_datetime("1970-01-01T01:00:00+01:00")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_datetime_with_tz():
     dt = datetime(1970, 1, 1, 1, tzinfo=timezone(timedelta(hours=1)))
     ts = parse_datetime(dt)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 

--- a/utils.py
+++ b/utils.py
@@ -252,13 +252,14 @@ def to_utc_datetime(value, tz="UTC") -> datetime:
 
 
 def parse_datetime(value):
-    """Parse an ISO-8601 string or numeric epoch value to ``numpy.datetime64``.
+    """Parse an ISO-8601 string or numeric epoch value to a timezone aware
+    ``datetime64`` value.
 
     The function accepts strings like ``"2023-09-28T13:45:00-04:00"`` or
     numeric Unix timestamps (as ``int``, ``float`` or numeric ``str``). Any
     parsed time lacking a timezone is interpreted as UTC. On success a
-    ``numpy.datetime64`` object in UTC (nanosecond resolution) is returned.
-    ``ValueError`` is raised if the input cannot be parsed.
+    ``datetime64[ns, UTC]`` scalar is returned. ``ValueError`` is raised if the
+    input cannot be parsed.
     """
 
     try:
@@ -269,7 +270,7 @@ def parse_datetime(value):
     if pd is None:
         raise RuntimeError("pandas is required for parse_datetime")
 
-    return pd.Timestamp(dt).to_datetime64()
+    return pd.Timestamp(dt)
 
 
 def parse_time(s, tz="UTC") -> float:


### PR DESCRIPTION
## Summary
- keep timezone information when parsing datetimes
- update `load_events` to preserve `datetime64[ns, UTC]`
- adapt baseline utilities to handle timezone-aware timestamps
- revise tests for timezone aware data

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b06a617a8832bbc9e7894f5eb34cd