### PR TITLE
Fix type conversion in binning

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -290,7 +290,6 @@ def _ts_bin_centers_widths(times, cfg, t_start, t_end):
     arr = np.asarray(times)
     if np.issubdtype(arr.dtype, "datetime64"):
         arr = arr.astype("int64") / 1e9
-    arr = arr.astype(float)
     times_rel = arr - float(t_start)
     bin_mode = str(
         cfg.get("plot_time_binning_mode", cfg.get("time_bin_mode", "fixed"))


### PR DESCRIPTION
## Summary
- simplify timestamp binning by removing an unnecessary float conversion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b4ca64568832b8f321c2918a9a433