### PR TITLE
Fix datetime conversion

### DIFF
--- a/baseline_utils.py
+++ b/baseline_utils.py
@@ -55,9 +55,9 @@ def _to_datetime64(col: pd.Series) -> np.ndarray:
         ser = col
         if getattr(ser.dtype, "tz", None) is not None:
             ser = ser.dt.tz_convert("UTC")
-        ts = ser.astype("datetime64[ns]").to_numpy()
+        ts = ser.to_numpy(dtype="datetime64[ns]")
     else:
-        ts = col.map(parse_datetime).astype("datetime64[ns]").to_numpy()
+        ts = col.map(parse_datetime).to_numpy(dtype="datetime64[ns]")
     return np.asarray(ts)
 
 


### PR DESCRIPTION
## Summary
- correct baseline_utils `_to_datetime64` to avoid deprecated timezone casting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b485cb078832b9a8a7fb558fba3e1