### PR TITLE
Remove Po214 special case for model uncertainty

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -344,14 +344,10 @@ def _model_uncertainty(centers, widths, fit_obj, iso, cfg, normalise):
     dE = params.get("dE_corrected", params.get(f"dE_{iso}", 0.0))
     dN0 = params.get(f"dN0_{iso}", 0.0)
     dB = params.get(f"dB_{iso}", params.get("dB", 0.0))
-    cov = 0.0
-    if iso == "Po214":
-        cov = params.get("cov_E_Po214_N0_Po214", 0.0)
-    else:
-        try:
-            cov = _cov_entry(fit_obj, f"E_{iso}", f"N0_{iso}")
-        except Exception:
-            cov = 0.0
+    try:
+        cov = _cov_entry(fit_obj, f"E_{iso}", f"N0_{iso}")
+    except Exception:
+        cov = 0.0
     t = np.asarray(centers, dtype=float)
     exp_term = np.exp(-lam * t)
     dR_dE = eff * (1.0 - exp_term)

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -562,13 +562,12 @@ def test_model_uncertainty_uses_covariance():
         "dN0_Po214": 0.2,
         "B_Po214": 0.0,
         "dB_Po214": 0.0,
-        "cov_E_Po214_N0_Po214": 0.05,
         "fit_valid": True,
     }
-    fr = FitResult(params, np.zeros((3, 3)), 0)
-    params_nc = dict(params)
-    params_nc.pop("cov_E_Po214_N0_Po214")
-    fr_nc = FitResult(params_nc, np.zeros((3, 3)), 0)
+    cov = np.zeros((3, 3))
+    cov[0, 1] = cov[1, 0] = 0.05
+    fr = FitResult(params, cov, 0)
+    fr_nc = FitResult(params, np.zeros((3, 3)), 0)
     cfg = {"time_fit": {"hl_po214": [10.0], "eff_po214": [1.0]}}
     with_cov = analyze._model_uncertainty(centers, widths, fr, "Po214", cfg, True)
     no_cov = analyze._model_uncertainty(centers, widths, fr_nc, "Po214", cfg, True)


### PR DESCRIPTION
## Summary
- compute Po214 covariance via `_cov_entry`
- update uncertainty test to rely on FitResult covariance

## Testing
- `pytest tests/test_fitting.py::test_model_uncertainty_uses_covariance -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b469c4044832b83cd7398ec5bea6d