### PR TITLE
Fix timestamp conversions

### DIFF
--- a/baseline.py
+++ b/baseline.py
@@ -17,7 +17,7 @@ def rate_histogram(df, bins):
     """
     if df.empty:
         return np.zeros(len(bins) - 1, dtype=float), 0.0
-    ts = baseline_utils._to_datetime64(df["timestamp"])
+    ts = baseline_utils._to_datetime64(df)
     ts_int = ts.view("int64")
     live = float((ts_int[-1] - ts_int[0]) / 1e9)
     hist_src = df.get("subtracted_adc_hist", df["adc"]).to_numpy()


### PR DESCRIPTION
## Summary
- allow `_to_datetime64` to accept a whole DataFrame
- update baseline utilities to pass DataFrame to `_to_datetime64`
- update `baseline.rate_histogram` accordingly

## Testing
- `pytest tests/test_baseline.py::test_rate_histogram_single_event -q`
- `pytest -q` *(fails: NameError: name 'summary' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685b554c76fc832b8ba4182ad519f197