### PR TITLE
Handle timezone-aware timestamps safely

### DIFF
--- a/baseline.py
+++ b/baseline.py
@@ -9,11 +9,17 @@ __all__ = ["rate_histogram", "subtract_baseline", "subtract_baseline_dataframe"]
 
 
 def rate_histogram(df, bins):
-    """Return (histogram in counts/s, live_time_s)."""
+    """Return ``(histogram, live_time_s)`` for a timestamped ``DataFrame``.
+
+    The timestamp column may be timezone-aware.  Internally timestamps are
+    converted to UTC and differences are computed using the underlying
+    integer nanoseconds to avoid dtype mismatches.
+    """
     if df.empty:
         return np.zeros(len(bins) - 1, dtype=float), 0.0
     ts = baseline_utils._to_datetime64(df["timestamp"])
-    live = float((ts[-1] - ts[0]) / np.timedelta64(1, "s"))
+    ts_int = ts.view("int64")
+    live = float((ts_int[-1] - ts_int[0]) / 1e9)
     hist_src = df.get("subtracted_adc_hist", df["adc"]).to_numpy()
     hist, _ = np.histogram(hist_src, bins=bins)
     if live <= 0:


### PR DESCRIPTION
## Summary
- handle timezone-aware series using integer nanoseconds
- compute live time from nanoseconds
- compare baseline ranges in integer nanoseconds
- document timezone handling in rate calculations

## Testing
- `pytest -q tests/test_baseline_datetime.py -q`
- `pytest tests/test_baseline_subtract.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685b50760638832b9da9bd2d932ce1af