### PR TITLE
Improve timezone dtype tests

### DIFF
--- a/tests/test_baseline_datetime.py
+++ b/tests/test_baseline_datetime.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-from datetime import datetime, timezone
 import pytest
 
 import sys
@@ -30,8 +29,8 @@ def test_subtract_baseline_datetime_column():
         df_an,
         df_full,
         bins=bins,
-        t_base0=datetime(1970,1,2,0,0,0,tzinfo=timezone.utc),
-        t_base1=datetime(1970,1,2,0,0,40,tzinfo=timezone.utc),
+        t_base0=pd.Timestamp("1970-01-02T00:00:00Z"),
+        t_base1=pd.Timestamp("1970-01-02T00:00:40Z"),
         mode="all",
     )
     integral = out["subtracted_adc_hist"].iloc[0].sum()

--- a/tests/test_baseline_subtract.py
+++ b/tests/test_baseline_subtract.py
@@ -2,7 +2,6 @@ import pytest
 import numpy as np
 import pandas as pd
 from pathlib import Path
-from datetime import datetime, timezone
 
 import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -63,8 +62,8 @@ def test_baseline_none_datetime():
         df,
         df,
         bins=bins,
-        t_base0=datetime.fromtimestamp(0, tz=timezone.utc),
-        t_base1=datetime.fromtimestamp(5, tz=timezone.utc),
+        t_base0=pd.Timestamp(0, unit="s", tz="UTC"),
+        t_base1=pd.Timestamp(5, unit="s", tz="UTC"),
         mode="none",
     )
     hist_before, _ = baseline.rate_histogram(df, bins)
@@ -87,8 +86,8 @@ def test_baseline_time_norm_datetime():
         df_an,
         df_full,
         bins=bins,
-        t_base0=datetime.fromtimestamp(100, tz=timezone.utc),
-        t_base1=datetime.fromtimestamp(140, tz=timezone.utc),
+        t_base0=pd.Timestamp(100, unit="s", tz="UTC"),
+        t_base1=pd.Timestamp(140, unit="s", tz="UTC"),
         mode="all",
     )
     integral = out["subtracted_adc_hist"].iloc[0].sum()

--- a/tests/test_datetime_pipeline.py
+++ b/tests/test_datetime_pipeline.py
@@ -1,0 +1,54 @@
+import pandas as pd
+import numpy as np
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import baseline
+import analyze
+from io_utils import load_events
+
+
+def test_pipeline_preserves_timestamp_dtype(tmp_path):
+    df = pd.DataFrame({
+        "fUniqueID": [1, 2, 3],
+        "fBits": [0, 0, 0],
+        "timestamp": [
+            "1970-01-01T00:00:00Z",
+            "1970-01-01T00:00:01Z",
+            "1970-01-01T00:00:02Z",
+        ],
+        "adc": [10.0, 11.0, 12.0],
+        "fchannel": [1, 1, 1],
+    })
+    csv_path = tmp_path / "events.csv"
+    df.to_csv(csv_path, index=False)
+
+    loaded = load_events(csv_path)
+    assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
+
+    bins = np.arange(0, 20, 10)
+    sub = baseline.subtract_baseline(
+        loaded,
+        loaded,
+        bins=bins,
+        t_base0=pd.Timestamp("1970-01-01T00:00:00Z"),
+        t_base1=pd.Timestamp("1970-01-01T00:00:02Z"),
+        mode="none",
+    )
+    assert str(sub["timestamp"].dtype) == "datetime64[ns, UTC]"
+
+    args = argparse.Namespace(slope=None)
+    out_df, *_ = analyze.prepare_analysis_df(
+        sub,
+        spike_end=None,
+        spike_periods=[],
+        run_periods=[],
+        analysis_end=None,
+        t0_global=pd.Timestamp("1970-01-01T00:00:00Z"),
+        cfg={},
+        args=args,
+    )
+    assert str(out_df["timestamp"].dtype) == "datetime64[ns, UTC]"

--- a/tests/test_timestamp_dtype.py
+++ b/tests/test_timestamp_dtype.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import numpy as np
 import argparse
-from datetime import datetime, timezone
 
 import sys
 from pathlib import Path
@@ -34,8 +33,8 @@ def test_subtract_baseline_preserves_dtype():
         df,
         df,
         bins=bins,
-        t_base0=datetime(1970, 1, 1, tzinfo=timezone.utc),
-        t_base1=datetime(1970, 1, 1, 0, 2, tzinfo=timezone.utc),
+        t_base0=pd.Timestamp("1970-01-01T00:00:00Z"),
+        t_base1=pd.Timestamp("1970-01-01T00:00:02Z"),
         mode="none",
     )
     assert str(out["timestamp"].dtype) == "datetime64[ns, UTC]"
@@ -51,7 +50,7 @@ def test_prepare_analysis_df_preserves_dtype():
         spike_periods=[],
         run_periods=[],
         analysis_end=None,
-        t0_global=datetime(1970, 1, 1, tzinfo=timezone.utc),
+        t0_global=pd.Timestamp("1970-01-01T00:00:00Z"),
         cfg={},
         args=args,
     )


### PR DESCRIPTION
## Summary
- replace datetime instances in tests with pandas Timestamp
- ensure subtract_baseline and prepare_analysis_df keep timezone dtype
- add regression test for ISO timestamp pipeline

## Testing
- `pip install --no-cache-dir -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b46936e3c832ba9b5900b68491748