### PR TITLE
Return timezone-aware pandas Timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ search for peak centroids:
 - `cps_to_bq(rate_cps, volume_liters=None)` returns the activity in Bq, or
   Bq/m^3 when a detector volume is supplied.
 - `parse_datetime(value)` converts ISO‑8601 strings, numeric seconds or
-  `datetime` objects to a UTC `numpy.datetime64` object.
+  `datetime` objects to a timezone-aware `pandas.Timestamp` with dtype `datetime64[ns, UTC]`.
 - `find_adc_bin_peaks(adc_values, expected, window=50, prominence=0.0, width=None)`
   histogramises the raw ADC spectrum, searches for maxima near each expected
   centroid and returns a `{peak: adc_centroid}` mapping in ADC units.

--- a/baseline_utils.py
+++ b/baseline_utils.py
@@ -95,8 +95,8 @@ def subtract_baseline_dataframe(
     if live_time_analysis is None:
         live_time_analysis = live_an
 
-    t0 = parse_datetime(t_base0)
-    t1 = parse_datetime(t_base1)
+    t0 = parse_datetime(t_base0).to_datetime64()
+    t1 = parse_datetime(t_base1).to_datetime64()
     ts_full = _seconds(df_full["timestamp"])
     mask = (ts_full >= t0) & (ts_full <= t1)
     if not mask.any():

--- a/tests/test_parse_datetime.py
+++ b/tests/test_parse_datetime.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 from datetime import datetime, timezone, timedelta
 import numpy as np
+import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -10,50 +11,50 @@ from utils import parse_datetime
 
 def test_parse_datetime_iso_string():
     ts = parse_datetime("1970-01-01T00:00:00Z")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_numeric():
     ts = parse_datetime(42)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64(42, "s")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.to_datetime(42, unit="s", utc=True)
 
 
 def test_parse_datetime_numeric_str():
     ts = parse_datetime("42")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64(42, "s")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.to_datetime(42, unit="s", utc=True)
 
 
 def test_parse_datetime_naive_datetime():
     dt = datetime(1970, 1, 1)
     ts = parse_datetime(dt)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_float():
     ts = parse_datetime(42.5)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:42.500000000")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.to_datetime(42.5, unit="s", utc=True)
 
 
 def test_parse_datetime_iso_without_tz():
     ts = parse_datetime("1970-01-01T00:00:00")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_iso_with_offset():
     ts = parse_datetime("1970-01-01T01:00:00+01:00")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_datetime_with_tz():
     dt = datetime(1970, 1, 1, 1, tzinfo=timezone(timedelta(hours=1)))
     ts = parse_datetime(dt)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 

--- a/tests/test_timestamp_dtype.py
+++ b/tests/test_timestamp_dtype.py
@@ -30,7 +30,7 @@ def test_subtract_baseline_preserves_dtype():
     ts = pd.date_range("1970-01-01", periods=3, freq="s", tz="UTC")
     df = pd.DataFrame({"timestamp": ts, "adc": [1, 2, 3]})
     bins = np.arange(0, 5)
-    out = baseline.subtract_baseline(
+    out = baseline.subtract_baseline_df(
         df,
         df,
         bins=bins,

--- a/utils.py
+++ b/utils.py
@@ -252,12 +252,13 @@ def to_utc_datetime(value, tz="UTC") -> datetime:
 
 
 def parse_datetime(value):
-    """Parse an ISO-8601 string or numeric epoch value to ``numpy.datetime64``.
+    """Parse an ISO-8601 string or numeric epoch value to a
+    :class:`pandas.Timestamp`.
 
     The function accepts strings like ``"2023-09-28T13:45:00-04:00"`` or
     numeric Unix timestamps (as ``int``, ``float`` or numeric ``str``). Any
     parsed time lacking a timezone is interpreted as UTC. On success a
-    ``numpy.datetime64`` object in UTC (nanosecond resolution) is returned.
+    ``pandas.Timestamp`` with dtype ``datetime64[ns, UTC]`` is returned.
     ``ValueError`` is raised if the input cannot be parsed.
     """
 
@@ -269,7 +270,7 @@ def parse_datetime(value):
     if pd is None:
         raise RuntimeError("pandas is required for parse_datetime")
 
-    return pd.Timestamp(dt).to_datetime64()
+    return pd.Timestamp(dt)
 
 
 def parse_time(s, tz="UTC") -> float:


### PR DESCRIPTION
## Summary
- return `pd.Timestamp` from `utils.parse_datetime`
- adapt baseline utilities to work with new return type
- update documentation and unit tests accordingly

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b12acbfb0832b8c3ba727eedab048