### PR TITLE
Use pd.Timestamp for test timestamps

### DIFF
--- a/tests/test_adc_drift.py
+++ b/tests/test_adc_drift.py
@@ -31,7 +31,7 @@ def _write_basic(tmp_path, drift_rate, mode="linear", params=None):
     df = pd.DataFrame({
         "fUniqueID": [1, 2, 3],
         "fBits": [0, 0, 0],
-        "timestamp": [0.0, 1.0, 2.0],
+        "timestamp": [pd.Timestamp(0.0, unit="s", tz="UTC"), pd.Timestamp(1.0, unit="s", tz="UTC"), pd.Timestamp(2.0, unit="s", tz="UTC")],
         "adc": [10, 10, 10],
         "fchannel": [1, 1, 1],
     })

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -43,7 +43,7 @@ def test_plot_time_series_receives_merged_config(tmp_path, monkeypatch):
         {
             "fUniqueID": [1],
             "fBits": [0],
-            "timestamp": [1000],
+            "timestamp": [pd.Timestamp(1000, unit="s", tz="UTC")],
             "adc": [7600],
             "fchannel": [1],
         }
@@ -132,7 +132,7 @@ def test_analysis_start_time_applied(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1],
         "fBits": [0],
-        "timestamp": [15],
+        "timestamp": [pd.Timestamp(15, unit="s", tz="UTC")],
         "adc": [7600],
         "fchannel": [1],
     })
@@ -199,7 +199,7 @@ def test_job_id_overrides_results_folder(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1],
         "fBits": [0],
-        "timestamp": [0],
+        "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")],
         "adc": [1000],
         "fchannel": [1],
     })
@@ -261,7 +261,7 @@ def test_efficiency_json_cli(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
     data = tmp_path / "d.csv"
     df.to_csv(data, index=False)
 
@@ -317,7 +317,7 @@ def test_systematics_json_cli(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1800], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1800], "fchannel": [1]})
     data = tmp_path / "d.csv"
     df.to_csv(data, index=False)
 
@@ -382,7 +382,7 @@ def test_time_bin_cli(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
@@ -437,7 +437,7 @@ def test_time_bin_override_logs(tmp_path, monkeypatch, caplog):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
@@ -488,7 +488,7 @@ def test_po210_time_series_plot_generated(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
@@ -537,7 +537,7 @@ def test_spike_count_cli(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
@@ -604,7 +604,7 @@ def test_spike_count_single_call(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
@@ -663,7 +663,7 @@ def test_assay_efficiency_list(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
@@ -744,7 +744,7 @@ def test_spike_efficiency_list(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
@@ -821,7 +821,7 @@ def test_debug_flag_sets_log_level(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
@@ -876,7 +876,7 @@ def test_settle_s_cli(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1, 2],
         "fBits": [0, 0],
-        "timestamp": [0.0, 10.0],
+        "timestamp": [pd.Timestamp(0.0, unit="s", tz="UTC"), pd.Timestamp(10.0, unit="s", tz="UTC")],
         "adc": [8.0, 8.0],
         "fchannel": [1, 1],
     })
@@ -926,7 +926,7 @@ def test_settle_s_summary(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
@@ -988,7 +988,7 @@ def test_analysis_end_time_cli(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1, 2],
         "fBits": [0, 0],
-        "timestamp": [0.0, 10.0],
+        "timestamp": [pd.Timestamp(0.0, unit="s", tz="UTC"), pd.Timestamp(10.0, unit="s", tz="UTC")],
         "adc": [8.0, 8.0],
         "fchannel": [1, 1],
     })
@@ -1047,7 +1047,7 @@ def test_analysis_start_time_cli(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1],
         "fBits": [0],
-        "timestamp": [15.0],
+        "timestamp": [pd.Timestamp(15.0, unit="s", tz="UTC")],
         "adc": [8.0],
         "fchannel": [1],
     })
@@ -1106,7 +1106,7 @@ def test_spike_end_time_cli(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1, 2],
         "fBits": [0, 0],
-        "timestamp": [0.0, 10.0],
+        "timestamp": [pd.Timestamp(0.0, unit="s", tz="UTC"), pd.Timestamp(10.0, unit="s", tz="UTC")],
         "adc": [8.0, 8.0],
         "fchannel": [1, 1],
     })
