### PR TITLE
Update datetime tests for timezone support

### DIFF
--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -81,11 +81,13 @@ def test_load_events(tmp_path, caplog):
     df.to_csv(p, index=False)
     with caplog.at_level(logging.INFO):
         loaded = load_events(p)
-    assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
-    expected_ts = pd.to_datetime([1000, 1005, 1010], unit="s", utc=True)
-    assert np.array_equal(
-        loaded["timestamp"].view("int64"), expected_ts.view("int64")
-    )
+    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
+    expected_ts = np.array([
+        pd.Timestamp(1000, unit="s", tz="UTC"),
+        pd.Timestamp(1005, unit="s", tz="UTC"),
+        pd.Timestamp(1010, unit="s", tz="UTC"),
+    ])
+    assert np.array_equal(loaded["timestamp"].to_numpy(), expected_ts)
     assert np.array_equal(loaded["adc"].values, np.array([1200, 1300, 1250]))
     assert "0 discarded" in caplog.text
 
@@ -105,11 +107,13 @@ def test_load_events_drop_bad_rows(tmp_path, caplog):
     with caplog.at_level(logging.INFO):
         loaded = load_events(p)
     # Expect rows with NaN/inf removed and duplicate dropped
-    assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
-    expected_ts = pd.to_datetime([1000, 1005, 1020], unit="s", utc=True)
-    assert np.array_equal(
-        loaded["timestamp"].view("int64"), expected_ts.view("int64")
-    )
+    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
+    expected_ts = np.array([
+        pd.Timestamp(1000, unit="s", tz="UTC"),
+        pd.Timestamp(1005, unit="s", tz="UTC"),
+        pd.Timestamp(1020, unit="s", tz="UTC"),
+    ])
+    assert np.array_equal(loaded["timestamp"].to_numpy(), expected_ts)
     assert "3 discarded" in caplog.text
 
 
@@ -126,8 +130,8 @@ def test_load_events_column_aliases(tmp_path):
     p = tmp_path / "alias.csv"
     df.to_csv(p, index=False)
     loaded = load_events(p)
-    assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
-    assert list(loaded["timestamp"])[0] == pd.to_datetime(parse_datetime(1000), utc=True)
+    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
+    assert list(loaded["timestamp"])[0] == pd.Timestamp(1000, unit="s", tz="UTC")
     assert list(loaded["adc"])[0] == 1250
     assert "time" not in loaded.columns
     assert "adc_ch" not in loaded.columns
@@ -153,8 +157,8 @@ def test_load_events_custom_columns(tmp_path):
         "fchannel": "chan",
     }
     loaded = load_events(p, column_map=column_map)
-    assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
-    assert list(loaded["timestamp"])[0] == pd.to_datetime(parse_datetime(1000), utc=True)
+    assert loaded["timestamp"].dtype == "datetime64[ns, UTC]"
+    assert list(loaded["timestamp"])[0] == pd.Timestamp(1000, unit="s", tz="UTC")
     assert list(loaded["adc"])[0] == 1250
     assert "ftimestamps" not in loaded.columns
 
@@ -189,7 +193,7 @@ def test_load_events_string_nan(tmp_path):
     df.to_csv(p, index=False)
     loaded = load_events(p)
     assert len(loaded) == 1
-    assert loaded["timestamp"].iloc[0] == pd.to_datetime(parse_datetime(1000), utc=True)
+    assert loaded["timestamp"].iloc[0] == pd.Timestamp(1000, unit="s", tz="UTC")
 
 
 def test_write_summary_and_copy_config(tmp_path):

--- a/tests/test_parse_datetime.py
+++ b/tests/test_parse_datetime.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 from datetime import datetime, timezone, timedelta
 import numpy as np
+import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -10,50 +11,58 @@ from utils import parse_datetime
 
 def test_parse_datetime_iso_string():
     ts = parse_datetime("1970-01-01T00:00:00Z")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
+    assert ts.tzinfo == timezone.utc
 
 
 def test_parse_datetime_numeric():
     ts = parse_datetime(42)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64(42, "s")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp(42, unit="s", tz="UTC")
+    assert ts.tzinfo == timezone.utc
 
 
 def test_parse_datetime_numeric_str():
     ts = parse_datetime("42")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64(42, "s")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp(42, unit="s", tz="UTC")
+    assert ts.tzinfo == timezone.utc
 
 
 def test_parse_datetime_naive_datetime():
     dt = datetime(1970, 1, 1)
     ts = parse_datetime(dt)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
+    assert ts.tzinfo == timezone.utc
 
 
 def test_parse_datetime_float():
     ts = parse_datetime(42.5)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:42.500000000")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp(42.5, unit="s", tz="UTC")
+    assert ts.tzinfo == timezone.utc
 
 
 def test_parse_datetime_iso_without_tz():
     ts = parse_datetime("1970-01-01T00:00:00")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
+    assert ts.tzinfo == timezone.utc
 
 
 def test_parse_datetime_iso_with_offset():
     ts = parse_datetime("1970-01-01T01:00:00+01:00")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
+    assert ts.tzinfo == timezone.utc
 
 
 def test_parse_datetime_datetime_with_tz():
     dt = datetime(1970, 1, 1, 1, tzinfo=timezone(timedelta(hours=1)))
     ts = parse_datetime(dt)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
+    assert ts.tzinfo == timezone.utc
 

--- a/utils.py
+++ b/utils.py
@@ -252,12 +252,12 @@ def to_utc_datetime(value, tz="UTC") -> datetime:
 
 
 def parse_datetime(value):
-    """Parse an ISO-8601 string or numeric epoch value to ``numpy.datetime64``.
+    """Parse an ISO-8601 string or numeric epoch value to ``pandas.Timestamp``.
 
     The function accepts strings like ``"2023-09-28T13:45:00-04:00"`` or
     numeric Unix timestamps (as ``int``, ``float`` or numeric ``str``). Any
     parsed time lacking a timezone is interpreted as UTC. On success a
-    ``numpy.datetime64`` object in UTC (nanosecond resolution) is returned.
+    timezone-aware ``pandas.Timestamp`` in UTC is returned.
     ``ValueError`` is raised if the input cannot be parsed.
     """
 
@@ -269,7 +269,7 @@ def parse_datetime(value):
     if pd is None:
         raise RuntimeError("pandas is required for parse_datetime")
 
-    return pd.Timestamp(dt).to_datetime64()
+    return pd.Timestamp(dt)
 
 
 def parse_time(s, tz="UTC") -> float:


### PR DESCRIPTION
## Summary
- ensure `parse_datetime` returns a timezone-aware `pd.Timestamp`
- update `tests/test_io_utils.py` to expect timezone-aware timestamps
- expect `pd.Timestamp` objects in `tests/test_parse_datetime.py`

## Testing
- `pytest tests/test_io_utils.py::test_load_events tests/test_io_utils.py::test_load_events_drop_bad_rows tests/test_io_utils.py::test_load_events_column_aliases tests/test_io_utils.py::test_load_events_custom_columns tests/test_io_utils.py::test_load_events_string_nan tests/test_parse_datetime.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685b12afebe4832b81ab4f5872333766