### PR TITLE
Refactor baseline utils API

### DIFF
--- a/baseline.py
+++ b/baseline.py
@@ -1,32 +1,5 @@
-import logging
-import numpy as np
-import pandas as pd
+from baseline_utils import rate_histogram, subtract_baseline_dataframe
 
-import baseline_utils
-from baseline_utils import subtract_baseline_dataframe
+subtract_baseline = subtract_baseline_dataframe
 
 __all__ = ["rate_histogram", "subtract_baseline", "subtract_baseline_dataframe"]
-
-
-def rate_histogram(df, bins):
-    """Return ``(histogram, live_time_s)`` for a timestamped ``DataFrame``.
-
-    The timestamp column may be timezone-aware.  Internally timestamps are
-    converted to UTC and differences are computed using the underlying
-    integer nanoseconds to avoid dtype mismatches.
-    """
-    if df.empty:
-        return np.zeros(len(bins) - 1, dtype=float), 0.0
-    ts = baseline_utils._to_datetime64(df)
-    ts_int = ts.view("int64")
-    live = float((ts_int[-1] - ts_int[0]) / 1e9)
-    hist_src = df.get("subtracted_adc_hist", df["adc"]).to_numpy()
-    hist, _ = np.histogram(hist_src, bins=bins)
-    if live <= 0:
-        return np.zeros_like(hist, dtype=float), live
-    return hist / live, live
-
-
-
-# Thin wrapper for backward compatibility
-subtract_baseline = baseline_utils.subtract_baseline_dataframe

--- a/baseline_utils.py
+++ b/baseline_utils.py
@@ -8,7 +8,6 @@ from utils import parse_datetime
 from radon.baseline import (
     subtract_baseline_counts,
     subtract_baseline_rate,
-    _scaling_factor,
 )
 
 __all__ = [
@@ -16,7 +15,7 @@ __all__ = [
     "subtract_baseline_dataframe",
     "subtract_baseline_counts",
     "subtract_baseline_rate",
-    "_scaling_factor",
+    "rate_histogram",
 ]
 
 
@@ -67,7 +66,7 @@ def _to_datetime64(events: pd.DataFrame | pd.Series) -> np.ndarray:
     return ser.to_numpy(dtype="datetime64[ns]")
 
 
-def _rate_histogram(df: pd.DataFrame, bins) -> tuple[np.ndarray, float]:
+def rate_histogram(df: pd.DataFrame, bins) -> tuple[np.ndarray, float]:
     """Return histogram in counts/s and the live time in seconds.
 
     Timestamp columns may be timezone-aware.  Differences are computed
@@ -109,7 +108,7 @@ def apply_baseline_subtraction(
     if mode == "none":
         return df_analysis.copy()
 
-    rate_an, live_an = _rate_histogram(df_analysis, bins)
+    rate_an, live_an = rate_histogram(df_analysis, bins)
     if live_time_analysis is None:
         live_time_analysis = live_an
 
@@ -124,7 +123,7 @@ def apply_baseline_subtraction(
         logging.warning("baseline_range matched no events – skipping subtraction")
         return df_analysis.copy()
 
-    rate_bl, live_bl = _rate_histogram(df_full.loc[mask], bins)
+    rate_bl, live_bl = rate_histogram(df_full.loc[mask], bins)
 
     if mode in ("electronics", "radon", "all"):
         net_counts = (rate_an - rate_bl) * live_time_analysis

--- a/tests/test_scaling_factor.py
+++ b/tests/test_scaling_factor.py
@@ -3,17 +3,18 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-import baseline_utils as baseline
+import baseline_utils
+from radon.baseline import _scaling_factor
 
 
 def test_scaling_factor_basic():
-    s, ds = baseline._scaling_factor(10.0, 5.0)
+    s, ds = _scaling_factor(10.0, 5.0)
     assert s == pytest.approx(2.0)
     assert ds == pytest.approx(0.0)
 
 
 def test_scaling_factor_uncertainty():
-    s, ds = baseline._scaling_factor(10.0, 5.0, 0.1, 0.2)
+    s, ds = _scaling_factor(10.0, 5.0, 0.1, 0.2)
     assert s == pytest.approx(2.0)
     expected_var = (0.1/5.0)**2 + ((10.0*0.2)/5.0**2)**2
     assert ds == pytest.approx((expected_var)**0.5)
@@ -21,11 +22,11 @@ def test_scaling_factor_uncertainty():
 
 def test_scaling_factor_zero_baseline():
     with pytest.raises(ValueError):
-        baseline._scaling_factor(1.0, 0.0)
+        _scaling_factor(1.0, 0.0)
 
 
 def test_compute_dilution_factor():
-    d = baseline.compute_dilution_factor(10.0, 5.0)
+    d = baseline_utils.compute_dilution_factor(10.0, 5.0)
     assert d == pytest.approx(10.0 / 15.0)
-    d_zero = baseline.compute_dilution_factor(0.0, 0.0)
+    d_zero = baseline_utils.compute_dilution_factor(0.0, 0.0)
     assert d_zero == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- simplify `baseline.py` and re-export helpers
- drop `_scaling_factor` from `baseline_utils.__all__`
- move `rate_histogram` implementation into `baseline_utils`
- adjust scaling-factor tests to import from `radon.baseline`

## Testing
- `pytest -q tests/test_scaling_factor.py tests/test_baseline_datetime.py tests/test_baseline_subtract.py tests/test_baseline.py::test_rate_histogram_single_event`

------
https://chatgpt.com/codex/tasks/task_e_685b61f79a8c832bb268efdbfc5008bf