### PR TITLE
Refactor rate_histogram

### DIFF
--- a/baseline.py
+++ b/baseline.py
@@ -1,32 +1,5 @@
-import logging
-import numpy as np
-import pandas as pd
+from baseline_utils import rate_histogram, subtract_baseline_dataframe
 
-import baseline_utils
-from baseline_utils import subtract_baseline_dataframe
+subtract_baseline = subtract_baseline_dataframe
 
 __all__ = ["rate_histogram", "subtract_baseline", "subtract_baseline_dataframe"]
-
-
-def rate_histogram(df, bins):
-    """Return ``(histogram, live_time_s)`` for a timestamped ``DataFrame``.
-
-    The timestamp column may be timezone-aware.  Internally timestamps are
-    converted to UTC and differences are computed using the underlying
-    integer nanoseconds to avoid dtype mismatches.
-    """
-    if df.empty:
-        return np.zeros(len(bins) - 1, dtype=float), 0.0
-    ts = baseline_utils._to_datetime64(df)
-    ts_int = ts.view("int64")
-    live = float((ts_int[-1] - ts_int[0]) / 1e9)
-    hist_src = df.get("subtracted_adc_hist", df["adc"]).to_numpy()
-    hist, _ = np.histogram(hist_src, bins=bins)
-    if live <= 0:
-        return np.zeros_like(hist, dtype=float), live
-    return hist / live, live
-
-
-
-# Thin wrapper for backward compatibility
-subtract_baseline = baseline_utils.subtract_baseline_dataframe

--- a/baseline_utils.py
+++ b/baseline_utils.py
@@ -17,6 +17,7 @@ __all__ = [
     "subtract_baseline_counts",
     "subtract_baseline_rate",
     "_scaling_factor",
+    "rate_histogram",
 ]
 
 
@@ -67,7 +68,7 @@ def _to_datetime64(events: pd.DataFrame | pd.Series) -> np.ndarray:
     return ser.to_numpy(dtype="datetime64[ns]")
 
 
-def _rate_histogram(df: pd.DataFrame, bins) -> tuple[np.ndarray, float]:
+def rate_histogram(df: pd.DataFrame, bins) -> tuple[np.ndarray, float]:
     """Return histogram in counts/s and the live time in seconds.
 
     Timestamp columns may be timezone-aware.  Differences are computed
@@ -85,6 +86,10 @@ def _rate_histogram(df: pd.DataFrame, bins) -> tuple[np.ndarray, float]:
     if live <= 0:
         return np.zeros_like(hist, dtype=float), live
     return hist / live, live
+
+
+# Backwards compatibility alias
+_rate_histogram = rate_histogram
 
 
 def apply_baseline_subtraction(

--- a/tests/test_baseline_datetime.py
+++ b/tests/test_baseline_datetime.py
@@ -7,13 +7,14 @@ import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import baseline
+from baseline_utils import rate_histogram
 
 
 def test_rate_histogram_datetime_column():
     ts = pd.date_range("1970-01-01", periods=5, freq="s", tz="UTC")
     df = pd.DataFrame({"timestamp": ts, "adc": np.arange(5)})
     bins = np.arange(0, 7)
-    rate, live = baseline.rate_histogram(df, bins)
+    rate, live = rate_histogram(df, bins)
     assert live == pytest.approx(4.0)
     assert np.allclose(rate, np.histogram(df["adc"], bins=bins)[0] / live)
     assert str(df["timestamp"].dtype) == "datetime64[ns, UTC]"

--- a/tests/test_baseline_subtract.py
+++ b/tests/test_baseline_subtract.py
@@ -7,8 +7,8 @@ from datetime import datetime, timezone
 import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-import baseline
 import baseline_utils
+from baseline_utils import rate_histogram
 
 
 def test_baseline_none():
@@ -25,8 +25,8 @@ def test_baseline_none():
         t_base1=pd.Timestamp(5, unit="s", tz="UTC"),
         mode="none",
     )
-    hist_before, _ = baseline.rate_histogram(df, bins)
-    hist_after, _ = baseline.rate_histogram(out, bins)
+    hist_before, _ = rate_histogram(df, bins)
+    hist_after, _ = rate_histogram(out, bins)
     assert np.allclose(hist_before, hist_after)
 
 
@@ -67,8 +67,8 @@ def test_baseline_none_datetime():
         t_base1=datetime.fromtimestamp(5, tz=timezone.utc),
         mode="none",
     )
-    hist_before, _ = baseline.rate_histogram(df, bins)
-    hist_after, _ = baseline.rate_histogram(out, bins)
+    hist_before, _ = rate_histogram(df, bins)
+    hist_after, _ = rate_histogram(out, bins)
     assert np.allclose(hist_before, hist_after)
 
 


### PR DESCRIPTION
## Summary
- move `rate_histogram` into `baseline_utils`
- re-export the function from `baseline`
- update tests to import from the new location

## Testing
- `pytest tests/test_baseline_subtract.py::test_baseline_none -q`
- `pytest -q` *(fails: AttributeError: property 'cov_df' of 'FitResult' object has no setter)*

------
https://chatgpt.com/codex/tasks/task_e_685b5d662db4832b8119eb573aa27c55