### PR TITLE
Simplify baseline datetime conversion

### DIFF
--- a/baseline.py
+++ b/baseline.py
@@ -17,7 +17,7 @@ def rate_histogram(df, bins):
     """
     if df.empty:
         return np.zeros(len(bins) - 1, dtype=float), 0.0
-    ts = baseline_utils._to_datetime64(df["timestamp"])
+    ts = baseline_utils._to_datetime64(df)
     ts_int = ts.view("int64")
     live = float((ts_int[-1] - ts_int[0]) / 1e9)
     hist_src = df.get("subtracted_adc_hist", df["adc"]).to_numpy()

--- a/baseline_utils.py
+++ b/baseline_utils.py
@@ -48,27 +48,17 @@ def compute_dilution_factor(monitor_volume: float, sample_volume: float) -> floa
     return float(monitor_volume) / float(total)
 
 
-def _to_datetime64(col: pd.Series) -> np.ndarray:
+def _to_datetime64(events: pd.DataFrame | pd.Series) -> np.ndarray:
     """Return ``numpy.ndarray`` of ``datetime64[ns]`` in UTC.
 
-    Both timezone-naive and timezone-aware inputs are supported.  Any
-    timezone information is converted to UTC before the underlying
-    integer nanoseconds are reinterpreted as ``datetime64[ns]``.  This
-    avoids ``pandas`` warnings when comparing arrays with different time
-    zone attributes.
+    ``events`` may be a ``DataFrame`` or ``Series`` containing a
+    datetime-like ``timestamp`` column.  Values are expected to be
+    timezone-aware and are converted to UTC before dropping the timezone
+    information.
     """
 
-    if pd.api.types.is_datetime64_any_dtype(col):
-        ser = col
-        if getattr(ser.dtype, "tz", None) is not None:
-            ser = ser.dt.tz_convert("UTC")
-        ts = ser.view("int64").view("datetime64[ns]")
-    else:
-        ser = col.map(parse_datetime)
-        if getattr(ser.dtype, "tz", None) is not None:
-            ser = ser.dt.tz_convert("UTC")
-        ts = ser.view("int64").view("datetime64[ns]")
-    return np.asarray(ts)
+    ts = events["timestamp"] if isinstance(events, pd.DataFrame) else events
+    return ts.dt.tz_convert("UTC").to_numpy(dtype="datetime64[ns]")
 
 
 def _rate_histogram(df: pd.DataFrame, bins) -> tuple[np.ndarray, float]:
@@ -81,7 +71,7 @@ def _rate_histogram(df: pd.DataFrame, bins) -> tuple[np.ndarray, float]:
 
     if df.empty:
         return np.zeros(len(bins) - 1, dtype=float), 0.0
-    ts = _to_datetime64(df["timestamp"])
+    ts = _to_datetime64(df)
     ts_int = ts.view("int64")
     live = float((ts_int[-1] - ts_int[0]) / 1e9)
     hist_src = df.get("subtracted_adc_hist", df["adc"]).to_numpy()
@@ -119,7 +109,7 @@ def subtract_baseline_dataframe(
 
     t0 = parse_datetime(t_base0)
     t1 = parse_datetime(t_base1)
-    ts_full = _to_datetime64(df_full["timestamp"])
+    ts_full = _to_datetime64(df_full)
     ts_int = ts_full.view("int64")
     t0_ns = t0.value
     t1_ns = t1.value


### PR DESCRIPTION
## Summary
- simplify `_to_datetime64` to operate on DataFrames directly
- update callers to use the new signature

## Testing
- `pytest tests/test_baseline_datetime.py tests/test_baseline_subtract.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685b52b742c4832bab5e0ffc663f0c30