### PR TITLE
Consolidate baseline helpers

### DIFF
--- a/baseline.py
+++ b/baseline.py
@@ -1,5 +1,5 @@
-import numpy as np
 import logging
+import numpy as np
 import pandas as pd
 
 import baseline_utils
@@ -27,16 +27,6 @@ def rate_histogram(df, bins):
     return hist / live, live
 
 
-def subtract_baseline(df_analysis, df_full, bins, t_base0, t_base1,
-                         mode="all", live_time_analysis=None):
-    """Wrapper for :func:`baseline_utils.subtract_baseline_dataframe`."""
 
-    return subtract_baseline_dataframe(
-        df_analysis,
-        df_full,
-        bins,
-        t_base0,
-        t_base1,
-        mode=mode,
-        live_time_analysis=live_time_analysis,
-    )
+# Thin wrapper for backward compatibility
+subtract_baseline = baseline_utils.subtract_baseline_dataframe

--- a/baseline_utils.py
+++ b/baseline_utils.py
@@ -5,6 +5,11 @@ import numpy as np
 import pandas as pd
 
 from utils import parse_datetime
+from radon.baseline import (
+    subtract_baseline_counts,
+    subtract_baseline_rate,
+    _scaling_factor,
+)
 
 __all__ = [
     "compute_dilution_factor",
@@ -15,24 +20,6 @@ __all__ = [
 ]
 
 
-def _scaling_factor(dt_window: float, dt_baseline: float,
-                    err_window: float = 0.0,
-                    err_baseline: float = 0.0) -> tuple[float, float]:
-    """Return scaling factor between analysis and baseline durations.
-
-    This helper computes ``dt_window / dt_baseline`` and propagates the
-    1-sigma uncertainty from ``err_window`` and ``err_baseline`` assuming they
-    are independent.  A ``ValueError`` is raised when ``dt_baseline`` is zero
-    to avoid division by zero.
-    """
-
-    if dt_baseline == 0:
-        raise ValueError("dt_baseline must be non-zero")
-
-    scale = float(dt_window) / float(dt_baseline)
-    var = (err_window / dt_baseline) ** 2
-    var += ((dt_window * err_baseline) / dt_baseline**2) ** 2
-    return scale, float(np.sqrt(var))
 
 
 def compute_dilution_factor(monitor_volume: float, sample_volume: float) -> float:
@@ -100,7 +87,7 @@ def _rate_histogram(df: pd.DataFrame, bins) -> tuple[np.ndarray, float]:
     return hist / live, live
 
 
-def subtract_baseline_dataframe(
+def apply_baseline_subtraction(
     df_analysis: pd.DataFrame,
     df_full: pd.DataFrame,
     bins,
@@ -149,64 +136,9 @@ def subtract_baseline_dataframe(
     return df_out
 
 
-def subtract_baseline_counts(
-    counts: float,
-    efficiency: float,
-    live_time: float,
-    baseline_counts: float,
-    baseline_live_time: float,
-) -> tuple[float, float]:
-    """Return background-corrected rate and uncertainty."""
-
-    if live_time <= 0:
-        raise ValueError("live_time must be positive for baseline correction")
-    if baseline_live_time <= 0:
-        raise ValueError("baseline_live_time must be positive for baseline correction")
-    if efficiency <= 0:
-        raise ValueError("efficiency must be positive for baseline correction")
-
-    scale, _ = _scaling_factor(live_time, baseline_live_time)
-
-    net = counts - scale * baseline_counts
-    corrected_rate = net / live_time / efficiency
-
-    sigma_sq = counts / live_time**2 / efficiency**2
-    baseline_sigma_sq = baseline_counts * scale**2 / live_time**2 / efficiency**2
-    corrected_sigma = np.sqrt(sigma_sq + baseline_sigma_sq)
-    return corrected_rate, corrected_sigma
+# Backwards compatibility
+subtract_baseline_dataframe = apply_baseline_subtraction
 
 
-def subtract_baseline_rate(
-    fit_rate: float,
-    fit_sigma: float,
-    counts: float,
-    efficiency: float,
-    live_time: float,
-    baseline_counts: float,
-    baseline_live_time: float,
-    scale: float = 1.0,
-) -> tuple[float, float, float, float]:
-    """Apply baseline subtraction to a fitted decay rate."""
 
-    if live_time <= 0:
-        raise ValueError("live_time must be positive for baseline correction")
-    if baseline_live_time <= 0:
-        raise ValueError("baseline_live_time must be positive for baseline correction")
-    if efficiency <= 0:
-        raise ValueError("efficiency must be positive for baseline correction")
-
-    baseline_rate = baseline_counts / (baseline_live_time * efficiency)
-    baseline_sigma = np.sqrt(baseline_counts) / (baseline_live_time * efficiency)
-
-    _, sigma_rate = subtract_baseline_counts(
-        counts,
-        efficiency,
-        live_time,
-        baseline_counts,
-        baseline_live_time,
-    )
-
-    corrected_rate = fit_rate - scale * baseline_rate
-    corrected_sigma = float(np.hypot(fit_sigma, sigma_rate * scale))
-
-    return corrected_rate, corrected_sigma, baseline_rate, baseline_sigma
+# thin wrappers are imported above from :mod:`radon.baseline`

--- a/radon/baseline.py
+++ b/radon/baseline.py
@@ -1,6 +1,95 @@
-"""Thin wrappers around :mod:`baseline_utils` for backward compatibility."""
+"""Baseline subtraction utilities for radon analysis."""
 
-from baseline_utils import subtract_baseline_counts, subtract_baseline_rate
+from __future__ import annotations
+
+import numpy as np
 
 __all__ = ["subtract_baseline_counts", "subtract_baseline_rate"]
 
+
+def _scaling_factor(
+    dt_window: float,
+    dt_baseline: float,
+    err_window: float = 0.0,
+    err_baseline: float = 0.0,
+) -> tuple[float, float]:
+    """Return scaling factor between analysis and baseline durations."""
+
+    if dt_baseline == 0:
+        raise ValueError("dt_baseline must be non-zero")
+
+    scale = float(dt_window) / float(dt_baseline)
+    var = (err_window / dt_baseline) ** 2
+    var += ((dt_window * err_baseline) / dt_baseline ** 2) ** 2
+    return scale, float(np.sqrt(var))
+
+
+def subtract_baseline_counts(
+    counts: float,
+    efficiency: float,
+    live_time: float,
+    baseline_counts: float,
+    baseline_live_time: float,
+) -> tuple[float, float]:
+    """Return background-corrected rate and uncertainty."""
+
+    if live_time <= 0:
+        raise ValueError("live_time must be positive for baseline correction")
+    if baseline_live_time <= 0:
+        raise ValueError(
+            "baseline_live_time must be positive for baseline correction"
+        )
+    if efficiency <= 0:
+        raise ValueError("efficiency must be positive for baseline correction")
+
+    scale, _ = _scaling_factor(live_time, baseline_live_time)
+
+    net = counts - scale * baseline_counts
+    corrected_rate = net / live_time / efficiency
+
+    sigma_sq = counts / live_time ** 2 / efficiency ** 2
+    baseline_sigma_sq = (
+        baseline_counts * scale ** 2 / live_time ** 2 / efficiency ** 2
+    )
+    corrected_sigma = np.sqrt(sigma_sq + baseline_sigma_sq)
+    return corrected_rate, corrected_sigma
+
+
+def subtract_baseline_rate(
+    fit_rate: float,
+    fit_sigma: float,
+    counts: float,
+    efficiency: float,
+    live_time: float,
+    baseline_counts: float,
+    baseline_live_time: float,
+    scale: float = 1.0,
+) -> tuple[float, float, float, float]:
+    """Apply baseline subtraction to a fitted decay rate."""
+
+    if live_time <= 0:
+        raise ValueError("live_time must be positive for baseline correction")
+    if baseline_live_time <= 0:
+        raise ValueError(
+            "baseline_live_time must be positive for baseline correction"
+        )
+    if efficiency <= 0:
+        raise ValueError("efficiency must be positive for baseline correction")
+
+    baseline_rate = baseline_counts / (baseline_live_time * efficiency)
+    baseline_sigma = np.sqrt(baseline_counts) / (
+        baseline_live_time * efficiency
+    )
+
+    _, sigma_rate = subtract_baseline_counts(
+        counts,
+        efficiency,
+        live_time,
+        baseline_counts,
+        baseline_live_time,
+    )
+
+    corrected_rate = fit_rate - scale * baseline_rate
+    corrected_sigma = float(np.hypot(fit_sigma, sigma_rate * scale))
+
+    return corrected_rate, corrected_sigma, baseline_rate, baseline_sigma


### PR DESCRIPTION
## Summary
- deduplicate baseline helpers and define canonical helpers in `radon/baseline.py`
- import helper wrappers from the radon module
- keep old APIs as thin aliases for backwards compatibility

## Testing
- `grep -R "def subtract_baseline" -n | wc -l`
- `pytest -q` *(fails: many missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685b57c597bc832ba1c86ba04abcc922