### PR TITLE
Make parse_datetime return timezone-aware Timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository provides a complete pipeline to analyze electrostatic radon monitor data.
 
-**Note:** All time quantities are expressed in seconds and all energies are given in MeV throughout the documentation and code. Input timestamps are converted with `to_utc_datetime` which accepts ISO‑8601 strings (with or without timezone), numeric epoch seconds and `datetime` objects and returns a timezone‑aware `numpy.datetime64` in UTC. The function is available from `utils.py` and is used throughout the command-line interface so both ISO‑8601 strings and Unix seconds work interchangeably. A global `--timezone` option controls which zone naïve times are interpreted in (default: `UTC`). Event timestamps remain timezone‑aware `datetime64` objects inside the pipeline; epoch seconds are produced only for numeric computations such as histogramming or fits.
+**Note:** All time quantities are expressed in seconds and all energies are given in MeV throughout the documentation and code. Input timestamps are converted with `to_utc_datetime` which accepts ISO‑8601 strings (with or without timezone), numeric epoch seconds and `datetime` objects and returns a timezone‑aware `datetime` in UTC. The function is available from `utils.py` and is used throughout the command-line interface so both ISO‑8601 strings and Unix seconds work interchangeably. A global `--timezone` option controls which zone naïve times are interpreted in (default: `UTC`). Event timestamps remain timezone‑aware objects inside the pipeline; epoch seconds are produced only for numeric computations such as histogramming or fits.
 
 ## Structure
 
@@ -72,7 +72,7 @@ The input file must be a comma-separated table with these columns:
 - `fBits` – status bits or flags
 - `timestamp` – event timestamp in seconds
   (either numeric Unix seconds or an ISO‑8601 string; parsed directly to
-  ``numpy.datetime64`` values via `parse_datetime`)
+  timezone-aware ``pandas.Timestamp`` values via `parse_datetime`)
 - `adc` – raw ADC value
 - `fchannel` – acquisition channel
 
@@ -561,7 +561,7 @@ search for peak centroids:
 - `cps_to_bq(rate_cps, volume_liters=None)` returns the activity in Bq, or
   Bq/m^3 when a detector volume is supplied.
 - `parse_datetime(value)` converts ISO‑8601 strings, numeric seconds or
-  `datetime` objects to a UTC `numpy.datetime64` object.
+  `datetime` objects to a timezone-aware `pandas.Timestamp` in UTC.
 - `find_adc_bin_peaks(adc_values, expected, window=50, prominence=0.0, width=None)`
   histogramises the raw ADC spectrum, searches for maxima near each expected
   centroid and returns a `{peak: adc_centroid}` mapping in ADC units.

