### PR TITLE
Fix timezone conversion for datetime columns

### DIFF
--- a/baseline_utils.py
+++ b/baseline_utils.py
@@ -54,8 +54,8 @@ def _to_datetime64(col: pd.Series) -> np.ndarray:
     if pd.api.types.is_datetime64_any_dtype(col):
         ser = col
         if getattr(ser.dtype, "tz", None) is not None:
-            ser = ser.dt.tz_convert("UTC")
-        ts = ser.astype("datetime64[ns]").to_numpy()
+            ser = ser.dt.tz_convert("UTC").dt.tz_localize(None)
+        ts = ser.to_numpy(dtype="datetime64[ns]")
     else:
         ts = col.map(parse_datetime).astype("datetime64[ns]").to_numpy()
     return np.asarray(ts)


### PR DESCRIPTION
## Summary
- convert timezone-aware series to UTC and drop tz before converting to numpy
- ensure baseline datetime tests pass without warnings

## Testing
- `pytest tests/test_baseline_datetime.py tests/test_timestamp_dtype.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685b4b580528832ba11e6a50766510be