### PR TITLE
Fix timestamp conversions to use astype

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -289,7 +289,7 @@ def _ts_bin_centers_widths(times, cfg, t_start, t_end):
     """Return bin centers and widths matching :func:`plot_time_series`."""
     arr = np.asarray(times)
     if np.issubdtype(arr.dtype, "datetime64"):
-        arr = arr.view("int64") / 1e9
+        arr = arr.astype("int64") / 1e9
     arr = arr.astype(float)
     times_rel = arr - float(t_start)
     bin_mode = str(
@@ -1015,7 +1015,7 @@ def main(argv=None):
         try:
             ts_vals = df_analysis["timestamp"]
             if pd.api.types.is_datetime64_any_dtype(ts_vals):
-                ts_seconds = ts_vals.view("int64").to_numpy() / 1e9
+                ts_seconds = ts_vals.astype("int64").to_numpy() / 1e9
             else:
                 ts_seconds = ts_vals.astype(float).to_numpy()
             df_analysis["adc"] = apply_linear_adc_shift(
@@ -1594,7 +1594,7 @@ def main(argv=None):
             iso_events = iso_events[iso_events["timestamp"] >= cut]
         ts_vals = iso_events["timestamp"]
         if pd.api.types.is_datetime64_any_dtype(ts_vals):
-            ts_vals = ts_vals.view("int64").to_numpy() / 1e9
+            ts_vals = ts_vals.astype("int64").to_numpy() / 1e9
         else:
             ts_vals = ts_vals.astype(float).to_numpy()
         times_dict = {iso: ts_vals}
@@ -1707,7 +1707,7 @@ def main(argv=None):
                 filtered_df = df_analysis[mask]
                 ts_vals = filtered_df["timestamp"]
                 if pd.api.types.is_datetime64_any_dtype(ts_vals):
-                    ts_vals = ts_vals.view("int64").to_numpy() / 1e9
+                    ts_vals = ts_vals.astype("int64").to_numpy() / 1e9
                 else:
                     ts_vals = ts_vals.astype(float).to_numpy()
                 times_dict = {iso: ts_vals}

--- a/io_utils.py
+++ b/io_utils.py
@@ -396,7 +396,7 @@ def apply_burst_filter(df, cfg=None, mode="rate"):
         else:
             ts = ts.dt.tz_convert("UTC")
     out_df["timestamp"] = ts
-    times_sec = ts.view("int64").to_numpy() / 1e9
+    times_sec = ts.astype("int64").to_numpy() / 1e9
 
     # ───── micro-burst veto ─────
     if mode in ("micro", "both"):
@@ -442,7 +442,7 @@ def apply_burst_filter(df, cfg=None, mode="rate"):
                 else:
                     ts = ts.dt.tz_convert("UTC")
             out_df["timestamp"] = ts
-            times_sec = ts.view("int64").to_numpy() / 1e9
+            times_sec = ts.astype("int64").to_numpy() / 1e9
 
     # ───── rate-based veto ─────
     if mode in ("rate", "both"):

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -84,7 +84,7 @@ def test_load_events(tmp_path, caplog):
     assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
     expected_ts = pd.to_datetime([1000, 1005, 1010], unit="s", utc=True)
     assert np.array_equal(
-        loaded["timestamp"].view("int64"), expected_ts.view("int64")
+        loaded["timestamp"].astype("int64"), expected_ts.astype("int64")
     )
     assert np.array_equal(loaded["adc"].values, np.array([1200, 1300, 1250]))
     assert "0 discarded" in caplog.text
@@ -108,7 +108,7 @@ def test_load_events_drop_bad_rows(tmp_path, caplog):
     assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
     expected_ts = pd.to_datetime([1000, 1005, 1020], unit="s", utc=True)
     assert np.array_equal(
-        loaded["timestamp"].view("int64"), expected_ts.view("int64")
+        loaded["timestamp"].astype("int64"), expected_ts.astype("int64")
     )
     assert "3 discarded" in caplog.text
 


### PR DESCRIPTION
## Summary
- use `astype("int64")` for datetime conversions
- update tests to compare timestamp ints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b48a57134832bbaa46f4c3eef5bc8