### PR TITLE
Introduce Summary dataclass

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -73,6 +73,7 @@ from io_utils import (
     load_events,
     write_summary,
     apply_burst_filter,
+    Summary,
 )
 from calibration import (
     derive_calibration_constants,
@@ -2044,31 +2045,31 @@ def main(argv=None):
             "peaks": cal_params.peaks,
         }
 
-    summary = {
-        "timestamp": now_str,
-        "config_used": args.config.name,
-        "calibration": cal_summary,
-        "calibration_valid": calibration_valid,
-        "spectral_fit": spec_dict,
-        "time_fit": time_fit_serializable,
-        "systematics": systematics_results,
-        "baseline": baseline_info,
-        "radon_results": radon_results,
-        "noise_cut": {"removed_events": int(n_removed_noise)},
-        "burst_filter": {
+    summary = Summary(
+        timestamp=now_str,
+        config_used=args.config.name,
+        calibration=cal_summary,
+        calibration_valid=calibration_valid,
+        spectral_fit=spec_dict,
+        time_fit=time_fit_serializable,
+        systematics=systematics_results,
+        baseline=baseline_info,
+        radon_results=radon_results,
+        noise_cut={"removed_events": int(n_removed_noise)},
+        burst_filter={
             "removed_events": int(n_removed_burst),
             "burst_mode": burst_mode,
         },
-        "adc_drift_rate": drift_rate,
-        "adc_drift_mode": drift_mode,
-        "adc_drift_params": drift_params,
-        "efficiency": efficiency_results,
-        "random_seed": seed_used,
-        "git_commit": commit,
-        "requirements_sha256": requirements_sha256,
-        "cli_sha256": cli_sha256,
-        "cli_args": cli_args,
-        "analysis": {
+        adc_drift_rate=drift_rate,
+        adc_drift_mode=drift_mode,
+        adc_drift_params=drift_params,
+        efficiency=efficiency_results,
+        random_seed=seed_used,
+        git_commit=commit,
+        requirements_sha256=requirements_sha256,
+        cli_sha256=cli_sha256,
+        cli_args=cli_args,
+        analysis={
             "analysis_start_time": t0_cfg,
             "analysis_end_time": t_end_cfg,
             "spike_end_time": spike_end_cfg,
@@ -2080,10 +2081,10 @@ def main(argv=None):
             ),
             "settle_s": cfg.get("analysis", {}).get("settle_s"),
         },
-    }
+    )
 
     if weights is not None:
-        summary["efficiency"]["blue_weights"] = list(weights)
+        summary.efficiency["blue_weights"] = list(weights)
 
     results_dir = Path(args.output_dir) / (args.job_id or now_str)
     if results_dir.exists():

--- a/io_utils.py
+++ b/io_utils.py
@@ -8,6 +8,9 @@ from datetime import datetime, timezone
 from dateutil import parser as date_parser
 import argparse
 import pandas as pd
+from dataclasses import dataclass, asdict
+from collections.abc import Mapping
+from typing import Any, Iterator
 from constants import load_nuclide_overrides
 
 import numpy as np
@@ -473,7 +476,50 @@ def apply_burst_filter(df, cfg=None, mode="rate"):
     return out_df, removed_total
 
 
-def write_summary(output_dir, summary_dict, timestamp=None):
+@dataclass
+class Summary(Mapping[str, Any]):
+    """Container for run summary information."""
+
+    timestamp: str
+    config_used: str
+    calibration: dict
+    calibration_valid: bool
+    spectral_fit: dict
+    time_fit: dict
+    systematics: dict | None
+    baseline: dict | None
+    radon_results: dict | None
+    noise_cut: dict
+    burst_filter: dict
+    adc_drift_rate: float | None
+    adc_drift_mode: str | None
+    adc_drift_params: dict | None
+    efficiency: dict
+    random_seed: int | None
+    git_commit: str | None
+    requirements_sha256: str | None
+    cli_sha256: str | None
+    cli_args: list
+    analysis: dict
+
+    def __getitem__(self, key: str) -> Any:  # type: ignore[override]
+        return getattr(self, key)
+
+    def __iter__(self) -> Iterator[str]:  # type: ignore[override]
+        return iter(asdict(self))
+
+    def __len__(self) -> int:  # type: ignore[override]
+        return len(asdict(self))
+
+    def get(self, key: str, default=None) -> Any:
+        return getattr(self, key, default)
+
+
+def write_summary(
+    output_dir: str | Path,
+    summary_dict: Mapping[str, Any] | Summary,
+    timestamp: str | None = None,
+) -> Path:
     """Write ``summary_dict`` to ``summary.json`` and return the results folder."""
 
     output_path = Path(output_dir)


### PR DESCRIPTION
## Summary
- add a `Summary` dataclass implementing mapping behaviour
- construct `Summary` in `analyze.py`
- accept `Summary` objects in `write_summary`

## Testing
- `mypy --config-file mypy.ini`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b4b573690832b9bfedc6531567651