### PR TITLE
Improve timezone handling in baseline utilities

### DIFF
--- a/tests/test_baseline_datetime.py
+++ b/tests/test_baseline_datetime.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 import pytest
 
 import sys
@@ -37,4 +38,35 @@ def test_subtract_baseline_datetime_column():
     integral = out["subtracted_adc_hist"].iloc[0].sum()
     assert integral == pytest.approx(0.0, rel=1e-6)
     assert str(out["timestamp"].dtype) == "datetime64[ns, UTC]"
+
+
+def test_rate_histogram_non_utc_timezone():
+    ts = pd.date_range("1970-01-01", periods=5, freq="s", tz="Asia/Tokyo")
+    df = pd.DataFrame({"timestamp": ts, "adc": np.arange(5)})
+    bins = np.arange(0, 7)
+    rate, live = baseline.rate_histogram(df, bins)
+    assert live == pytest.approx(4.0)
+    assert np.allclose(rate, np.histogram(df["adc"], bins=bins)[0] / live)
+
+
+def test_subtract_baseline_non_utc_timezone():
+    ts_an = pd.date_range("1970-01-01", periods=5, freq="s", tz="Asia/Tokyo")
+    df_an = pd.DataFrame({"timestamp": ts_an, "adc": [1, 2, 3, 4, 5]})
+    ts_bl = pd.to_datetime(np.linspace(86400, 86440, 50), unit="s", utc=True).tz_convert("Asia/Tokyo")
+    df_bl = pd.DataFrame({"timestamp": ts_bl, "adc": np.tile([1,2,3,4,5],10)})
+    df_full = pd.concat([df_an, df_bl], ignore_index=True)
+    bins = np.arange(0, 7)
+    tz = ZoneInfo("Asia/Tokyo")
+    t0 = datetime(1970,1,2,9,0,0,tzinfo=tz)
+    t1 = datetime(1970,1,2,9,0,40,tzinfo=tz)
+    out = baseline.subtract_baseline(
+        df_an,
+        df_full,
+        bins=bins,
+        t_base0=t0,
+        t_base1=t1,
+        mode="all",
+    )
+    integral = out["subtracted_adc_hist"].iloc[0].sum()
+    assert integral == pytest.approx(0.0, rel=1e-6)
 


### PR DESCRIPTION
## Summary
- make `_to_datetime64` robust to timezone conversions using explicit `view("int64")`
- compute live times from integer nanoseconds in histogram functions
- compare baseline ranges using integer nanoseconds
- update docstrings for the new behaviour
- test histogram and subtraction with non-UTC timestamps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b4db5fdc4832b8c8c82cf3615e549