### PR TITLE
Update scaling factor imports

### DIFF
--- a/baseline_utils.py
+++ b/baseline_utils.py
@@ -8,7 +8,6 @@ from utils import parse_datetime
 from radon.baseline import (
     subtract_baseline_counts,
     subtract_baseline_rate,
-    _scaling_factor,
 )
 
 __all__ = [
@@ -16,7 +15,6 @@ __all__ = [
     "subtract_baseline_dataframe",
     "subtract_baseline_counts",
     "subtract_baseline_rate",
-    "_scaling_factor",
 ]
 
 

--- a/tests/test_scaling_factor.py
+++ b/tests/test_scaling_factor.py
@@ -3,17 +3,18 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-import baseline_utils as baseline
+import baseline_utils
+from radon.baseline import _scaling_factor
 
 
 def test_scaling_factor_basic():
-    s, ds = baseline._scaling_factor(10.0, 5.0)
+    s, ds = _scaling_factor(10.0, 5.0)
     assert s == pytest.approx(2.0)
     assert ds == pytest.approx(0.0)
 
 
 def test_scaling_factor_uncertainty():
-    s, ds = baseline._scaling_factor(10.0, 5.0, 0.1, 0.2)
+    s, ds = _scaling_factor(10.0, 5.0, 0.1, 0.2)
     assert s == pytest.approx(2.0)
     expected_var = (0.1/5.0)**2 + ((10.0*0.2)/5.0**2)**2
     assert ds == pytest.approx((expected_var)**0.5)
@@ -21,11 +22,11 @@ def test_scaling_factor_uncertainty():
 
 def test_scaling_factor_zero_baseline():
     with pytest.raises(ValueError):
-        baseline._scaling_factor(1.0, 0.0)
+        _scaling_factor(1.0, 0.0)
 
 
 def test_compute_dilution_factor():
-    d = baseline.compute_dilution_factor(10.0, 5.0)
+    d = baseline_utils.compute_dilution_factor(10.0, 5.0)
     assert d == pytest.approx(10.0 / 15.0)
-    d_zero = baseline.compute_dilution_factor(0.0, 0.0)
+    d_zero = baseline_utils.compute_dilution_factor(0.0, 0.0)
     assert d_zero == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- drop `_scaling_factor` from `baseline_utils.__all__`
- update scaling factor tests to import from `radon.baseline`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: AttributeError: property 'cov_df' of 'FitResult' object has no setter)*

------
https://chatgpt.com/codex/tasks/task_e_685b5d675920832bb088a0db2981b2d6