### PR TITLE
Fix timestamp conversion to retain timezone

### DIFF
--- a/baseline.py
+++ b/baseline.py
@@ -1,7 +1,6 @@
 import numpy as np
 import logging
 import pandas as pd
-from utils import parse_datetime
 
 from baseline_utils import subtract_baseline_dataframe
 
@@ -9,17 +8,14 @@ __all__ = ["rate_histogram", "subtract_baseline", "subtract_baseline_dataframe"]
 
 
 def _to_datetime64(events: pd.DataFrame) -> np.ndarray:
-    """Return numpy.ndarray[datetime64[ns, UTC]]."""
+    """Return ``numpy.ndarray`` of UTC timestamps."""
 
     ts_col = events["timestamp"]
-    if pd.api.types.is_datetime64_any_dtype(ts_col):
-        ser = ts_col
-        if getattr(ser.dtype, "tz", None) is not None:
-            ser = ser.dt.tz_convert("UTC")
-        ts = ser.to_numpy(dtype="datetime64[ns]")
+    if pd.api.types.is_numeric_dtype(ts_col):
+        ts = pd.to_datetime(ts_col, unit="s", utc=True)
     else:
-        ts = ts_col.map(parse_datetime).astype("datetime64[ns]").to_numpy()
-    return np.asarray(ts)
+        ts = pd.to_datetime(ts_col, utc=True)
+    return ts.dt.tz_convert("UTC").to_numpy(dtype="datetime64[ns]")
 
 
 def rate_histogram(df, bins):

--- a/baseline_utils.py
+++ b/baseline_utils.py
@@ -48,17 +48,15 @@ def compute_dilution_factor(monitor_volume: float, sample_volume: float) -> floa
     return float(monitor_volume) / float(total)
 
 
-def _to_datetime64(col: pd.Series) -> np.ndarray:
-    """Return numpy.ndarray[datetime64[ns, UTC]]."""
+def _to_datetime64(events: pd.DataFrame) -> np.ndarray:
+    """Return ``numpy.ndarray`` of UTC timestamps."""
 
-    if pd.api.types.is_datetime64_any_dtype(col):
-        ser = col
-        if getattr(ser.dtype, "tz", None) is not None:
-            ser = ser.dt.tz_convert("UTC")
-        ts = ser.astype("datetime64[ns]").to_numpy()
+    ts_col = events["timestamp"]
+    if pd.api.types.is_numeric_dtype(ts_col):
+        ts = pd.to_datetime(ts_col, unit="s", utc=True)
     else:
-        ts = col.map(parse_datetime).astype("datetime64[ns]").to_numpy()
-    return np.asarray(ts)
+        ts = pd.to_datetime(ts_col, utc=True)
+    return ts.dt.tz_convert("UTC").to_numpy(dtype="datetime64[ns]")
 
 
 def _rate_histogram(df: pd.DataFrame, bins) -> tuple[np.ndarray, float]:
@@ -66,7 +64,7 @@ def _rate_histogram(df: pd.DataFrame, bins) -> tuple[np.ndarray, float]:
 
     if df.empty:
         return np.zeros(len(bins) - 1, dtype=float), 0.0
-    ts = _to_datetime64(df["timestamp"])
+    ts = _to_datetime64(df)
     live = float((ts[-1] - ts[0]) / np.timedelta64(1, "s"))
     hist_src = df.get("subtracted_adc_hist", df["adc"]).to_numpy()
     hist, _ = np.histogram(hist_src, bins=bins)
@@ -97,7 +95,7 @@ def subtract_baseline_dataframe(
 
     t0 = parse_datetime(t_base0)
     t1 = parse_datetime(t_base1)
-    ts_full = _to_datetime64(df_full["timestamp"])
+    ts_full = _to_datetime64(df_full)
     mask = (ts_full >= t0) & (ts_full <= t1)
     if not mask.any():
         logging.warning("baseline_range matched no events – skipping subtraction")


### PR DESCRIPTION
## Summary
- handle numeric timestamps with `pd.to_datetime(..., unit="s")`
- use timezone-preserving helper `_to_datetime64`
- update `_rate_histogram` and baseline subtraction to use the revised helper

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b485b4ef4832ba769300b0150fd74