@@ -1165,7 +1165,7 @@ def test_spike_period_cli(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1, 2, 3],
         "fBits": [0, 0, 0],
-        "timestamp": [0.0, 6.0, 12.0],
+        "timestamp": [pd.Timestamp(0.0, unit="s", tz="UTC"), pd.Timestamp(6.0, unit="s", tz="UTC"), pd.Timestamp(12.0, unit="s", tz="UTC")],
         "adc": [8.0, 8.0, 8.0],
         "fchannel": [1, 1, 1],
     })
@@ -1237,7 +1237,7 @@ def test_seed_cli_sets_random_seed(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
@@ -1290,7 +1290,7 @@ def test_ambient_concentration_recorded(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
@@ -1350,7 +1350,7 @@ def test_ambient_concentration_from_config(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
@@ -1410,7 +1410,7 @@ def test_ambient_file_interpolation(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1, 2],
         "fBits": [0, 0],
-        "timestamp": [0, 2],
+        "timestamp": [pd.Timestamp(0, unit="s", tz="UTC"), pd.Timestamp(2, unit="s", tz="UTC")],
         "adc": [1, 1],
         "fchannel": [1, 1],
     })
@@ -1490,7 +1490,7 @@ def test_burst_mode_from_config(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
@@ -1538,7 +1538,7 @@ def test_burst_mode_micro_config(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
@@ -1586,7 +1586,7 @@ def test_burst_mode_cli_overrides(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
@@ -1635,7 +1635,7 @@ def test_burst_mode_summary_config(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
@@ -1694,7 +1694,7 @@ def test_burst_filter_auto_disabled(tmp_path, monkeypatch):
         {
             "fUniqueID": [1, 2],
             "fBits": [0, 0],
-            "timestamp": [0, 2000],
+            "timestamp": [pd.Timestamp(0, unit="s", tz="UTC"), pd.Timestamp(2000, unit="s", tz="UTC")],
             "adc": [1, 1],
             "fchannel": [1, 1],
         }
@@ -1755,7 +1755,7 @@ def test_ambient_concentration_default_none(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
@@ -1807,7 +1807,7 @@ def test_ambient_concentration_written_to_summary_file(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
@@ -1872,7 +1872,7 @@ def test_spike_periods_null_config(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0.0], "adc": [8.0], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0.0, unit="s", tz="UTC")], "adc": [8.0], "fchannel": [1]})
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
@@ -1932,7 +1932,7 @@ def test_hl_po214_cli_overrides(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0.0], "adc": [8.0], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0.0, unit="s", tz="UTC")], "adc": [8.0], "fchannel": [1]})
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
@@ -1988,7 +1988,7 @@ def test_hl_po210_default_used(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0.0], "adc": [8.0], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0.0, unit="s", tz="UTC")], "adc": [8.0], "fchannel": [1]})
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 
@@ -2049,7 +2049,7 @@ def test_time_fields_written_back(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1, 2, 3],
         "fBits": [0, 0, 0],
-        "timestamp": [0.5, 2.5, 4.5],
+        "timestamp": [pd.Timestamp(0.5, unit="s", tz="UTC"), pd.Timestamp(2.5, unit="s", tz="UTC"), pd.Timestamp(4.5, unit="s", tz="UTC")],
         "adc": [8.0, 8.0, 8.0],
         "fchannel": [1, 1, 1],
     })

--- a/tests/test_analyze_noise_cutoff.py
+++ b/tests/test_analyze_noise_cutoff.py
@@ -31,7 +31,7 @@ def test_analyze_noise_cutoff(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1, 2],
         "fBits": [0, 0],
-        "timestamp": [1.0, 2.0],
+        "timestamp": [pd.Timestamp(1.0, unit="s", tz="UTC"), pd.Timestamp(2.0, unit="s", tz="UTC")],
         "adc": [50, 150],
         "fchannel": [1, 1],
     })

--- a/tests/test_analyze_systematics.py
+++ b/tests/test_analyze_systematics.py
@@ -31,7 +31,7 @@ def test_analyze_systematics_runs(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1],
         "fBits": [0],