--- a/analyze.py
+++ b/analyze.py
@@ -223,10 +223,10 @@ def prepare_analysis_df(
     df_analysis = df.copy()
     ts = df_analysis["timestamp"]
     if not pd.api.types.is_datetime64_any_dtype(ts):
-        df_analysis["timestamp"] = pd.to_datetime(ts, unit="s", utc=True)
+        df_analysis["timestamp"] = ts.map(parse_datetime)
     else:
         if ts.dt.tz is None:
-            df_analysis["timestamp"] = ts.dt.tz_localize(timezone.utc)
+            df_analysis["timestamp"] = ts.map(parse_datetime)
         else:
             df_analysis["timestamp"] = ts.dt.tz_convert(timezone.utc)
 
@@ -820,15 +820,8 @@ def main(argv=None):
     try:
         events_all = load_events(args.input, column_map=cfg.get("columns"))
 
-        # 1) Parse non-datetime values
-        if not pd.api.types.is_datetime64_any_dtype(events_all["timestamp"]):
-            events_all["timestamp"] = events_all["timestamp"].map(parse_datetime)
-
-        # 2) Localize naïve datetimes to UTC
-        if events_all["timestamp"].dt.tz is None:
-            events_all["timestamp"] = events_all["timestamp"].dt.tz_localize(timezone.utc)
-        else:
-            events_all["timestamp"] = events_all["timestamp"].dt.tz_convert(timezone.utc)
+        # Parse timestamps to UTC ``Timestamp`` objects
+        events_all["timestamp"] = events_all["timestamp"].map(parse_datetime)
 
 
     except Exception as e:

--- a/baseline_utils.py
+++ b/baseline_utils.py
@@ -95,8 +95,8 @@ def subtract_baseline_dataframe(
     if live_time_analysis is None:
         live_time_analysis = live_an
 
-    t0 = parse_datetime(t_base0)
-    t1 = parse_datetime(t_base1)
+    t0 = parse_datetime(t_base0).to_datetime64()
+    t1 = parse_datetime(t_base1).to_datetime64()
     ts_full = _to_datetime64(df_full["timestamp"])
     mask = (ts_full >= t0) & (ts_full <= t1)
     if not mask.any():

--- a/io_utils.py
+++ b/io_utils.py
@@ -296,7 +296,7 @@ def load_events(csv_path, *, column_map=None):
 
     df = df.rename(columns=rename, errors="ignore")
 
-    # Parse timestamps directly to ``datetime64`` values
+    # Parse timestamps directly to timezone-aware ``Timestamp`` values
     if "timestamp" in df.columns:
         def _safe_parse(val):
             try:
@@ -304,9 +304,7 @@ def load_events(csv_path, *, column_map=None):
             except Exception:
                 return pd.NaT
 
-        df["timestamp"] = pd.to_datetime(
-            df["timestamp"].map(_safe_parse), utc=True
-        )
+        df["timestamp"] = df["timestamp"].map(_safe_parse)
 
     # Check required columns after renaming
     required_cols = ["fUniqueID", "fBits", "timestamp", "adc", "fchannel"]
@@ -389,10 +387,9 @@ def apply_burst_filter(df, cfg=None, mode="rate"):
     ts = out_df["timestamp"]
     if not pd.api.types.is_datetime64_any_dtype(ts):
         ts = ts.map(parse_datetime)
-        ts = pd.to_datetime(ts, utc=True)
     else:
         if ts.dt.tz is None:
-            ts = ts.dt.tz_localize("UTC")
+            ts = ts.map(parse_datetime)
         else:
             ts = ts.dt.tz_convert("UTC")
     out_df["timestamp"] = ts
@@ -435,10 +432,9 @@ def apply_burst_filter(df, cfg=None, mode="rate"):
             ts = out_df["timestamp"]
             if not pd.api.types.is_datetime64_any_dtype(ts):
                 ts = ts.map(parse_datetime)
-                ts = pd.to_datetime(ts, utc=True)
             else:
                 if ts.dt.tz is None:
-                    ts = ts.dt.tz_localize("UTC")
+                    ts = ts.map(parse_datetime)
                 else:
                     ts = ts.dt.tz_convert("UTC")
             out_df["timestamp"] = ts

--- a/tests/test_interval_parsing.py
+++ b/tests/test_interval_parsing.py
@@ -31,10 +31,10 @@ def test_config_interval_parsing_to_datetime():
         "baseline": {"range": ["1970-01-01T00:00:01Z", "1970-01-01T00:00:02Z"]},
         "analysis": {"radon_interval": ["1970-01-01T00:00:03Z", "1970-01-01T00:00:04Z"]},
     }
-    b_start = pd.to_datetime(parse_datetime(cfg["baseline"]["range"][0]), utc=True)
-    b_end = pd.to_datetime(parse_datetime(cfg["baseline"]["range"][1]), utc=True)
-    r_start = pd.to_datetime(parse_datetime(cfg["analysis"]["radon_interval"][0]), utc=True)
-    r_end = pd.to_datetime(parse_datetime(cfg["analysis"]["radon_interval"][1]), utc=True)
+    b_start = parse_datetime(cfg["baseline"]["range"][0])
+    b_end = parse_datetime(cfg["baseline"]["range"][1])
+    r_start = parse_datetime(cfg["analysis"]["radon_interval"][0])
+    r_end = parse_datetime(cfg["analysis"]["radon_interval"][1])
     for dt in (b_start, b_end, r_start, r_end):
         assert dt.tzinfo is not None
         assert dt.tzinfo.utcoffset(dt) == timedelta(0)

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -127,7 +127,7 @@ def test_load_events_column_aliases(tmp_path):
     df.to_csv(p, index=False)
     loaded = load_events(p)
     assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
-    assert list(loaded["timestamp"])[0] == pd.to_datetime(parse_datetime(1000), utc=True)
+    assert list(loaded["timestamp"])[0] == parse_datetime(1000)
     assert list(loaded["adc"])[0] == 1250
     assert "time" not in loaded.columns
     assert "adc_ch" not in loaded.columns
@@ -154,7 +154,7 @@ def test_load_events_custom_columns(tmp_path):
     }
     loaded = load_events(p, column_map=column_map)
     assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
