### PR TITLE
Improve radon activity covariance handling

### DIFF
--- a/fitting.py
+++ b/fitting.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import TypedDict, NotRequired
 
 import numpy as np
+import pandas as pd
 from iminuit import Minuit
 from scipy.optimize import curve_fit, OptimizeWarning
 from calibration import emg_left, gaussian
@@ -114,6 +115,18 @@ class FitResult:
             return float(self.cov[i1, i2])
 
         raise KeyError(f"Parameter(s) missing in covariance: {name1}, {name2}")
+
+    @property
+    def cov_df(self) -> pd.DataFrame:
+        """Return covariance matrix as a :class:`pandas.DataFrame`."""
+        if self.cov is None or self.param_index is None:
+            return pd.DataFrame()
+        ordered = sorted(self.param_index.items(), key=lambda kv: kv[1])
+        names = [n for n, _ in ordered]
+        cov = np.asarray(self.cov, dtype=float)
+        if cov.ndim == 2 and cov.shape[0] == len(names):
+            return pd.DataFrame(cov, index=names, columns=names)
+        return pd.DataFrame()
 
 
 def fit_decay(times, priors, t0=0.0, t_end=None, flags=None):


### PR DESCRIPTION
## Summary
- add `cov_df` property to `FitResult` for convenient covariance access
- expose covariance via `_cov_entry` to gracefully handle missing entries
- retrieve `cov_en0` from the new dataframe when plotting radon activity

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b5b0bc578832b88579da2b7d7171c