-        "timestamp": [1.0],
+        "timestamp": [pd.Timestamp(1.0, unit="s", tz="UTC")],
         "adc": [5],
         "fchannel": [1],
     })

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -38,7 +38,7 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1, 2, 3],
         "fBits": [0, 0, 0],
-        "timestamp": [1, 2, 20],
+        "timestamp": [pd.Timestamp(1, unit="s", tz="UTC"), pd.Timestamp(2, unit="s", tz="UTC"), pd.Timestamp(20, unit="s", tz="UTC")],
         "adc": [8, 8, 8],
         "fchannel": [1, 1, 1],
     })
@@ -97,7 +97,9 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
     corr_sig = summary["baseline"]["corrected_sigma_Bq"]["Po214"]
 
     eff = cfg["time_fit"]["eff_po214"][0]
-    live_time = df["timestamp"].iloc[-1] - df["timestamp"].iloc[0]
+    live_time = (
+        df["timestamp"].iloc[-1] - df["timestamp"].iloc[0]
+    ).total_seconds()
     counts = summary["baseline"]["analysis_counts"]["Po214"]
     base_counts = summary["baseline"]["rate_Bq"]["Po214"] * summary["baseline"]["live_time"] * eff
     exp_rate, exp_sigma = subtract_baseline_counts(
@@ -135,7 +137,7 @@ def test_baseline_scaling_factor(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1, 2, 3],
         "fBits": [0, 0, 0],
-        "timestamp": [1, 2, 20],
+        "timestamp": [pd.Timestamp(1, unit="s", tz="UTC"), pd.Timestamp(2, unit="s", tz="UTC"), pd.Timestamp(20, unit="s", tz="UTC")],
         "adc": [8, 8, 8],
         "fchannel": [1, 1, 1],
     })
@@ -188,7 +190,9 @@ def test_baseline_scaling_factor(tmp_path, monkeypatch):
     corr_sig = summary["baseline"]["corrected_sigma_Bq"]["Po214"]
 
     eff = cfg["time_fit"]["eff_po214"][0]
-    live_time = df["timestamp"].iloc[-1] - df["timestamp"].iloc[0]
+    live_time = (
+        df["timestamp"].iloc[-1] - df["timestamp"].iloc[0]
+    ).total_seconds()
     counts = summary["baseline"]["analysis_counts"]["Po214"]
     base_counts = summary["baseline"]["rate_Bq"]["Po214"] * summary["baseline"]["live_time"] * eff
     exp_rate, exp_sigma = subtract_baseline_counts(
@@ -223,7 +227,7 @@ def test_n0_prior_from_baseline(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1, 2, 3],
         "fBits": [0, 0, 0],
-        "timestamp": [1, 2, 20],
+        "timestamp": [pd.Timestamp(1, unit="s", tz="UTC"), pd.Timestamp(2, unit="s", tz="UTC"), pd.Timestamp(20, unit="s", tz="UTC")],
         "adc": [8, 8, 8],
         "fchannel": [1, 1, 1],
     })
@@ -313,7 +317,7 @@ def test_isotopes_to_subtract_control(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1, 2, 3],
         "fBits": [0, 0, 0],
-        "timestamp": [1, 2, 20],
+        "timestamp": [pd.Timestamp(1, unit="s", tz="UTC"), pd.Timestamp(2, unit="s", tz="UTC"), pd.Timestamp(20, unit="s", tz="UTC")],
         "adc": [8, 8, 8],
         "fchannel": [1, 1, 1],
     })
@@ -398,7 +402,7 @@ def test_baseline_scaling_multiple_isotopes(tmp_path, monkeypatch):
         {
             "fUniqueID": [1, 2, 3, 4, 5, 6],
             "fBits": [0] * 6,
-            "timestamp": [1, 2, 3, 4, 20, 21],
+            "timestamp": [pd.Timestamp(1, unit="s", tz="UTC"), pd.Timestamp(2, unit="s", tz="UTC"), pd.Timestamp(3, unit="s", tz="UTC"), pd.Timestamp(4, unit="s", tz="UTC"), pd.Timestamp(20, unit="s", tz="UTC"), pd.Timestamp(21, unit="s", tz="UTC")],
             "adc": [8.0, 6.0, 5.3, 2.0, 8.0, 6.0],
             "fchannel": [1] * 6,
         }
