### PR TITLE
Fix timezone-aware datetime conversion

### DIFF
--- a/baseline.py
+++ b/baseline.py
@@ -12,7 +12,7 @@ def rate_histogram(df, bins):
     """Return (histogram in counts/s, live_time_s)."""
     if df.empty:
         return np.zeros(len(bins) - 1, dtype=float), 0.0
-    ts = baseline_utils._to_datetime64(df["timestamp"])
+    ts = baseline_utils._to_datetime64(df)
     live = float((ts[-1] - ts[0]) / np.timedelta64(1, "s"))
     hist_src = df.get("subtracted_adc_hist", df["adc"]).to_numpy()
     hist, _ = np.histogram(hist_src, bins=bins)

--- a/baseline_utils.py
+++ b/baseline_utils.py
@@ -48,16 +48,14 @@ def compute_dilution_factor(monitor_volume: float, sample_volume: float) -> floa
     return float(monitor_volume) / float(total)
 
 
-def _to_datetime64(col: pd.Series) -> np.ndarray:
-    """Return numpy.ndarray[datetime64[ns, UTC]]."""
+def _to_datetime64(events: pd.DataFrame) -> np.ndarray:
+    """Return ``timestamp`` column as ``numpy.ndarray[datetime64[ns, UTC]]``."""
 
-    if pd.api.types.is_datetime64_any_dtype(col):
-        ser = col
-        if getattr(ser.dtype, "tz", None) is not None:
-            ser = ser.dt.tz_convert("UTC")
-        ts = ser.to_numpy(dtype="datetime64[ns]")
-    else:
-        ts = col.map(parse_datetime).to_numpy(dtype="datetime64[ns]")
+    ts = (
+        events["timestamp"]
+        .dt.tz_convert("UTC")
+        .to_numpy(dtype="datetime64[ns]")
+    )
     return np.asarray(ts)
 
 
@@ -66,7 +64,7 @@ def _rate_histogram(df: pd.DataFrame, bins) -> tuple[np.ndarray, float]:
 
     if df.empty:
         return np.zeros(len(bins) - 1, dtype=float), 0.0
-    ts = _to_datetime64(df["timestamp"])
+    ts = _to_datetime64(df)
     live = float((ts[-1] - ts[0]) / np.timedelta64(1, "s"))
     hist_src = df.get("subtracted_adc_hist", df["adc"]).to_numpy()
     hist, _ = np.histogram(hist_src, bins=bins)
@@ -97,7 +95,7 @@ def subtract_baseline_dataframe(
 
     t0 = parse_datetime(t_base0).to_datetime64()
     t1 = parse_datetime(t_base1).to_datetime64()
-    ts_full = _to_datetime64(df_full["timestamp"])
+    ts_full = _to_datetime64(df_full)
     mask = (ts_full >= t0) & (ts_full <= t1)
     if not mask.any():
         logging.warning("baseline_range matched no events – skipping subtraction")


### PR DESCRIPTION
## Summary
- keep event timestamps timezone aware when histogramming
- update baseline utilities to use timezone-preserving helper
- adjust baseline rate histogram accordingly

## Testing
- `pytest -q`
- `pytest tests/test_baseline_datetime.py::test_rate_histogram_datetime_column -q`


------
https://chatgpt.com/codex/tasks/task_e_685b4e2ace1c832bb9c5979d18d17301