-    assert list(loaded["timestamp"])[0] == pd.to_datetime(parse_datetime(1000), utc=True)
+    assert list(loaded["timestamp"])[0] == parse_datetime(1000)
     assert list(loaded["adc"])[0] == 1250
     assert "ftimestamps" not in loaded.columns
 
@@ -189,7 +189,7 @@ def test_load_events_string_nan(tmp_path):
     df.to_csv(p, index=False)
     loaded = load_events(p)
     assert len(loaded) == 1
-    assert loaded["timestamp"].iloc[0] == pd.to_datetime(parse_datetime(1000), utc=True)
+    assert loaded["timestamp"].iloc[0] == parse_datetime(1000)
 
 
 def test_write_summary_and_copy_config(tmp_path):

--- a/tests/test_parse_datetime.py
+++ b/tests/test_parse_datetime.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 from datetime import datetime, timezone, timedelta
 import numpy as np
+import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -10,50 +11,50 @@ from utils import parse_datetime
 
 def test_parse_datetime_iso_string():
     ts = parse_datetime("1970-01-01T00:00:00Z")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_numeric():
     ts = parse_datetime(42)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64(42, "s")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp(42, unit="s", tz="UTC")
 
 
 def test_parse_datetime_numeric_str():
     ts = parse_datetime("42")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64(42, "s")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp(42, unit="s", tz="UTC")
 
 
 def test_parse_datetime_naive_datetime():
     dt = datetime(1970, 1, 1)
     ts = parse_datetime(dt)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_float():
     ts = parse_datetime(42.5)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:42.500000000")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp(42.5, unit="s", tz="UTC")
 
 
 def test_parse_datetime_iso_without_tz():
     ts = parse_datetime("1970-01-01T00:00:00")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_iso_with_offset():
     ts = parse_datetime("1970-01-01T01:00:00+01:00")
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_datetime_with_tz():
     dt = datetime(1970, 1, 1, 1, tzinfo=timezone(timedelta(hours=1)))
     ts = parse_datetime(dt)
-    assert isinstance(ts, np.datetime64)
-    assert ts == np.datetime64("1970-01-01T00:00:00")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 

--- a/utils.py
+++ b/utils.py
@@ -252,13 +252,13 @@ def to_utc_datetime(value, tz="UTC") -> datetime:
 
 
 def parse_datetime(value):
-    """Parse an ISO-8601 string or numeric epoch value to ``numpy.datetime64``.
+    """Parse an ISO-8601 string or numeric epoch value to ``pandas.Timestamp``.
 
     The function accepts strings like ``"2023-09-28T13:45:00-04:00"`` or
     numeric Unix timestamps (as ``int``, ``float`` or numeric ``str``). Any
-    parsed time lacking a timezone is interpreted as UTC. On success a
-    ``numpy.datetime64`` object in UTC (nanosecond resolution) is returned.
-    ``ValueError`` is raised if the input cannot be parsed.
+    parsed time lacking a timezone is interpreted as UTC.  On success a
+    timezone-aware ``pandas.Timestamp`` in UTC is returned. ``ValueError`` is
+    raised if the input cannot be parsed.
     """
 
     try:
@@ -269,7 +269,7 @@ def parse_datetime(value):
     if pd is None:
         raise RuntimeError("pandas is required for parse_datetime")
 
-    return pd.Timestamp(dt).to_datetime64()
+    return pd.Timestamp(dt.replace(tzinfo=None), tz="UTC")
 
 
 def parse_time(s, tz="UTC") -> float:


### PR DESCRIPTION
## Summary
- return UTC-aware `pd.Timestamp` from `parse_datetime`
- drop downstream timestamp localization logic
- adjust baseline helpers for Timestamp output
- update unit tests and README for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b4688a3f8832bb4f48101d0b22cf9