@@ -479,7 +483,9 @@ def test_baseline_scaling_multiple_isotopes(tmp_path, monkeypatch):
     corr_sig = summary["baseline"]["corrected_sigma_Bq"]["Po214"]
 
     eff = cfg["time_fit"]["eff_po214"][0]
-    live_time = df["timestamp"].iloc[-1] - df["timestamp"].iloc[0]
+    live_time = (
+        df["timestamp"].iloc[-1] - df["timestamp"].iloc[0]
+    ).total_seconds()
     counts = summary["baseline"]["analysis_counts"]["Po214"]
     base_counts = summary["baseline"]["rate_Bq"]["Po214"] * summary["baseline"]["live_time"] * eff
     exp_rate, exp_sigma = subtract_baseline_counts(
@@ -514,7 +520,7 @@ def test_noise_level_none_not_recorded(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1, 2, 3],
         "fBits": [0, 0, 0],
-        "timestamp": [1, 2, 20],
+        "timestamp": [pd.Timestamp(1, unit="s", tz="UTC"), pd.Timestamp(2, unit="s", tz="UTC"), pd.Timestamp(20, unit="s", tz="UTC")],
         "adc": [8, 8, 8],
         "fchannel": [1, 1, 1],
     })
@@ -585,7 +591,7 @@ def test_sigma_rate_uses_weighted_counts(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1, 2, 3],
         "fBits": [0, 0, 0],
-        "timestamp": [1, 2, 20],
+        "timestamp": [pd.Timestamp(1, unit="s", tz="UTC"), pd.Timestamp(2, unit="s", tz="UTC"), pd.Timestamp(20, unit="s", tz="UTC")],
         "adc": [8, 8, 8],
         "fchannel": [1, 1, 1],
     })
@@ -642,7 +648,7 @@ def test_sigma_rate_uses_weighted_counts(tmp_path, monkeypatch):
 
 
 def test_rate_histogram_single_event():
-    df = pd.DataFrame({"timestamp": [1.0], "adc": [10.0]})
+    df = pd.DataFrame({"timestamp": [pd.Timestamp(1.0, unit="s", tz="UTC")], "adc": [10.0]})
     bins = np.array([0, 20])
     rate, live = baseline.rate_histogram(df, bins)
     assert live == 0.0

--- a/tests/test_baseline_flow.py
+++ b/tests/test_baseline_flow.py
@@ -27,7 +27,7 @@ def test_baseline_event_from_unfiltered_data(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1, 2],
         "fBits": [0, 0],
-        "timestamp": [1.0, 10.0],
+        "timestamp": [pd.Timestamp(1.0, unit="s", tz="UTC"), pd.Timestamp(10.0, unit="s", tz="UTC")],
         "adc": [2, 10],
         "fchannel": [1, 1],
     })

--- a/tests/test_baseline_noise_propagation.py
+++ b/tests/test_baseline_noise_propagation.py
@@ -34,7 +34,7 @@ def test_baseline_noise_propagation(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1, 2, 3],
         "fBits": [0, 0, 0],
-        "timestamp": [1.0, 2.0, 20.0],
+        "timestamp": [pd.Timestamp(1.0, unit="s", tz="UTC"), pd.Timestamp(2.0, unit="s", tz="UTC"), pd.Timestamp(20.0, unit="s", tz="UTC")],
         "adc": [10.0, 12.0, 50.0],
         "fchannel": [1, 1, 1],
     })

--- a/tests/test_baseline_range_cli.py
+++ b/tests/test_baseline_range_cli.py
@@ -35,7 +35,7 @@ def test_baseline_range_cli_overrides_config(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1, 2, 3],
         "fBits": [0, 0, 0],
-        "timestamp": [1.0, 12.0, 20.0],
+        "timestamp": [pd.Timestamp(1.0, unit="s", tz="UTC"), pd.Timestamp(12.0, unit="s", tz="UTC"), pd.Timestamp(20.0, unit="s", tz="UTC")],
         "adc": [8, 8, 8],
         "fchannel": [1, 1, 1],
     })

