### PR TITLE
Refactor summary to dataclass

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -73,6 +73,7 @@ from io_utils import (
     load_events,
     write_summary,
     apply_burst_filter,
+    Summary,
 )
 from calibration import (
     derive_calibration_constants,
@@ -2031,31 +2032,31 @@ def main(argv=None):
             "peaks": cal_params.peaks,
         }
 
-    summary = {
-        "timestamp": now_str,
-        "config_used": args.config.name,
-        "calibration": cal_summary,
-        "calibration_valid": calibration_valid,
-        "spectral_fit": spec_dict,
-        "time_fit": time_fit_serializable,
-        "systematics": systematics_results,
-        "baseline": baseline_info,
-        "radon_results": radon_results,
-        "noise_cut": {"removed_events": int(n_removed_noise)},
-        "burst_filter": {
+    summary = Summary(
+        timestamp=now_str,
+        config_used=args.config.name,
+        calibration=cal_summary,
+        calibration_valid=calibration_valid,
+        spectral_fit=spec_dict,
+        time_fit=time_fit_serializable,
+        systematics=systematics_results,
+        baseline=baseline_info,
+        radon_results=radon_results,
+        noise_cut={"removed_events": int(n_removed_noise)},
+        burst_filter={
             "removed_events": int(n_removed_burst),
             "burst_mode": burst_mode,
         },
-        "adc_drift_rate": drift_rate,
-        "adc_drift_mode": drift_mode,
-        "adc_drift_params": drift_params,
-        "efficiency": efficiency_results,
-        "random_seed": seed_used,
-        "git_commit": commit,
-        "requirements_sha256": requirements_sha256,
-        "cli_sha256": cli_sha256,
-        "cli_args": cli_args,
-        "analysis": {
+        adc_drift_rate=drift_rate,
+        adc_drift_mode=drift_mode,
+        adc_drift_params=drift_params,
+        efficiency=efficiency_results,
+        random_seed=seed_used,
+        git_commit=commit,
+        requirements_sha256=requirements_sha256,
+        cli_sha256=cli_sha256,
+        cli_args=cli_args,
+        analysis={
             "analysis_start_time": t0_cfg,
             "analysis_end_time": t_end_cfg,
             "spike_end_time": spike_end_cfg,
@@ -2067,10 +2068,10 @@ def main(argv=None):
             ),
             "settle_s": cfg.get("analysis", {}).get("settle_s"),
         },
-    }
+    )
 
     if weights is not None:
-        summary["efficiency"]["blue_weights"] = list(weights)
+        summary.efficiency["blue_weights"] = list(weights)
 
     results_dir = Path(args.output_dir) / (args.job_id or now_str)
     if results_dir.exists():

--- a/io_utils.py
+++ b/io_utils.py
@@ -5,6 +5,7 @@ import json
 import logging
 import warnings
 from datetime import datetime, timezone
+from dataclasses import dataclass, field
 from dateutil import parser as date_parser
 import argparse
 import pandas as pd
@@ -50,6 +51,33 @@ def extract_time_series_events(events, cfg):
     return out
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Summary:
+    """Summary information written to ``summary.json``."""
+
+    timestamp: str | None = None
+    config_used: str | None = None
+    calibration: dict = field(default_factory=dict)
+    calibration_valid: bool | None = None
+    spectral_fit: dict = field(default_factory=dict)
+    time_fit: dict = field(default_factory=dict)
+    systematics: dict = field(default_factory=dict)
+    baseline: dict = field(default_factory=dict)
+    radon_results: dict = field(default_factory=dict)
+    noise_cut: dict = field(default_factory=dict)
+    burst_filter: dict = field(default_factory=dict)
+    adc_drift_rate: float | None = None
+    adc_drift_mode: str | None = None
+    adc_drift_params: dict = field(default_factory=dict)
+    efficiency: dict = field(default_factory=dict)
+    random_seed: int | None = None
+    git_commit: str | None = None
+    requirements_sha256: str | None = None
+    cli_sha256: str | None = None
+    cli_args: list[str] = field(default_factory=list)
+    analysis: dict = field(default_factory=dict)
 
 
 CONFIG_SCHEMA = {
@@ -473,8 +501,8 @@ def apply_burst_filter(df, cfg=None, mode="rate"):
     return out_df, removed_total
 
 
-def write_summary(output_dir, summary_dict, timestamp=None):
-    """Write ``summary_dict`` to ``summary.json`` and return the results folder."""
+def write_summary(output_dir, summary: Summary, timestamp: str | None = None):
+    """Write ``summary`` to ``summary.json`` and return the results folder."""
 
     output_path = Path(output_dir)
 
@@ -490,7 +518,7 @@ def write_summary(output_dir, summary_dict, timestamp=None):
 
     summary_path = results_folder / "summary.json"
 
-    sanitized = to_native(summary_dict)
+    sanitized = to_native(summary)
 
     with open(summary_path, "w", encoding="utf-8") as f:
         json.dump(sanitized, f, indent=4)

--- a/tests/test_adc_drift.py
+++ b/tests/test_adc_drift.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 from calibration import CalibrationResult
 from fitting import FitResult, FitParams
+from dataclasses import asdict
 
 
 def _write_basic(tmp_path, drift_rate, mode="linear", params=None):
@@ -69,7 +70,7 @@ def test_adc_drift_applied(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -123,7 +124,7 @@ def test_adc_drift_zero_noop(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -279,7 +280,7 @@ def test_adc_drift_warning_on_failure(tmp_path, monkeypatch, capsys):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -10,6 +10,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 from calibration import CalibrationResult
 from fitting import FitResult, FitParams
+from dataclasses import asdict
 
 
 def test_plot_time_series_receives_merged_config(tmp_path, monkeypatch):
@@ -560,7 +561,7 @@ def test_spike_count_cli(tmp_path, monkeypatch):
     saved = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        saved["summary"] = summary
+        saved["summary"] = asdict(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -698,7 +699,7 @@ def test_assay_efficiency_list(tmp_path, monkeypatch):
     saved = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        saved["summary"] = summary
+        saved["summary"] = asdict(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -781,7 +782,7 @@ def test_spike_efficiency_list(tmp_path, monkeypatch):
     saved = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        saved["summary"] = summary
+        saved["summary"] = asdict(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -941,7 +942,7 @@ def test_settle_s_summary(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -1188,7 +1189,7 @@ def test_spike_period_cli(tmp_path, monkeypatch):
     saved = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        saved["summary"] = summary
+        saved["summary"] = asdict(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -1251,7 +1252,7 @@ def test_seed_cli_sets_random_seed(tmp_path, monkeypatch):
 
     captured = {}
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -1310,7 +1311,7 @@ def test_ambient_concentration_recorded(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "plot_equivalent_air", fake_plot_equivalent_air)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -1370,7 +1371,7 @@ def test_ambient_concentration_from_config(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "plot_equivalent_air", fake_plot_equivalent_air)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -1651,7 +1652,7 @@ def test_burst_mode_summary_config(tmp_path, monkeypatch):
     saved = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        saved["summary"] = summary
+        saved["summary"] = asdict(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -1770,7 +1771,7 @@ def test_ambient_concentration_default_none(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -1885,7 +1886,7 @@ def test_spike_periods_null_config(tmp_path, monkeypatch):
     saved = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        saved["summary"] = summary
+        saved["summary"] = asdict(summary)
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_analyze_noise_cutoff.py
+++ b/tests/test_analyze_noise_cutoff.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from dataclasses import asdict
 import numpy as np
 from fitting import FitResult, FitParams
 
@@ -62,7 +63,7 @@ def test_analyze_noise_cutoff(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit_time_series)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -8,6 +8,7 @@ import numpy as np
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
+from dataclasses import asdict
 from calibration import CalibrationResult
 import baseline
 from baseline_utils import subtract_baseline_counts
@@ -68,7 +69,7 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
     monkeypatch.setattr(baseline_noise, "estimate_baseline_noise", lambda *a, **k: (5.0, {}))
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -163,7 +164,7 @@ def test_baseline_scaling_factor(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -267,7 +268,7 @@ def test_n0_prior_from_baseline(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "scan_systematics", fake_scan_systematics)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -343,7 +344,7 @@ def test_isotopes_to_subtract_control(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -442,7 +443,7 @@ def test_baseline_scaling_multiple_isotopes(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -546,7 +547,7 @@ def test_noise_level_none_not_recorded(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -626,7 +627,7 @@ def test_sigma_rate_uses_weighted_counts(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_baseline_flow.py
+++ b/tests/test_baseline_flow.py
@@ -8,6 +8,7 @@ import analyze
 import baseline_noise
 import numpy as np
 from calibration import CalibrationResult
+from dataclasses import asdict
 
 
 def test_baseline_event_from_unfiltered_data(tmp_path, monkeypatch):
@@ -54,7 +55,7 @@ def test_baseline_event_from_unfiltered_data(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_baseline_noise_propagation.py
+++ b/tests/test_baseline_noise_propagation.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
 from calibration import CalibrationResult
+from dataclasses import asdict
 from fitting import FitResult, FitParams
 
 
@@ -66,7 +67,7 @@ def test_baseline_noise_propagation(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1,1)), 0))
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_baseline_range_cli.py
+++ b/tests/test_baseline_range_cli.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from dataclasses import asdict
 import baseline_noise
 from fitting import FitResult, FitParams
 
@@ -76,7 +77,7 @@ def test_baseline_range_cli_overrides_config(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_baseline_range_empty.py
+++ b/tests/test_baseline_range_empty.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from dataclasses import asdict
 import baseline_noise
 from fitting import FitResult, FitParams
 
@@ -78,7 +79,7 @@ def test_cli_baseline_range_empty(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_blue_weights.py
+++ b/tests/test_blue_weights.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 from calibration import CalibrationResult
 from fitting import FitResult, FitParams
+from dataclasses import asdict
 
 
 def test_blue_weights_summary(tmp_path, monkeypatch):
@@ -62,7 +63,7 @@ def test_blue_weights_summary(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_cli_baseline_range.py
+++ b/tests/test_cli_baseline_range.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from dataclasses import asdict
 import baseline_noise
 from fitting import FitResult, FitParams
 
@@ -78,7 +79,7 @@ def test_cli_baseline_range_overrides_config(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_cli_baseline_range_iso.py
+++ b/tests/test_cli_baseline_range_iso.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from dataclasses import asdict
 import baseline_noise
 from fitting import FitResult, FitParams
 
@@ -78,7 +79,7 @@ def test_cli_baseline_range_iso_strings(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -158,7 +159,7 @@ def test_cli_baseline_range_timezone(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_cli_baseline_range_override2.py
+++ b/tests/test_cli_baseline_range_override2.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
+from dataclasses import asdict
 import baseline_noise
 from fitting import FitResult, FitParams
 
@@ -78,7 +79,7 @@ def test_cli_baseline_range_overrides_config_again(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_cli_metadata.py
+++ b/tests/test_cli_metadata.py
@@ -8,6 +8,7 @@ import analyze
 import numpy as np
 from calibration import CalibrationResult
 from fitting import FitResult, FitParams
+from dataclasses import asdict
 
 
 def test_summary_includes_git_and_cli(tmp_path, monkeypatch):
@@ -51,7 +52,7 @@ def test_summary_includes_git_and_cli(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write_summary(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -15,6 +15,7 @@ from io_utils import (
     write_summary,
     copy_config,
     apply_burst_filter,
+    Summary,
 )
 from utils import parse_datetime
 
@@ -210,7 +211,7 @@ def test_load_events_string_nan(tmp_path):
 
 
 def test_write_summary_and_copy_config(tmp_path):
-    summary = {"a": 1, "b": 2}
+    summary = Summary(calibration={"a": 1, "b": 2})
     outdir = tmp_path / "out"
     ts = "19700101T000000Z"
     cfg = {"test": 1}
@@ -226,7 +227,7 @@ def test_write_summary_and_copy_config(tmp_path):
 
 def test_write_summary_with_nullable_integers(tmp_path):
     series = pd.Series([1, pd.NA], dtype="Int64")
-    summary = {"present": series.iloc[0], "missing": series.iloc[1], "list": series.tolist()}
+    summary = Summary(calibration={"present": series.iloc[0], "missing": series.iloc[1], "list": series.tolist()})
     outdir = tmp_path / "out2"
     ts = "19700101T000001Z"
     results = write_summary(outdir, summary, ts)
@@ -234,13 +235,13 @@ def test_write_summary_with_nullable_integers(tmp_path):
     assert summary_path.exists()
     with open(summary_path, "r", encoding="utf-8") as f:
         loaded = json.load(f)
-    assert loaded["present"] == 1
-    assert loaded["missing"] is None
-    assert loaded["list"] == [1, None]
+    assert loaded["calibration"]["present"] == 1
+    assert loaded["calibration"]["missing"] is None
+    assert loaded["calibration"]["list"] == [1, None]
 
 
 def test_write_summary_with_nan_values(tmp_path):
-    summary = {"nan": float("nan"), "inf": float("inf"), "list": [float("nan"), 1.0]}
+    summary = Summary(calibration={"nan": float("nan"), "inf": float("inf"), "list": [float("nan"), 1.0]})
     outdir = tmp_path / "out_nan"
     ts = "19700101T000002Z"
     results = write_summary(outdir, summary, ts)
@@ -248,9 +249,9 @@ def test_write_summary_with_nan_values(tmp_path):
     assert summary_path.exists()
     with open(summary_path, "r", encoding="utf-8") as f:
         loaded = json.load(f)
-    assert loaded["nan"] is None
-    assert loaded["inf"] is None
-    assert loaded["list"] == [None, 1.0]
+    assert loaded["calibration"]["nan"] is None
+    assert loaded["calibration"]["inf"] is None
+    assert loaded["calibration"]["list"] == [None, 1.0]
 
 
 def test_apply_burst_filter_no_removal():

--- a/tests/test_noise_cut.py
+++ b/tests/test_noise_cut.py
@@ -7,6 +7,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import numpy as np
 from calibration import CalibrationResult
+from dataclasses import asdict
 
 
 def test_noise_cutoff_cli_overrides(tmp_path, monkeypatch):
@@ -68,7 +69,7 @@ def test_noise_cutoff_cli_overrides(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_noise_cutoff.py
+++ b/tests/test_noise_cutoff.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import numpy as np
 from calibration import CalibrationResult
+from dataclasses import asdict
 from fitting import FitResult, FitParams
 
 
@@ -64,7 +65,7 @@ def test_noise_cutoff_filters_events(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -138,7 +139,7 @@ def test_invalid_noise_cutoff_skips_cut(tmp_path, monkeypatch, caplog):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_pipeline_after_fix.py
+++ b/tests/test_pipeline_after_fix.py
@@ -6,6 +6,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import analyze
+from dataclasses import asdict
 
 
 def test_pipeline_calibrates_after_fix(tmp_path, monkeypatch):
@@ -43,7 +44,7 @@ def test_pipeline_calibrates_after_fix(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_sample_radon.py
+++ b/tests/test_sample_radon.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import radon_activity
 import numpy as np
+from dataclasses import asdict
 from calibration import CalibrationResult
 from fitting import FitResult, FitParams
 
@@ -57,7 +58,7 @@ def test_total_radon_uses_sample_volume(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from fitting import FitResult, FitParams
 
 import analyze
+from dataclasses import asdict
 import baseline_noise
 from calibration import CalibrationResult
 
@@ -66,7 +67,7 @@ def test_time_window_filters_events(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -206,7 +207,7 @@ def test_time_window_filters_events_config(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -286,7 +287,7 @@ def test_run_period_filters_events(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -374,7 +375,7 @@ def test_baseline_range_iso_strings(tmp_path, monkeypatch, start, end):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
@@ -458,7 +459,7 @@ def test_unified_filter_combined_windows(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
-        captured["summary"] = summary
+        captured["summary"] = asdict(summary)
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
         return str(d)


### PR DESCRIPTION
## Summary
- add a dataclass `Summary` used for JSON output
- update `analyze` to build `Summary`
- adapt `write_summary` and tests for the new dataclass

## Testing
- `python -m mypy --config-file mypy.ini`
- `pytest -q` *(fails: Package 'numpy' is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_685b4ffa7ad4832b86353363b42462d8