### PR TITLE
Fix timezone handling for event timestamps

### DIFF
--- a/baseline.py
+++ b/baseline.py
@@ -5,7 +5,12 @@ from utils import parse_datetime
 
 from baseline_utils import subtract_baseline_dataframe
 
-__all__ = ["compute_rate_histogram", "subtract_baseline_df", "subtract_baseline_dataframe"]
+__all__ = [
+    "compute_rate_histogram",
+    "subtract_baseline_df",
+    "subtract_baseline_dataframe",
+    "subtract_baseline",
+]
 
 
 def _to_datetime64(col):
@@ -13,11 +18,13 @@ def _to_datetime64(col):
 
     if pd.api.types.is_datetime64_any_dtype(col):
         ser = col
-        if getattr(ser.dtype, "tz", None) is not None:
-            ser = ser.dt.tz_convert("UTC").dt.tz_localize(None)
-        ts = ser.astype("datetime64[ns]").to_numpy()
     else:
-        ts = col.map(parse_datetime).astype("datetime64[ns]").to_numpy()
+        ser = col.map(parse_datetime)
+
+    if getattr(ser.dtype, "tz", None) is not None:
+        ser = ser.dt.tz_convert("UTC").dt.tz_localize(None)
+
+    ts = ser.astype("datetime64[ns]").to_numpy()
     return np.asarray(ts)
 
 
@@ -39,6 +46,20 @@ def subtract_baseline_df(df_analysis, df_full, bins, t_base0, t_base1,
     """Wrapper for :func:`baseline_utils.subtract_baseline_dataframe`."""
 
     return subtract_baseline_dataframe(
+        df_analysis,
+        df_full,
+        bins,
+        t_base0,
+        t_base1,
+        mode=mode,
+        live_time_analysis=live_time_analysis,
+    )
+
+
+def subtract_baseline(df_analysis, df_full, bins, t_base0, t_base1,
+                      mode="all", live_time_analysis=None):
+    """Backward-compatible alias for :func:`subtract_baseline_df`."""
+    return subtract_baseline_df(
         df_analysis,
         df_full,
         bins,

--- a/io_utils.py
+++ b/io_utils.py
@@ -296,7 +296,7 @@ def load_events(csv_path, *, column_map=None):
 
     df = df.rename(columns=rename, errors="ignore")
 
-    # Parse timestamps directly to ``datetime64`` values
+    # Parse timestamps directly to timezone-aware ``Timestamp`` values
     if "timestamp" in df.columns:
         def _safe_parse(val):
             try:
@@ -304,9 +304,7 @@ def load_events(csv_path, *, column_map=None):
             except Exception:
                 return pd.NaT
 
-        df["timestamp"] = pd.to_datetime(
-            df["timestamp"].map(_safe_parse), utc=True
-        )
+        df["timestamp"] = df["timestamp"].map(_safe_parse)
 
     # Check required columns after renaming
     required_cols = ["fUniqueID", "fBits", "timestamp", "adc", "fchannel"]

--- a/tests/test_interval_parsing.py
+++ b/tests/test_interval_parsing.py
@@ -7,7 +7,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 from utils import parse_time_arg, parse_datetime
 from dateutil.tz import gettz
-import pandas as pd
 
 
 def test_cli_interval_parsing_to_datetime():
@@ -31,10 +30,10 @@ def test_config_interval_parsing_to_datetime():
         "baseline": {"range": ["1970-01-01T00:00:01Z", "1970-01-01T00:00:02Z"]},
         "analysis": {"radon_interval": ["1970-01-01T00:00:03Z", "1970-01-01T00:00:04Z"]},
     }
-    b_start = pd.to_datetime(parse_datetime(cfg["baseline"]["range"][0]), utc=True)
-    b_end = pd.to_datetime(parse_datetime(cfg["baseline"]["range"][1]), utc=True)
-    r_start = pd.to_datetime(parse_datetime(cfg["analysis"]["radon_interval"][0]), utc=True)
-    r_end = pd.to_datetime(parse_datetime(cfg["analysis"]["radon_interval"][1]), utc=True)
+    b_start = parse_datetime(cfg["baseline"]["range"][0])
+    b_end = parse_datetime(cfg["baseline"]["range"][1])
+    r_start = parse_datetime(cfg["analysis"]["radon_interval"][0])
+    r_end = parse_datetime(cfg["analysis"]["radon_interval"][1])
     for dt in (b_start, b_end, r_start, r_end):
         assert dt.tzinfo is not None
         assert dt.tzinfo.utcoffset(dt) == timedelta(0)

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -127,7 +127,7 @@ def test_load_events_column_aliases(tmp_path):
     df.to_csv(p, index=False)
     loaded = load_events(p)
     assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
-    assert list(loaded["timestamp"])[0] == pd.to_datetime(parse_datetime(1000), utc=True)
+    assert list(loaded["timestamp"])[0] == parse_datetime(1000)
     assert list(loaded["adc"])[0] == 1250
     assert "time" not in loaded.columns
     assert "adc_ch" not in loaded.columns
@@ -154,7 +154,7 @@ def test_load_events_custom_columns(tmp_path):
     }
     loaded = load_events(p, column_map=column_map)
     assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
-    assert list(loaded["timestamp"])[0] == pd.to_datetime(parse_datetime(1000), utc=True)
+    assert list(loaded["timestamp"])[0] == parse_datetime(1000)
     assert list(loaded["adc"])[0] == 1250
     assert "ftimestamps" not in loaded.columns
 
@@ -189,7 +189,7 @@ def test_load_events_string_nan(tmp_path):
     df.to_csv(p, index=False)
     loaded = load_events(p)
     assert len(loaded) == 1
-    assert loaded["timestamp"].iloc[0] == pd.to_datetime(parse_datetime(1000), utc=True)
+    assert loaded["timestamp"].iloc[0] == parse_datetime(1000)
 
 
 def test_write_summary_and_copy_config(tmp_path):

--- a/tests/test_parse_datetime.py
+++ b/tests/test_parse_datetime.py
@@ -1,59 +1,60 @@
 import sys
 from pathlib import Path
 from datetime import datetime, timezone, timedelta
-import numpy as np
+import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from utils import parse_datetime
 
 
+
 def test_parse_datetime_iso_string():
     ts = parse_datetime("1970-01-01T00:00:00Z")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_numeric():
     ts = parse_datetime(42)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64(42, "s")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp(42, unit="s", tz="UTC")
 
 
 def test_parse_datetime_numeric_str():
     ts = parse_datetime("42")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64(42, "s")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp(42, unit="s", tz="UTC")
 
 
 def test_parse_datetime_naive_datetime():
     dt = datetime(1970, 1, 1)
     ts = parse_datetime(dt)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_float():
     ts = parse_datetime(42.5)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:42.500000000")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp(42.5, unit="s", tz="UTC")
 
 
 def test_parse_datetime_iso_without_tz():
     ts = parse_datetime("1970-01-01T00:00:00")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_iso_with_offset():
     ts = parse_datetime("1970-01-01T01:00:00+01:00")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_datetime_with_tz():
     dt = datetime(1970, 1, 1, 1, tzinfo=timezone(timedelta(hours=1)))
     ts = parse_datetime(dt)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 


### PR DESCRIPTION
## Summary
- ensure `parse_datetime` returns a UTC timezone aware value
- keep timezone info when loading events
- support timezone aware values in baseline utilities
- expose `baseline.subtract_baseline` for backward compatibility
- update tests for timezone-aware datetimes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b12a91b94832b8a6e3d49282a5717