--- a/tests/test_baseline_range_empty.py
+++ b/tests/test_baseline_range_empty.py
@@ -36,7 +36,7 @@ def test_cli_baseline_range_empty(tmp_path, monkeypatch):
         {
             "fUniqueID": [1, 2, 3],
             "fBits": [0, 0, 0],
-            "timestamp": [0.5, 1.5, 2.5],
+            "timestamp": [pd.Timestamp(0.5, unit="s", tz="UTC"), pd.Timestamp(1.5, unit="s", tz="UTC"), pd.Timestamp(2.5, unit="s", tz="UTC")],
             "adc": [8.0, 8.0, 8.0],
             "fchannel": [1, 1, 1],
         }

--- a/tests/test_baseline_subtract.py
+++ b/tests/test_baseline_subtract.py
@@ -13,7 +13,7 @@ import baseline_utils
 
 def test_baseline_none():
     df = pd.DataFrame({
-        "timestamp": np.linspace(0, 9, 10),
+        "timestamp": pd.to_datetime(np.linspace(0, 9, 10), unit="s", utc=True),
         "adc": np.arange(10),
     })
     bins = np.arange(0, 11)
@@ -32,11 +32,11 @@ def test_baseline_none():
 
 def test_baseline_time_norm():
     df_an = pd.DataFrame({
-        "timestamp": np.linspace(0, 4, 5),
+        "timestamp": pd.to_datetime(np.linspace(0, 4, 5), unit="s", utc=True),
         "adc": [1, 2, 3, 4, 5],
     })
     df_bl = pd.DataFrame({
-        "timestamp": np.linspace(100, 140, 50),
+        "timestamp": pd.to_datetime(np.linspace(100, 140, 50), unit="s", utc=True),
         "adc": np.tile([1, 2, 3, 4, 5], 10),
     })
     df_full = pd.concat([df_an, df_bl], ignore_index=True)
@@ -55,7 +55,7 @@ def test_baseline_time_norm():
 
 def test_baseline_none_datetime():
     df = pd.DataFrame({
-        "timestamp": np.linspace(0, 9, 10),
+        "timestamp": pd.to_datetime(np.linspace(0, 9, 10), unit="s", utc=True),
         "adc": np.arange(10),
     })
     bins = np.arange(0, 11)
@@ -74,11 +74,11 @@ def test_baseline_none_datetime():
 
 def test_baseline_time_norm_datetime():
     df_an = pd.DataFrame({
-        "timestamp": np.linspace(0, 4, 5),
+        "timestamp": pd.to_datetime(np.linspace(0, 4, 5), unit="s", utc=True),
         "adc": [1, 2, 3, 4, 5],
     })
     df_bl = pd.DataFrame({
-        "timestamp": np.linspace(100, 140, 50),
+        "timestamp": pd.to_datetime(np.linspace(100, 140, 50), unit="s", utc=True),
         "adc": np.tile([1, 2, 3, 4, 5], 10),
     })
     df_full = pd.concat([df_an, df_bl], ignore_index=True)

