### PR TITLE
Add to_seconds helper and refactor timestamp conversions

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -105,7 +105,7 @@ from utils import (
     parse_time_arg,
     to_utc_datetime,
 )
-from utils import parse_datetime
+from utils import parse_datetime, to_seconds
 from baseline_utils import (
     subtract_baseline_dataframe,
     subtract_baseline_counts,
@@ -1002,11 +1002,7 @@ def main(argv=None):
 
     if drift_rate != 0.0 or drift_mode != "linear" or drift_params is not None:
         try:
-            ts_vals = df_analysis["timestamp"]
-            if pd.api.types.is_datetime64_any_dtype(ts_vals):
-                ts_seconds = ts_vals.astype("int64").to_numpy() / 1e9
-            else:
-                ts_seconds = ts_vals.astype(float).to_numpy()
+            ts_seconds = to_seconds(df_analysis["timestamp"])
             df_analysis["adc"] = apply_linear_adc_shift(
                 df_analysis["adc"].values,
                 ts_seconds,
@@ -1581,11 +1577,7 @@ def main(argv=None):
             t0_dt = to_utc_datetime(t0_global)
             cut = t0_dt + timedelta(seconds=float(args.settle_s))
             iso_events = iso_events[iso_events["timestamp"] >= cut]
-        ts_vals = iso_events["timestamp"]
-        if pd.api.types.is_datetime64_any_dtype(ts_vals):
-            ts_vals = ts_vals.astype("int64").to_numpy() / 1e9
-        else:
-            ts_vals = ts_vals.astype(float).to_numpy()
+        ts_vals = to_seconds(iso_events["timestamp"])
         times_dict = {iso: ts_vals}
         weights_map = {iso: iso_events["weight"].values}
         fit_cfg = {
@@ -1694,11 +1686,7 @@ def main(argv=None):
                 )
                 mask = probs > 0
                 filtered_df = df_analysis[mask]
-                ts_vals = filtered_df["timestamp"]
-                if pd.api.types.is_datetime64_any_dtype(ts_vals):
-                    ts_vals = ts_vals.astype("int64").to_numpy() / 1e9
-                else:
-                    ts_vals = ts_vals.astype(float).to_numpy()
+                ts_vals = to_seconds(filtered_df["timestamp"])
                 times_dict = {iso: ts_vals}
                 weights_local = {iso: probs[mask]}
                 cfg_fit = {

--- a/io_utils.py
+++ b/io_utils.py
@@ -11,7 +11,7 @@ import pandas as pd
 from constants import load_nuclide_overrides
 
 import numpy as np
-from utils import to_native, parse_datetime
+from utils import to_native, parse_datetime, to_seconds
 import jsonschema
 
 
@@ -393,7 +393,7 @@ def apply_burst_filter(df, cfg=None, mode="rate"):
         else:
             ts = ts.dt.tz_convert("UTC")
     out_df["timestamp"] = ts
-    times_sec = ts.astype("int64").to_numpy() / 1e9
+    times_sec = to_seconds(ts)
 
     # ───── micro-burst veto ─────
     if mode in ("micro", "both"):
@@ -438,7 +438,7 @@ def apply_burst_filter(df, cfg=None, mode="rate"):
                 else:
                     ts = ts.dt.tz_convert("UTC")
             out_df["timestamp"] = ts
-            times_sec = ts.astype("int64").to_numpy() / 1e9
+            times_sec = to_seconds(ts)
 
     # ───── rate-based veto ─────
     if mode in ("rate", "both"):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,8 @@ import sys
 from pathlib import Path
 from datetime import datetime, timezone
 import pytest
+import numpy as np
+import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -12,6 +14,7 @@ from utils import (
     parse_timestamp,
     parse_time,
     parse_time_arg,
+    to_seconds,
     LITERS_PER_M3,
 )
 
@@ -86,3 +89,15 @@ def test_parse_timestamp_iso():
 
 def test_parse_timestamp_datetime_naive():
     assert parse_timestamp(datetime(1970, 1, 1)) == pytest.approx(0.0)
+
+
+def test_to_seconds_datetime_series():
+    ser = pd.Series(pd.to_datetime([0, 1, 2], unit="s", utc=True))
+    out = to_seconds(ser)
+    assert np.allclose(out, [0.0, 1.0, 2.0])
+
+
+def test_to_seconds_numeric_series():
+    ser = pd.Series([0.0, 1.5, 2.2])
+    out = to_seconds(ser)
+    assert np.allclose(out, [0.0, 1.5, 2.2])

--- a/utils.py
+++ b/utils.py
@@ -19,6 +19,7 @@ __all__ = [
     "parse_time_arg",
     "parse_timestamp",
     "parse_datetime",
+    "to_seconds",
     "parse_time",
     "LITERS_PER_M3",
 ]
@@ -270,6 +271,18 @@ def parse_datetime(value):
         raise RuntimeError("pandas is required for parse_datetime")
 
     return pd.Timestamp(dt.replace(tzinfo=None), tz="UTC")
+
+
+def to_seconds(series: pd.Series) -> np.ndarray:
+    """Return float seconds from a timestamp series."""
+
+    if not pd.api.types.is_datetime64_any_dtype(series):
+        return series.astype(float).to_numpy()
+    if getattr(series.dtype, "tz", None) is None:
+        series = series.map(parse_datetime)
+    else:
+        series = series.dt.tz_convert("UTC")
+    return series.astype("int64").to_numpy() / 1e9
 
 
 def parse_time(s, tz="UTC") -> float:


### PR DESCRIPTION
## Summary
- add `to_seconds` utility
- use it in burst filtering and analysis code
- test numeric and datetime input

## Testing
- `pytest tests/test_utils.py::test_to_seconds_datetime_series tests/test_utils.py::test_to_seconds_numeric_series -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b4ca04338832bbce49f2946307587