### PR TITLE
Remove Po214 model uncertainty special case

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -344,14 +344,7 @@ def _model_uncertainty(centers, widths, fit_obj, iso, cfg, normalise):
     dE = params.get("dE_corrected", params.get(f"dE_{iso}", 0.0))
     dN0 = params.get(f"dN0_{iso}", 0.0)
     dB = params.get(f"dB_{iso}", params.get("dB", 0.0))
-    cov = 0.0
-    if iso == "Po214":
-        cov = params.get("cov_E_Po214_N0_Po214", 0.0)
-    else:
-        try:
-            cov = _cov_entry(fit_obj, f"E_{iso}", f"N0_{iso}")
-        except Exception:
-            cov = 0.0
+    cov = _cov_entry(fit_obj, f"E_{iso}", f"N0_{iso}")
     t = np.asarray(centers, dtype=float)
     exp_term = np.exp(-lam * t)
     dR_dE = eff * (1.0 - exp_term)

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -562,13 +562,20 @@ def test_model_uncertainty_uses_covariance():
         "dN0_Po214": 0.2,
         "B_Po214": 0.0,
         "dB_Po214": 0.0,
-        "cov_E_Po214_N0_Po214": 0.05,
         "fit_valid": True,
     }
-    fr = FitResult(params, np.zeros((3, 3)), 0)
-    params_nc = dict(params)
-    params_nc.pop("cov_E_Po214_N0_Po214")
-    fr_nc = FitResult(params_nc, np.zeros((3, 3)), 0)
+    cov = np.array([
+        [0.01, 0.05, 0.0],
+        [0.05, 0.04, 0.0],
+        [0.0, 0.0, 0.0],
+    ])
+    fr = FitResult(params, cov, 0)
+    cov_nc = np.array([
+        [0.01, 0.0, 0.0],
+        [0.0, 0.04, 0.0],
+        [0.0, 0.0, 0.0],
+    ])
+    fr_nc = FitResult(params, cov_nc, 0)
     cfg = {"time_fit": {"hl_po214": [10.0], "eff_po214": [1.0]}}
     with_cov = analyze._model_uncertainty(centers, widths, fr, "Po214", cfg, True)
     no_cov = analyze._model_uncertainty(centers, widths, fr_nc, "Po214", cfg, True)


### PR DESCRIPTION
## Summary
- simplify `_model_uncertainty` by using `_cov_entry` for all isotopes
- update unit test to verify covariance matrix is used

## Testing
- `pytest -q tests/test_fitting.py`

------
https://chatgpt.com/codex/tasks/task_e_685b423af648832ba68f82de1320e31d