--- a/tests/test_blue_weights.py
+++ b/tests/test_blue_weights.py
@@ -29,7 +29,7 @@ def test_blue_weights_summary(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 

--- a/tests/test_cli_baseline_range.py
+++ b/tests/test_cli_baseline_range.py
@@ -36,7 +36,7 @@ def test_cli_baseline_range_overrides_config(tmp_path, monkeypatch):
         {
             "fUniqueID": [1, 2, 3],
             "fBits": [0, 0, 0],
-            "timestamp": [0.5, 1.5, 2.5],
+            "timestamp": [pd.Timestamp(0.5, unit="s", tz="UTC"), pd.Timestamp(1.5, unit="s", tz="UTC"), pd.Timestamp(2.5, unit="s", tz="UTC")],
             "adc": [8.0, 8.0, 8.0],
             "fchannel": [1, 1, 1],
         }

--- a/tests/test_cli_baseline_range_iso.py
+++ b/tests/test_cli_baseline_range_iso.py
@@ -36,7 +36,7 @@ def test_cli_baseline_range_iso_strings(tmp_path, monkeypatch):
         {
             "fUniqueID": [1, 2, 3],
             "fBits": [0, 0, 0],
-            "timestamp": [0.5, 1.5, 2.5],
+            "timestamp": [pd.Timestamp(0.5, unit="s", tz="UTC"), pd.Timestamp(1.5, unit="s", tz="UTC"), pd.Timestamp(2.5, unit="s", tz="UTC")],
             "adc": [8.0, 8.0, 8.0],
             "fchannel": [1, 1, 1],
         }
@@ -132,7 +132,7 @@ def test_cli_baseline_range_timezone(tmp_path, monkeypatch):
         {
             "fUniqueID": [1, 2, 3],
             "fBits": [0, 0, 0],
-            "timestamp": [0.5, 1.5, 2.5],
+            "timestamp": [pd.Timestamp(0.5, unit="s", tz="UTC"), pd.Timestamp(1.5, unit="s", tz="UTC"), pd.Timestamp(2.5, unit="s", tz="UTC")],
             "adc": [8.0, 8.0, 8.0],
             "fchannel": [1, 1, 1],
         }

--- a/tests/test_cli_baseline_range_override2.py
+++ b/tests/test_cli_baseline_range_override2.py
@@ -36,7 +36,7 @@ def test_cli_baseline_range_overrides_config_again(tmp_path, monkeypatch):
         {
             "fUniqueID": [1, 2, 3],
             "fBits": [0, 0, 0],
-            "timestamp": [0.5, 2.5, 3.5],
+            "timestamp": [pd.Timestamp(0.5, unit="s", tz="UTC"), pd.Timestamp(2.5, unit="s", tz="UTC"), pd.Timestamp(3.5, unit="s", tz="UTC")],
             "adc": [8.0, 8.0, 8.0],
             "fchannel": [1, 1, 1],
         }

--- a/tests/test_cli_metadata.py
+++ b/tests/test_cli_metadata.py
@@ -26,7 +26,7 @@ def test_summary_includes_git_and_cli(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1],
         "fBits": [0],
-        "timestamp": [0],
+        "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")],
         "adc": [1000],
         "fchannel": [1],
     })

--- a/tests/test_empty_after_filters.py
+++ b/tests/test_empty_after_filters.py
@@ -28,7 +28,7 @@ def test_exit_when_noise_cut_removes_all(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1],
         "fBits": [0],
-        "timestamp": [1.0],
+        "timestamp": [pd.Timestamp(1.0, unit="s", tz="UTC")],
         "adc": [5],
         "fchannel": [1],
     })

--- a/tests/test_expected_peaks_default.py
+++ b/tests/test_expected_peaks_default.py
@@ -41,7 +41,7 @@ def test_expected_peaks_default(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1],
         "fBits": [0],
-        "timestamp": [0],
+        "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")],
         "adc": [1000],
         "fchannel": [1],
     })

--- a/tests/test_hierarchical_summary.py
+++ b/tests/test_hierarchical_summary.py
@@ -27,7 +27,7 @@ def test_hierarchical_summary(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1],
         "fBits": [0],
-        "timestamp": [0],
+        "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")],
         "adc": [1000],
         "fchannel": [1],
     })

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -72,7 +72,7 @@ def test_load_events(tmp_path, caplog):
         {
             "fUniqueID": [1, 2, 3],
             "fBits": [0, 0, 0],
-            "timestamp": [1000, 1005, 1010],
+            "timestamp": [pd.Timestamp(1000, unit="s", tz="UTC"), pd.Timestamp(1005, unit="s", tz="UTC"), pd.Timestamp(1010, unit="s", tz="UTC")],
             "adc": [1200, 1300, 1250],
             "fchannel": [1, 1, 1],
         }
@@ -164,7 +164,7 @@ def test_load_events_missing_column(tmp_path):
         {
             "fUniqueID": [1],
             "fBits": [0],
-            "timestamp": [1000],
+            "timestamp": [pd.Timestamp(1000, unit="s", tz="UTC")],
             # ADC column intentionally missing
             "fchannel": [1],
         }

--- a/tests/test_job_id_duplicate.py
+++ b/tests/test_job_id_duplicate.py
@@ -31,7 +31,7 @@ def test_duplicate_job_id_raises(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1],
         "fBits": [0],
-        "timestamp": [0],
+        "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")],
         "adc": [1000],
         "fchannel": [1],
     })
@@ -96,7 +96,7 @@ def test_job_id_overwrite_allows_rerun(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1],
         "fBits": [0],
