### PR TITLE
Remove _cov_entry helper and access covariance directly

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -124,27 +124,6 @@ def _fit_params(obj: FitResult | Mapping[str, float] | None) -> FitParams:
     return {}
 
 
-def _cov_entry(fit: FitResult | dict, p1: str, p2: str) -> float:
-    """Return covariance between two parameters from a ``FitResult``.
-
-    Raises
-    ------
-    KeyError
-        If either ``p1`` or ``p2`` is not present in the covariance matrix.
-    """
-
-    if not isinstance(fit, FitResult):
-        key = f"cov_{p1}_{p2}"
-        return float(fit.get(key, 0.0)) if isinstance(fit, Mapping) else 0.0
-    try:
-        return float(fit.cov_df.loc[p1, p2])
-    except Exception:
-        try:
-            return fit.get_cov(p1, p2)
-        except Exception:
-            return 0.0
-
-
 def _ensure_events(events: pd.DataFrame, stage: str) -> None:
     """Exit if ``events`` is empty, printing a helpful message."""
     if len(events) == 0:
@@ -350,10 +329,18 @@ def _model_uncertainty(centers, widths, fit_obj, iso, cfg, normalise):
     dE = params.get("dE_corrected", params.get(f"dE_{iso}", 0.0))
     dN0 = params.get(f"dN0_{iso}", 0.0)
     dB = params.get(f"dB_{iso}", params.get("dB", 0.0))
-    try:
-        cov = _cov_entry(fit_obj, f"E_{iso}", f"N0_{iso}")
-    except Exception:
-        cov = 0.0
+    cov = 0.0
+    if isinstance(fit_obj, FitResult):
+        try:
+            cov = float(fit_obj.cov_df.loc[f"E_{iso}", f"N0_{iso}"])
+        except KeyError:
+            try:
+                cov = fit_obj.get_cov(f"E_{iso}", f"N0_{iso}")
+            except KeyError:
+                cov = 0.0
+    elif isinstance(fit_obj, Mapping):
+        key = f"cov_E_{iso}_N0_{iso}"
+        cov = float(fit_obj.get(key, 0.0))
     t = np.asarray(centers, dtype=float)
     exp_term = np.exp(-lam * t)
     dR_dE = eff * (1.0 - exp_term)
@@ -1959,7 +1946,13 @@ def main(argv=None):
             default_const = cfg.get("nuclide_constants", {})
             default_hl = default_const.get("Po214", PO214).half_life_s
             hl = cfg.get("time_fit", {}).get("hl_po214", [default_hl])[0]
-            cov = _cov_entry(fit_result, "E_Po214", "N0_Po214")
+            try:
+                cov = float(fit_result.cov_df.loc["E_Po214", "N0_Po214"])
+            except KeyError:
+                try:
+                    cov = fit_result.get_cov("E_Po214", "N0_Po214")
+                except KeyError:
+                    cov = 0.0
             delta214, err_delta214 = radon_delta(
                 t_start_rel,
                 t_end_rel,
@@ -1982,7 +1975,13 @@ def main(argv=None):
             default_const = cfg.get("nuclide_constants", {})
             default_hl = default_const.get("Po218", PO218).half_life_s
             hl = cfg.get("time_fit", {}).get("hl_po218", [default_hl])[0]
-            cov = _cov_entry(fit_result, "E_Po218", "N0_Po218")
+            try:
+                cov = float(fit_result.cov_df.loc["E_Po218", "N0_Po218"])
+            except KeyError:
+                try:
+                    cov = fit_result.get_cov("E_Po218", "N0_Po218")
+                except KeyError:
+                    cov = 0.0
             delta218, err_delta218 = radon_delta(
                 t_start_rel,
                 t_end_rel,
@@ -2196,7 +2195,13 @@ def main(argv=None):
             default_const = cfg.get("nuclide_constants", {})
             default_hl = default_const.get("Po214", PO214).half_life_s
             hl = cfg.get("time_fit", {}).get("hl_po214", [default_hl])[0]
-            cov = _cov_entry(fit_result, "E_Po214", "N0_Po214")
+            try:
+                cov = float(fit_result.cov_df.loc["E_Po214", "N0_Po214"])
+            except KeyError:
+                try:
+                    cov = fit_result.get_cov("E_Po214", "N0_Po214")
+                except KeyError:
+                    cov = 0.0
             A214, dA214 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl, cov)
             plot_radon_activity(
                 times,
@@ -2217,7 +2222,13 @@ def main(argv=None):
             default_const = cfg.get("nuclide_constants", {})
             default_hl = default_const.get("Po218", PO218).half_life_s
             hl = cfg.get("time_fit", {}).get("hl_po218", [default_hl])[0]
-            cov = _cov_entry(fit_result, "E_Po218", "N0_Po218")
+            try:
+                cov = float(fit_result.cov_df.loc["E_Po218", "N0_Po218"])
+            except KeyError:
+                try:
+                    cov = fit_result.get_cov("E_Po218", "N0_Po218")
+                except KeyError:
+                    cov = 0.0
             A218, dA218 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl, cov)
 
         activity_arr = np.zeros_like(times, dtype=float)
@@ -2273,7 +2284,13 @@ def main(argv=None):
                 default_const = cfg.get("nuclide_constants", {})
                 default_hl = default_const.get("Po214", PO214).half_life_s
                 hl214 = cfg.get("time_fit", {}).get("hl_po214", [default_hl])[0]
-                cov214 = _cov_entry(fit_result, "E_Po214", "N0_Po214")
+                try:
+                    cov214 = float(fit_result.cov_df.loc["E_Po214", "N0_Po214"])
+                except KeyError:
+                    try:
+                        cov214 = fit_result.get_cov("E_Po214", "N0_Po214")
+                    except KeyError:
+                        cov214 = 0.0
                 A214_tr, _ = radon_activity_curve(
                     rel_trend, E214, dE214, N0214, dN0214, hl214, cov214
                 )
@@ -2288,7 +2305,13 @@ def main(argv=None):
                 default_const = cfg.get("nuclide_constants", {})
                 default_hl = default_const.get("Po218", PO218).half_life_s
                 hl218 = cfg.get("time_fit", {}).get("hl_po218", [default_hl])[0]
-                cov218 = _cov_entry(fit_result, "E_Po218", "N0_Po218")
+                try:
+                    cov218 = float(fit_result.cov_df.loc["E_Po218", "N0_Po218"])
+                except KeyError:
+                    try:
+                        cov218 = fit_result.get_cov("E_Po218", "N0_Po218")
+                    except KeyError:
+                        cov218 = 0.0
                 A218_tr, _ = radon_activity_curve(
                     rel_trend, E218, dE218, N0218, dN0218, hl218, cov218
                 )


### PR DESCRIPTION
## Summary
- remove `_cov_entry` helper from `analyze.py`
- look up covariance directly using `fit_obj.cov_df` or `fit_obj.get_cov`
- store covariance matrix internally in `FitResult` via `_cov_df` attribute
- update `FitResult` accessors
- adjust tests accordingly (all still pass)

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b5d5cd7c4832ba9344a98e280ad39