### PR TITLE
Fix timestamp conversion to preserve timezone

### DIFF
--- a/baseline.py
+++ b/baseline.py
@@ -12,7 +12,7 @@ def rate_histogram(df, bins):
     """Return (histogram in counts/s, live_time_s)."""
     if df.empty:
         return np.zeros(len(bins) - 1, dtype=float), 0.0
-    ts = baseline_utils._to_datetime64(df["timestamp"])
+    ts = baseline_utils._to_datetime64(df)
     live = float((ts[-1] - ts[0]) / np.timedelta64(1, "s"))
     hist_src = df.get("subtracted_adc_hist", df["adc"]).to_numpy()
     hist, _ = np.histogram(hist_src, bins=bins)


### PR DESCRIPTION
## Summary
- preserve timestamp timezone in `_to_datetime64`
- adjust callers in `baseline_utils` and `baseline`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b4bd10260832bac7c9d5687f6590f