-        "timestamp": [0],
+        "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")],
         "adc": [1000],
         "fchannel": [1],
     })

--- a/tests/test_noise_cut.py
+++ b/tests/test_noise_cut.py
@@ -34,7 +34,7 @@ def test_noise_cutoff_cli_overrides(tmp_path, monkeypatch):
         {
             "fUniqueID": [1, 2],
             "fBits": [0, 0],
-            "timestamp": [1.0, 2.0],
+            "timestamp": [pd.Timestamp(1.0, unit="s", tz="UTC"), pd.Timestamp(2.0, unit="s", tz="UTC")],
             "adc": [5, 15],
             "fchannel": [1, 1],
         }

--- a/tests/test_noise_cutoff.py
+++ b/tests/test_noise_cutoff.py
@@ -33,7 +33,7 @@ def test_noise_cutoff_filters_events(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1, 2],
         "fBits": [0, 0],
-        "timestamp": [1.0, 2.0],
+        "timestamp": [pd.Timestamp(1.0, unit="s", tz="UTC"), pd.Timestamp(2.0, unit="s", tz="UTC")],
         "adc": [5, 15],
         "fchannel": [1, 1],
     })
@@ -107,7 +107,7 @@ def test_invalid_noise_cutoff_skips_cut(tmp_path, monkeypatch, caplog):
     df = pd.DataFrame({
         "fUniqueID": [1, 2],
         "fBits": [0, 0],
-        "timestamp": [1.0, 2.0],
+        "timestamp": [pd.Timestamp(1.0, unit="s", tz="UTC"), pd.Timestamp(2.0, unit="s", tz="UTC")],
         "adc": [5, 15],
         "fchannel": [1, 1],
     })

--- a/tests/test_override_logging.py
+++ b/tests/test_override_logging.py
@@ -43,7 +43,7 @@ def test_analysis_end_time_override_logs(tmp_path, monkeypatch, caplog):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 
@@ -81,7 +81,7 @@ def test_analysis_start_time_override_logs(tmp_path, monkeypatch, caplog):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
     data_path = tmp_path / "data.csv"
     df.to_csv(data_path, index=False)
 

--- a/tests/test_sample_radon.py
+++ b/tests/test_sample_radon.py
@@ -30,7 +30,7 @@ def test_total_radon_uses_sample_volume(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1],
         "fBits": [0],
-        "timestamp": [0],
+        "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")],
         "adc": [8],
         "fchannel": [1],
     })

--- a/tests/test_systematics.py
+++ b/tests/test_systematics.py
@@ -136,7 +136,7 @@ def test_analyze_systematics_skip_unknown(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1],
         "fBits": [0],
-        "timestamp": [0.0],
+        "timestamp": [pd.Timestamp(0.0, unit="s", tz="UTC")],
         "adc": [10],
         "fchannel": [1],
     })

--- a/tests/test_time_bin_mode_conflict.py
+++ b/tests/test_time_bin_mode_conflict.py
@@ -23,7 +23,7 @@ def test_time_bin_mode_conflict(tmp_path, monkeypatch):
     with open(cfg_path, "w") as f:
         json.dump(cfg, f)
 
-    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [0], "adc": [1], "fchannel": [1]})
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
     data_path = tmp_path / "d.csv"
     df.to_csv(data_path, index=False)
 

--- a/tests/test_time_series_po210_plot.py
+++ b/tests/test_time_series_po210_plot.py
@@ -16,7 +16,7 @@ from plot_utils import plot_time_series
 def test_extract_time_series_po210_count():
     df = pd.DataFrame(
         {
-            "timestamp": [1.0, 2.0, 3.0, 4.0],
+            "timestamp": [pd.Timestamp(1.0, unit="s", tz="UTC"), pd.Timestamp(2.0, unit="s", tz="UTC"), pd.Timestamp(3.0, unit="s", tz="UTC"), pd.Timestamp(4.0, unit="s", tz="UTC")],
             "energy_MeV": [5.1, 5.3, 5.25, 5.5],
         }
     )

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -35,7 +35,7 @@ def test_time_window_filters_events(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1, 2, 3, 4],
         "fBits": [0, 0, 0, 0],
