### PR TITLE
Fix timezone handling in baseline_utils

### DIFF
--- a/baseline_utils.py
+++ b/baseline_utils.py
@@ -54,7 +54,7 @@ def _to_datetime64(col: pd.Series) -> np.ndarray:
     if pd.api.types.is_datetime64_any_dtype(col):
         ser = col
         if getattr(ser.dtype, "tz", None) is not None:
-            ser = ser.dt.tz_convert("UTC")
+            ser = ser.dt.tz_convert("UTC").dt.tz_localize(None)
         ts = ser.to_numpy(dtype="datetime64[ns]")
     else:
         ts = col.map(parse_datetime).to_numpy(dtype="datetime64[ns]")


### PR DESCRIPTION
## Summary
- strip timezone information in `_to_datetime64`

## Testing
- `pytest -q`
- `pytest -q tests/test_baseline_datetime.py::test_rate_histogram_datetime_column -W error`
- `pytest -q tests/test_baseline_datetime.py::test_subtract_baseline_datetime_column -W error`


------
https://chatgpt.com/codex/tasks/task_e_685b4cec7ea0832b9224f64a1e7148fe