### PR TITLE
Validate covariance matrix dimensions

### DIFF
--- a/fitting.py
+++ b/fitting.py
@@ -89,17 +89,14 @@ class FitResult:
             self.param_index = {name: i for i, name in enumerate(ordered)}
         if self.cov is not None:
             self.cov = np.asarray(self.cov, dtype=float)
-            if (
-                self.param_index is not None
-                and self.cov.ndim >= 2
-                and (
-                    self.cov.shape[0] != len(self.param_index)
-                    or self.cov.shape[1] != len(self.param_index)
-                )
-            ):
-                raise ValueError(
-                    "Covariance matrix dimension does not match parameter index"
-                )
+            if self.cov.ndim >= 2:
+                if self.cov.shape[0] != self.cov.shape[1] or (
+                    self.param_index is not None
+                    and self.cov.shape[0] != len(self.param_index)
+                ):
+                    raise ValueError(
+                        "cov must be square and match param_index length"
+                    )
 
     def get_cov(self, name1: str, name2: str) -> float:
         """Return covariance entry for two parameters."""

--- a/tests/test_cov_entry.py
+++ b/tests/test_cov_entry.py
@@ -59,3 +59,16 @@ def test_cov_entry_prefix_handled():
     assert len(fr.param_index) == 2
     assert "cov_A_B" not in fr.param_index
     assert fr.get_cov("A", "B") == pytest.approx(0.1)
+
+
+def test_fit_result_cov_mismatch():
+    params = {"A": 1.0, "B": 2.0, "C": 3.0}
+    cov = np.ones((2, 3))
+    with pytest.raises(ValueError):
+        FitResult(params, cov, 0)
+
+
+def test_fit_result_cov_ok():
+    params = {"A": 1.0, "B": 2.0, "C": 3.0}
+    cov = np.eye(3)
+    FitResult(params, cov, 0)


### PR DESCRIPTION
## Summary
- validate that covariance matrix is square and matches parameter count
- test FitResult covariance matrix validation

## Testing
- `pytest -q tests/test_cov_entry.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b42338c4c832b8dd6d7392ef01e8e