-        "timestamp": [0.0, 2.0, 6.0, 9.0],
+        "timestamp": [pd.Timestamp(0.0, unit="s", tz="UTC"), pd.Timestamp(2.0, unit="s", tz="UTC"), pd.Timestamp(6.0, unit="s", tz="UTC"), pd.Timestamp(9.0, unit="s", tz="UTC")],
         "adc": [8.0, 8.0, 8.0, 8.0],
         "fchannel": [1, 1, 1, 1],
     })
@@ -114,7 +114,7 @@ def test_invalid_baseline_range_raises(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1],
         "fBits": [0],
-        "timestamp": [0.0],
+        "timestamp": [pd.Timestamp(0.0, unit="s", tz="UTC")],
         "adc": [8.0],
         "fchannel": [1],
     })
@@ -175,7 +175,7 @@ def test_time_window_filters_events_config(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1, 2, 3, 4],
         "fBits": [0, 0, 0, 0],
-        "timestamp": [0.0, 2.0, 6.0, 9.0],
+        "timestamp": [pd.Timestamp(0.0, unit="s", tz="UTC"), pd.Timestamp(2.0, unit="s", tz="UTC"), pd.Timestamp(6.0, unit="s", tz="UTC"), pd.Timestamp(9.0, unit="s", tz="UTC")],
         "adc": [8.0, 8.0, 8.0, 8.0],
         "fchannel": [1, 1, 1, 1],
     })
@@ -255,7 +255,7 @@ def test_run_period_filters_events(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1, 2, 3, 4],
         "fBits": [0, 0, 0, 0],
-        "timestamp": [0.0, 2.0, 5.0, 7.0],
+        "timestamp": [pd.Timestamp(0.0, unit="s", tz="UTC"), pd.Timestamp(2.0, unit="s", tz="UTC"), pd.Timestamp(5.0, unit="s", tz="UTC"), pd.Timestamp(7.0, unit="s", tz="UTC")],
         "adc": [8.0, 8.0, 8.0, 8.0],
         "fchannel": [1, 1, 1, 1],
     })
@@ -343,7 +343,7 @@ def test_baseline_range_iso_strings(tmp_path, monkeypatch, start, end):
     df = pd.DataFrame({
         "fUniqueID": [1, 2, 3, 4],
         "fBits": [0, 0, 0, 0],
-        "timestamp": [0.0, 2.0, 6.0, 9.0],
+        "timestamp": [pd.Timestamp(0.0, unit="s", tz="UTC"), pd.Timestamp(2.0, unit="s", tz="UTC"), pd.Timestamp(6.0, unit="s", tz="UTC"), pd.Timestamp(9.0, unit="s", tz="UTC")],
         "adc": [8.0, 8.0, 8.0, 8.0],
         "fchannel": [1, 1, 1, 1],
     })
@@ -427,7 +427,7 @@ def test_unified_filter_combined_windows(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "fUniqueID": [1, 2, 3, 4, 5, 6],
         "fBits": [0, 0, 0, 0, 0, 0],
-        "timestamp": [0.0, 1.0, 2.0, 2.2, 3.0, 5.0],
+        "timestamp": [pd.Timestamp(0.0, unit="s", tz="UTC"), pd.Timestamp(1.0, unit="s", tz="UTC"), pd.Timestamp(2.0, unit="s", tz="UTC"), pd.Timestamp(2.2, unit="s", tz="UTC"), pd.Timestamp(3.0, unit="s", tz="UTC"), pd.Timestamp(5.0, unit="s", tz="UTC")],
         "adc": [8.0]*6,
         "fchannel": [1]*6,
     })

--- a/tests/test_timestamp_dtype.py
+++ b/tests/test_timestamp_dtype.py
@@ -16,7 +16,7 @@ def test_load_events_returns_timezone(tmp_path):
     df = pd.DataFrame({
         "fUniqueID": [1],
         "fBits": [0],
-        "timestamp": [1000],
+        "timestamp": [pd.Timestamp(1000, unit="s", tz="UTC")],
         "adc": [1200],
         "fchannel": [1],
     })


### PR DESCRIPTION
## Summary
- update tests to construct timestamp columns with timezone-aware `pd.Timestamp`
- adjust baseline tests to compute live_time in seconds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b487d50fc832bad6de830d726fb53