### PR TITLE
Consolidate baseline helpers

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -108,7 +108,7 @@ from utils import (
 )
 from utils import parse_datetime, to_seconds
 from baseline_utils import (
-    subtract_baseline_dataframe,
+    apply_baseline_dataframe,
     subtract_baseline_counts,
     subtract_baseline_rate,
     compute_dilution_factor,
@@ -1235,7 +1235,7 @@ def main(argv=None):
         t_base0 = args.baseline_range[0]
         t_base1 = args.baseline_range[1]
         edges = adc_hist_edges(df_analysis["adc"].values, hist_bins)
-        df_analysis = subtract_baseline_dataframe(
+        df_analysis = apply_baseline_dataframe(
             df_analysis,
             events_all,
             bins=edges,

--- a/baseline.py
+++ b/baseline.py
@@ -3,9 +3,9 @@ import logging
 import pandas as pd
 
 import baseline_utils
-from baseline_utils import subtract_baseline_dataframe
+from baseline_utils import apply_baseline_dataframe
 
-__all__ = ["rate_histogram", "subtract_baseline", "subtract_baseline_dataframe"]
+__all__ = ["rate_histogram", "apply_baseline", "apply_baseline_dataframe"]
 
 
 def rate_histogram(df, bins):
@@ -27,11 +27,11 @@ def rate_histogram(df, bins):
     return hist / live, live
 
 
-def subtract_baseline(df_analysis, df_full, bins, t_base0, t_base1,
-                         mode="all", live_time_analysis=None):
-    """Wrapper for :func:`baseline_utils.subtract_baseline_dataframe`."""
+def apply_baseline(df_analysis, df_full, bins, t_base0, t_base1,
+                   mode="all", live_time_analysis=None):
+    """Wrapper for :func:`baseline_utils.apply_baseline_dataframe`."""
 
-    return subtract_baseline_dataframe(
+    return apply_baseline_dataframe(
         df_analysis,
         df_full,
         bins,

--- a/baseline_utils.py
+++ b/baseline_utils.py
@@ -5,34 +5,21 @@ import numpy as np
 import pandas as pd
 
 from utils import parse_datetime
+from radon.baseline import (
+    subtract_baseline_counts,
+    subtract_baseline_rate,
+    _scaling_factor,
+)
 
 __all__ = [
     "compute_dilution_factor",
-    "subtract_baseline_dataframe",
+    "apply_baseline_dataframe",
     "subtract_baseline_counts",
     "subtract_baseline_rate",
     "_scaling_factor",
 ]
 
 
-def _scaling_factor(dt_window: float, dt_baseline: float,
-                    err_window: float = 0.0,
-                    err_baseline: float = 0.0) -> tuple[float, float]:
-    """Return scaling factor between analysis and baseline durations.
-
-    This helper computes ``dt_window / dt_baseline`` and propagates the
-    1-sigma uncertainty from ``err_window`` and ``err_baseline`` assuming they
-    are independent.  A ``ValueError`` is raised when ``dt_baseline`` is zero
-    to avoid division by zero.
-    """
-
-    if dt_baseline == 0:
-        raise ValueError("dt_baseline must be non-zero")
-
-    scale = float(dt_window) / float(dt_baseline)
-    var = (err_window / dt_baseline) ** 2
-    var += ((dt_window * err_baseline) / dt_baseline**2) ** 2
-    return scale, float(np.sqrt(var))
 
 
 def compute_dilution_factor(monitor_volume: float, sample_volume: float) -> float:
@@ -100,7 +87,7 @@ def _rate_histogram(df: pd.DataFrame, bins) -> tuple[np.ndarray, float]:
     return hist / live, live
 
 
-def subtract_baseline_dataframe(
+def apply_baseline_dataframe(
     df_analysis: pd.DataFrame,
     df_full: pd.DataFrame,
     bins,
@@ -149,64 +136,3 @@ def subtract_baseline_dataframe(
     return df_out
 
 
-def subtract_baseline_counts(
-    counts: float,
-    efficiency: float,
-    live_time: float,
-    baseline_counts: float,
-    baseline_live_time: float,
-) -> tuple[float, float]:
-    """Return background-corrected rate and uncertainty."""
-
-    if live_time <= 0:
-        raise ValueError("live_time must be positive for baseline correction")
-    if baseline_live_time <= 0:
-        raise ValueError("baseline_live_time must be positive for baseline correction")
-    if efficiency <= 0:
-        raise ValueError("efficiency must be positive for baseline correction")
-
-    scale, _ = _scaling_factor(live_time, baseline_live_time)
-
-    net = counts - scale * baseline_counts
-    corrected_rate = net / live_time / efficiency
-
-    sigma_sq = counts / live_time**2 / efficiency**2
-    baseline_sigma_sq = baseline_counts * scale**2 / live_time**2 / efficiency**2
-    corrected_sigma = np.sqrt(sigma_sq + baseline_sigma_sq)
-    return corrected_rate, corrected_sigma
-
-
-def subtract_baseline_rate(
-    fit_rate: float,
-    fit_sigma: float,
-    counts: float,
-    efficiency: float,
-    live_time: float,
-    baseline_counts: float,
-    baseline_live_time: float,
-    scale: float = 1.0,
-) -> tuple[float, float, float, float]:
-    """Apply baseline subtraction to a fitted decay rate."""
-
-    if live_time <= 0:
-        raise ValueError("live_time must be positive for baseline correction")
-    if baseline_live_time <= 0:
-        raise ValueError("baseline_live_time must be positive for baseline correction")
-    if efficiency <= 0:
-        raise ValueError("efficiency must be positive for baseline correction")
-
-    baseline_rate = baseline_counts / (baseline_live_time * efficiency)
-    baseline_sigma = np.sqrt(baseline_counts) / (baseline_live_time * efficiency)
-
-    _, sigma_rate = subtract_baseline_counts(
-        counts,
-        efficiency,
-        live_time,
-        baseline_counts,
-        baseline_live_time,
-    )
-
-    corrected_rate = fit_rate - scale * baseline_rate
-    corrected_sigma = float(np.hypot(fit_sigma, sigma_rate * scale))
-
-    return corrected_rate, corrected_sigma, baseline_rate, baseline_sigma

--- a/radmon/__init__.py
+++ b/radmon/__init__.py
@@ -1,3 +1,5 @@
 """Helper package exposing baseline utilities."""
-from baseline import subtract_baseline
-__all__ = ["subtract_baseline"]
+
+from baseline import apply_baseline
+
+__all__ = ["apply_baseline"]

--- a/radmon/baseline.py
+++ b/radmon/baseline.py
@@ -1,0 +1,3 @@
+from radon.baseline import subtract_baseline_counts, subtract_baseline_rate
+
+__all__ = ["subtract_baseline_counts", "subtract_baseline_rate"]

--- a/radon/baseline.py
+++ b/radon/baseline.py
@@ -1,6 +1,88 @@
-"""Thin wrappers around :mod:`baseline_utils` for backward compatibility."""
+"""Baseline subtraction helpers used throughout the analysis codebase."""
 
-from baseline_utils import subtract_baseline_counts, subtract_baseline_rate
+from __future__ import annotations
+
+import numpy as np
 
 __all__ = ["subtract_baseline_counts", "subtract_baseline_rate"]
+
+
+def _scaling_factor(
+    dt_window: float,
+    dt_baseline: float,
+    err_window: float = 0.0,
+    err_baseline: float = 0.0,
+) -> tuple[float, float]:
+    """Return scaling factor between analysis and baseline durations."""
+
+    if dt_baseline == 0:
+        raise ValueError("dt_baseline must be non-zero")
+
+    scale = float(dt_window) / float(dt_baseline)
+    var = (err_window / dt_baseline) ** 2
+    var += ((dt_window * err_baseline) / dt_baseline**2) ** 2
+    return scale, float(np.sqrt(var))
+
+
+def subtract_baseline_counts(
+    counts: float,
+    efficiency: float,
+    live_time: float,
+    baseline_counts: float,
+    baseline_live_time: float,
+) -> tuple[float, float]:
+    """Return background-corrected rate and uncertainty."""
+
+    if live_time <= 0:
+        raise ValueError("live_time must be positive for baseline correction")
+    if baseline_live_time <= 0:
+        raise ValueError("baseline_live_time must be positive for baseline correction")
+    if efficiency <= 0:
+        raise ValueError("efficiency must be positive for baseline correction")
+
+    scale, _ = _scaling_factor(live_time, baseline_live_time)
+
+    net = counts - scale * baseline_counts
+    corrected_rate = net / live_time / efficiency
+
+    sigma_sq = counts / live_time**2 / efficiency**2
+    baseline_sigma_sq = baseline_counts * scale**2 / live_time**2 / efficiency**2
+    corrected_sigma = np.sqrt(sigma_sq + baseline_sigma_sq)
+    return corrected_rate, corrected_sigma
+
+
+def subtract_baseline_rate(
+    fit_rate: float,
+    fit_sigma: float,
+    counts: float,
+    efficiency: float,
+    live_time: float,
+    baseline_counts: float,
+    baseline_live_time: float,
+    scale: float = 1.0,
+) -> tuple[float, float, float, float]:
+    """Apply baseline subtraction to a fitted decay rate."""
+
+    if live_time <= 0:
+        raise ValueError("live_time must be positive for baseline correction")
+    if baseline_live_time <= 0:
+        raise ValueError("baseline_live_time must be positive for baseline correction")
+    if efficiency <= 0:
+        raise ValueError("efficiency must be positive for baseline correction")
+
+    baseline_rate = baseline_counts / (baseline_live_time * efficiency)
+    baseline_sigma = np.sqrt(baseline_counts) / (baseline_live_time * efficiency)
+
+    _, sigma_rate = subtract_baseline_counts(
+        counts,
+        efficiency,
+        live_time,
+        baseline_counts,
+        baseline_live_time,
+    )
+
+    corrected_rate = fit_rate - scale * baseline_rate
+    corrected_sigma = float(np.hypot(fit_sigma, sigma_rate * scale))
+
+    return corrected_rate, corrected_sigma, baseline_rate, baseline_sigma
 

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -11,7 +11,6 @@ import baseline_noise
 from dataclasses import asdict
 from calibration import CalibrationResult
 import baseline
-from baseline_utils import subtract_baseline_counts
 from radon.baseline import subtract_baseline_counts
 from fitting import FitResult, FitParams
 

--- a/tests/test_baseline_datetime.py
+++ b/tests/test_baseline_datetime.py
@@ -26,7 +26,7 @@ def test_subtract_baseline_datetime_column():
     df_bl = pd.DataFrame({"timestamp": ts_bl, "adc": np.tile([1,2,3,4,5],10)})
     df_full = pd.concat([df_an, df_bl], ignore_index=True)
     bins = np.arange(0, 7)
-    out = baseline.subtract_baseline(
+    out = baseline.apply_baseline(
         df_an,
         df_full,
         bins=bins,

--- a/tests/test_baseline_subtract.py
+++ b/tests/test_baseline_subtract.py
@@ -17,7 +17,7 @@ def test_baseline_none():
         "adc": np.arange(10),
     })
     bins = np.arange(0, 11)
-    out = baseline_utils.subtract_baseline_dataframe(
+    out = baseline_utils.apply_baseline_dataframe(
         df,
         df,
         bins=bins,
@@ -41,7 +41,7 @@ def test_baseline_time_norm():
     })
     df_full = pd.concat([df_an, df_bl], ignore_index=True)
     bins = np.arange(0, 7)
-    out = baseline_utils.subtract_baseline_dataframe(
+    out = baseline_utils.apply_baseline_dataframe(
         df_an,
         df_full,
         bins=bins,
@@ -59,7 +59,7 @@ def test_baseline_none_datetime():
         "adc": np.arange(10),
     })
     bins = np.arange(0, 11)
-    out = baseline_utils.subtract_baseline_dataframe(
+    out = baseline_utils.apply_baseline_dataframe(
         df,
         df,
         bins=bins,
@@ -83,7 +83,7 @@ def test_baseline_time_norm_datetime():
     })
     df_full = pd.concat([df_an, df_bl], ignore_index=True)
     bins = np.arange(0, 7)
-    out = baseline_utils.subtract_baseline_dataframe(
+    out = baseline_utils.apply_baseline_dataframe(
         df_an,
         df_full,
         bins=bins,

--- a/tests/test_baseline_uncertainty.py
+++ b/tests/test_baseline_uncertainty.py
@@ -3,7 +3,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import pytest
 import numpy as np
-from baseline_utils import subtract_baseline_counts, subtract_baseline_rate
+from radon.baseline import subtract_baseline_counts, subtract_baseline_rate
 
 
 def test_subtract_baseline_uncertainty():

--- a/tests/test_datetime_pipeline.py
+++ b/tests/test_datetime_pipeline.py
@@ -31,7 +31,7 @@ def test_datetime_pipeline(tmp_path):
     assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
 
     bins = np.arange(0, 5)
-    subtracted = baseline.subtract_baseline(
+    subtracted = baseline.apply_baseline(
         loaded,
         loaded,
         bins=bins,

--- a/tests/test_time_series_weights.py
+++ b/tests/test_time_series_weights.py
@@ -124,7 +124,7 @@ def test_corrected_sigma_weighting():
     res_std = fit_time_series({"Po214": times}, 0.0, T, cfg, weights={"Po214": np.ones_like(times)})
 
     # Expected uncertainty from baseline subtraction
-    from baseline_utils import subtract_baseline_counts
+    from radon.baseline import subtract_baseline_counts
 
     _, corrected_sigma = subtract_baseline_counts(
         n,

--- a/tests/test_timestamp_dtype.py
+++ b/tests/test_timestamp_dtype.py
@@ -30,7 +30,7 @@ def test_subtract_baseline_preserves_dtype():
     ts = pd.date_range("1970-01-01", periods=3, freq="s", tz="UTC")
     df = pd.DataFrame({"timestamp": ts, "adc": [1, 2, 3]})
     bins = np.arange(0, 5)
-    out = baseline.subtract_baseline(
+    out = baseline.apply_baseline(
         df,
         df,
         bins=bins,


### PR DESCRIPTION
## Summary
- move baseline math into `radon.baseline`
- rename dataframe function to `apply_baseline_dataframe`
- re-export new API from old modules
- update callers and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b5a088acc832ba1d42fa59a38c1cb