### PR TITLE
Use dataclass for analysis summary

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -74,6 +74,7 @@ from io_utils import (
     write_summary,
     apply_burst_filter,
 )
+from summary import Summary
 from calibration import (
     derive_calibration_constants,
     derive_calibration_constants_auto,
@@ -2031,31 +2032,34 @@ def main(argv=None):
             "peaks": cal_params.peaks,
         }
 
-    summary = {
-        "timestamp": now_str,
-        "config_used": args.config.name,
-        "calibration": cal_summary,
-        "calibration_valid": calibration_valid,
-        "spectral_fit": spec_dict,
-        "time_fit": time_fit_serializable,
-        "systematics": systematics_results,
-        "baseline": baseline_info,
-        "radon_results": radon_results,
-        "noise_cut": {"removed_events": int(n_removed_noise)},
-        "burst_filter": {
+    if weights is not None:
+        efficiency_results["blue_weights"] = list(weights)
+
+    summary = Summary(
+        timestamp=now_str,
+        config_used=args.config.name,
+        calibration=cal_summary,
+        calibration_valid=calibration_valid,
+        spectral_fit=spec_dict,
+        time_fit=time_fit_serializable,
+        systematics=systematics_results,
+        baseline=baseline_info,
+        radon_results=radon_results,
+        noise_cut={"removed_events": int(n_removed_noise)},
+        burst_filter={
             "removed_events": int(n_removed_burst),
             "burst_mode": burst_mode,
         },
-        "adc_drift_rate": drift_rate,
-        "adc_drift_mode": drift_mode,
-        "adc_drift_params": drift_params,
-        "efficiency": efficiency_results,
-        "random_seed": seed_used,
-        "git_commit": commit,
-        "requirements_sha256": requirements_sha256,
-        "cli_sha256": cli_sha256,
-        "cli_args": cli_args,
-        "analysis": {
+        adc_drift_rate=drift_rate,
+        adc_drift_mode=drift_mode,
+        adc_drift_params=drift_params,
+        efficiency=efficiency_results,
+        random_seed=seed_used,
+        git_commit=commit,
+        requirements_sha256=requirements_sha256,
+        cli_sha256=cli_sha256,
+        cli_args=cli_args,
+        analysis={
             "analysis_start_time": t0_cfg,
             "analysis_end_time": t_end_cfg,
             "spike_end_time": spike_end_cfg,
@@ -2067,10 +2071,7 @@ def main(argv=None):
             ),
             "settle_s": cfg.get("analysis", {}).get("settle_s"),
         },
-    }
-
-    if weights is not None:
-        summary["efficiency"]["blue_weights"] = list(weights)
+    )
 
     results_dir = Path(args.output_dir) / (args.job_id or now_str)
     if results_dir.exists():

--- a/io_utils.py
+++ b/io_utils.py
@@ -12,6 +12,7 @@ from constants import load_nuclide_overrides
 
 import numpy as np
 from utils import to_native, parse_datetime, to_seconds
+from dataclasses import is_dataclass, asdict
 import jsonschema
 
 
@@ -473,8 +474,8 @@ def apply_burst_filter(df, cfg=None, mode="rate"):
     return out_df, removed_total
 
 
-def write_summary(output_dir, summary_dict, timestamp=None):
-    """Write ``summary_dict`` to ``summary.json`` and return the results folder."""
+def write_summary(output_dir, summary, timestamp=None):
+    """Write ``summary`` to ``summary.json`` and return the results folder."""
 
     output_path = Path(output_dir)
 
@@ -490,6 +491,10 @@ def write_summary(output_dir, summary_dict, timestamp=None):
 
     summary_path = results_folder / "summary.json"
 
+    if is_dataclass(summary):
+        summary_dict = asdict(summary)
+    else:
+        summary_dict = summary
     sanitized = to_native(summary_dict)
 
     with open(summary_path, "w", encoding="utf-8") as f:

--- a/summary.py
+++ b/summary.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+@dataclass
+class Summary:
+    timestamp: str
+    config_used: str
+    calibration: Dict[str, Any]
+    calibration_valid: bool
+    spectral_fit: Dict[str, Any]
+    time_fit: Dict[str, Any]
+    systematics: Dict[str, Any]
+    baseline: Dict[str, Any]
+    radon_results: Dict[str, Any]
+    noise_cut: Dict[str, Any]
+    burst_filter: Dict[str, Any]
+    adc_drift_rate: Optional[float] = None
+    adc_drift_mode: Optional[str] = None
+    adc_drift_params: Optional[Dict[str, Any]] = None
+    efficiency: Dict[str, Any] = field(default_factory=dict)
+    random_seed: Optional[int] = None
+    git_commit: Optional[str] = None
+    requirements_sha256: Optional[str] = None
+    cli_sha256: Optional[str] = None
+    cli_args: List[str] = field(default_factory=list)
+    analysis: Dict[str, Any] = field(default_factory=dict)

--- a/tests/test_adc_drift.py
+++ b/tests/test_adc_drift.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 import pandas as pd
 import numpy as np
+import dataclasses
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
@@ -69,6 +70,8 @@ def test_adc_drift_applied(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
@@ -123,6 +126,8 @@ def test_adc_drift_zero_noop(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
@@ -279,6 +284,8 @@ def test_adc_drift_warning_on_failure(tmp_path, monkeypatch, capsys):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -2,6 +2,7 @@ import json
 import sys
 from pathlib import Path
 from datetime import datetime, timezone
+import dataclasses
 import pandas as pd
 import numpy as np
 import logging
@@ -560,6 +561,8 @@ def test_spike_count_cli(tmp_path, monkeypatch):
     saved = {}
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         saved["summary"] = summary
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
@@ -698,6 +701,8 @@ def test_assay_efficiency_list(tmp_path, monkeypatch):
     saved = {}
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         saved["summary"] = summary
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
@@ -781,6 +786,8 @@ def test_spike_efficiency_list(tmp_path, monkeypatch):
     saved = {}
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         saved["summary"] = summary
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
@@ -941,6 +948,8 @@ def test_settle_s_summary(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
@@ -1188,6 +1197,8 @@ def test_spike_period_cli(tmp_path, monkeypatch):
     saved = {}
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         saved["summary"] = summary
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
@@ -1251,6 +1262,8 @@ def test_seed_cli_sets_random_seed(tmp_path, monkeypatch):
 
     captured = {}
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
@@ -1310,6 +1323,8 @@ def test_ambient_concentration_recorded(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "plot_equivalent_air", fake_plot_equivalent_air)
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
@@ -1370,6 +1385,8 @@ def test_ambient_concentration_from_config(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "plot_equivalent_air", fake_plot_equivalent_air)
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
@@ -1651,6 +1668,8 @@ def test_burst_mode_summary_config(tmp_path, monkeypatch):
     saved = {}
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         saved["summary"] = summary
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
@@ -1770,6 +1789,8 @@ def test_ambient_concentration_default_none(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)
@@ -1885,6 +1906,8 @@ def test_spike_periods_null_config(tmp_path, monkeypatch):
     saved = {}
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         saved["summary"] = summary
         d = Path(out_dir) / "x"
         d.mkdir(parents=True, exist_ok=True)

--- a/tests/test_analyze_noise_cutoff.py
+++ b/tests/test_analyze_noise_cutoff.py
@@ -6,6 +6,7 @@ import pandas as pd
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import numpy as np
+import dataclasses
 from fitting import FitResult, FitParams
 
 
@@ -62,6 +63,8 @@ def test_analyze_noise_cutoff(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit_time_series)
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -10,6 +10,7 @@ import analyze
 import baseline_noise
 from calibration import CalibrationResult
 import baseline
+import dataclasses
 from baseline_utils import subtract_baseline_counts
 from radon.baseline import subtract_baseline_counts
 from fitting import FitResult, FitParams
@@ -68,6 +69,8 @@ def test_simple_baseline_subtraction(tmp_path, monkeypatch):
     monkeypatch.setattr(baseline_noise, "estimate_baseline_noise", lambda *a, **k: (5.0, {}))
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
@@ -163,6 +166,8 @@ def test_baseline_scaling_factor(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
@@ -267,6 +272,8 @@ def test_n0_prior_from_baseline(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "scan_systematics", fake_scan_systematics)
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
@@ -343,6 +350,8 @@ def test_isotopes_to_subtract_control(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
@@ -442,6 +451,8 @@ def test_baseline_scaling_multiple_isotopes(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
@@ -546,6 +557,8 @@ def test_noise_level_none_not_recorded(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
@@ -626,6 +639,8 @@ def test_sigma_rate_uses_weighted_counts(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)

--- a/tests/test_baseline_flow.py
+++ b/tests/test_baseline_flow.py
@@ -6,6 +6,7 @@ import pandas as pd
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
+import dataclasses
 import numpy as np
 from calibration import CalibrationResult
 
@@ -54,6 +55,8 @@ def test_baseline_event_from_unfiltered_data(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)

--- a/tests/test_baseline_noise_propagation.py
+++ b/tests/test_baseline_noise_propagation.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import baseline_noise
 from calibration import CalibrationResult
+import dataclasses
 from fitting import FitResult, FitParams
 
 
@@ -66,6 +67,8 @@ def test_baseline_noise_propagation(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({"E_Po214": 1.0}), np.zeros((1,1)), 0))
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)

--- a/tests/test_baseline_range_cli.py
+++ b/tests/test_baseline_range_cli.py
@@ -5,6 +5,7 @@ import pandas as pd
 import numpy as np
 from calibration import CalibrationResult
 from datetime import datetime, timezone
+import dataclasses
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
@@ -76,6 +77,8 @@ def test_baseline_range_cli_overrides_config(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)

--- a/tests/test_baseline_range_empty.py
+++ b/tests/test_baseline_range_empty.py
@@ -5,6 +5,7 @@ import pandas as pd
 import numpy as np
 from calibration import CalibrationResult
 from datetime import datetime, timezone
+import dataclasses
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
@@ -78,6 +79,8 @@ def test_cli_baseline_range_empty(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)

--- a/tests/test_blue_weights.py
+++ b/tests/test_blue_weights.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 from calibration import CalibrationResult
 from fitting import FitResult, FitParams
+import dataclasses
 
 
 def test_blue_weights_summary(tmp_path, monkeypatch):
@@ -62,6 +63,8 @@ def test_blue_weights_summary(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)

--- a/tests/test_cli_baseline_range.py
+++ b/tests/test_cli_baseline_range.py
@@ -5,6 +5,7 @@ import pandas as pd
 import numpy as np
 from calibration import CalibrationResult
 from datetime import datetime, timezone
+import dataclasses
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
@@ -78,6 +79,8 @@ def test_cli_baseline_range_overrides_config(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)

--- a/tests/test_cli_baseline_range_iso.py
+++ b/tests/test_cli_baseline_range_iso.py
@@ -5,6 +5,7 @@ import pandas as pd
 import numpy as np
 from calibration import CalibrationResult
 from datetime import datetime, timezone
+import dataclasses
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
@@ -78,6 +79,8 @@ def test_cli_baseline_range_iso_strings(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
@@ -158,6 +161,8 @@ def test_cli_baseline_range_timezone(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)

--- a/tests/test_cli_baseline_range_override2.py
+++ b/tests/test_cli_baseline_range_override2.py
@@ -5,6 +5,7 @@ import pandas as pd
 import numpy as np
 from calibration import CalibrationResult
 from datetime import datetime, timezone
+import dataclasses
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
@@ -78,6 +79,8 @@ def test_cli_baseline_range_overrides_config_again(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)

--- a/tests/test_cli_metadata.py
+++ b/tests/test_cli_metadata.py
@@ -8,6 +8,7 @@ import analyze
 import numpy as np
 from calibration import CalibrationResult
 from fitting import FitResult, FitParams
+import dataclasses
 
 
 def test_summary_includes_git_and_cli(tmp_path, monkeypatch):
@@ -51,6 +52,8 @@ def test_summary_includes_git_and_cli(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write_summary(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)

--- a/tests/test_noise_cut.py
+++ b/tests/test_noise_cut.py
@@ -7,6 +7,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import numpy as np
 from calibration import CalibrationResult
+import dataclasses
 
 
 def test_noise_cutoff_cli_overrides(tmp_path, monkeypatch):
@@ -68,6 +69,8 @@ def test_noise_cutoff_cli_overrides(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)

--- a/tests/test_noise_cutoff.py
+++ b/tests/test_noise_cutoff.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 import pandas as pd
 import pytest
+import dataclasses
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
@@ -64,6 +65,8 @@ def test_noise_cutoff_filters_events(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
@@ -138,6 +141,8 @@ def test_invalid_noise_cutoff_skips_cut(tmp_path, monkeypatch, caplog):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)

--- a/tests/test_pipeline_after_fix.py
+++ b/tests/test_pipeline_after_fix.py
@@ -6,6 +6,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import analyze
+import dataclasses
 
 
 def test_pipeline_calibrates_after_fix(tmp_path, monkeypatch):
@@ -43,6 +44,8 @@ def test_pipeline_calibrates_after_fix(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)

--- a/tests/test_sample_radon.py
+++ b/tests/test_sample_radon.py
@@ -7,6 +7,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import analyze
 import radon_activity
+import dataclasses
 import numpy as np
 from calibration import CalibrationResult
 from fitting import FitResult, FitParams
@@ -57,6 +58,8 @@ def test_total_radon_uses_sample_volume(tmp_path, monkeypatch):
     captured = {}
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 import numpy as np
+import dataclasses
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from fitting import FitResult, FitParams
 
@@ -66,6 +67,8 @@ def test_time_window_filters_events(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
@@ -206,6 +209,8 @@ def test_time_window_filters_events_config(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
@@ -286,6 +291,8 @@ def test_run_period_filters_events(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
@@ -374,6 +381,8 @@ def test_baseline_range_iso_strings(tmp_path, monkeypatch, start, end):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)
@@ -458,6 +467,8 @@ def test_unified_filter_combined_windows(tmp_path, monkeypatch):
     monkeypatch.setattr(analyze, "fit_time_series", fake_fit)
 
     def fake_write(out_dir, summary, timestamp=None):
+        if dataclasses.is_dataclass(summary):
+            summary = dataclasses.asdict(summary)
         captured["summary"] = summary
         d = Path(out_dir) / (timestamp or "x")
         d.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- introduce `Summary` dataclass to represent analysis results
- build summary using the dataclass in `analyze.py`
- update `write_summary` to serialize dataclass objects
- adapt unit tests to handle the dataclass

## Testing
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b4ffa7ad4832b86353363b42462d8