### PR TITLE
Add timestamp utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ This repository provides a complete pipeline to analyze electrostatic radon moni
 - `efficiency.py`: Efficiency calculations and BLUE combination helpers.
 - `systematics.py`: Scan for systematic uncertainties (optional).
 - `plot_utils.py`: Plotting routines for spectrum and time-series.
-- `utils.py`: Miscellaneous utilities providing `parse_datetime` for
-  time conversion, JSON validation, and count-rate conversions.
+- `utils.py`: Miscellaneous utilities providing `parse_datetime` and
+  `parse_timestamp` for time conversion, `to_epoch_seconds`, JSON validation,
+  and count-rate conversions.
 - `tests/`: `pytest` unit tests for calibration, fitting, and I/O.
 
 ## Installation
@@ -563,6 +564,8 @@ search for peak centroids:
   Bq/m^3 when a detector volume is supplied.
 - `parse_datetime(value)` converts ISO‑8601 strings, numeric seconds or
   `datetime` objects to a timezone-aware `pandas.Timestamp` in UTC.
+- `parse_timestamp(value)` parses a value to a UTC `pandas.Timestamp`.
+- `to_epoch_seconds(ts_or_str)` converts timestamps to Unix seconds.
 - `find_adc_bin_peaks(adc_values, expected, window=50, prominence=0.0, width=None)`
   histogramises the raw ADC spectrum, searches for maxima near each expected
   centroid and returns a `{peak: adc_centroid}` mapping in ADC units.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ from utils import (
     cps_to_bq,
     find_adc_bin_peaks,
     parse_timestamp,
+    to_epoch_seconds,
     parse_time,
     parse_time_arg,
     to_seconds,
@@ -80,15 +81,21 @@ def test_parse_time_naive_timezone():
 
 
 def test_parse_timestamp_numeric():
-    assert parse_timestamp(42) == pytest.approx(42.0)
+    ts = parse_timestamp(42)
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp(42, unit="s", tz="UTC")
 
 
 def test_parse_timestamp_iso():
-    assert parse_timestamp("1970-01-01T00:00:00Z") == pytest.approx(0.0)
+    ts = parse_timestamp("1970-01-01T00:00:00Z")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_timestamp_datetime_naive():
-    assert parse_timestamp(datetime(1970, 1, 1)) == pytest.approx(0.0)
+    ts = parse_timestamp(datetime(1970, 1, 1))
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_to_seconds_datetime_series():
@@ -101,3 +108,11 @@ def test_to_seconds_numeric_series():
     ser = pd.Series([0.0, 1.5, 2.2])
     out = to_seconds(ser)
     assert np.allclose(out, [0.0, 1.5, 2.2])
+
+def test_to_epoch_seconds_timestamp():
+    ts = pd.Timestamp("1970-01-01T00:00:01Z")
+    assert to_epoch_seconds(ts) == pytest.approx(1.0)
+
+
+def test_to_epoch_seconds_string():
+    assert to_epoch_seconds("1970-01-01T00:00:02Z") == pytest.approx(2.0)

--- a/utils/time_utils.py
+++ b/utils/time_utils.py
@@ -1,0 +1,46 @@
+"""Time conversion utilities."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Union
+
+import pandas as pd
+from dateutil import parser as date_parser
+
+__all__ = ["parse_timestamp", "to_epoch_seconds"]
+
+
+TimestampLike = Union[str, int, float, datetime, pd.Timestamp]
+
+
+def parse_timestamp(value: TimestampLike) -> pd.Timestamp:
+    """Return ``value`` parsed as a timezone-aware ``pandas.Timestamp`` in UTC."""
+    if isinstance(value, pd.Timestamp):
+        ts = value
+    elif isinstance(value, datetime):
+        ts = pd.Timestamp(value)
+    elif isinstance(value, (int, float)):
+        ts = pd.Timestamp(float(value), unit="s", tz="UTC")
+    elif isinstance(value, str):
+        try:
+            num = float(value)
+            ts = pd.Timestamp(num, unit="s", tz="UTC")
+        except ValueError:
+            try:
+                ts = pd.Timestamp(date_parser.isoparse(value))
+            except Exception as e:
+                raise ValueError(f"invalid timestamp: {value!r}") from e
+    else:
+        raise ValueError(f"invalid timestamp: {value!r}")
+    if ts.tzinfo is None:
+        ts = ts.tz_localize("UTC")
+    else:
+        ts = ts.tz_convert("UTC")
+    return ts
+
+
+def to_epoch_seconds(ts_or_str: TimestampLike) -> float:
+    """Convert ``ts_or_str`` to Unix epoch seconds."""
+    ts = parse_timestamp(ts_or_str)
+    return ts.timestamp()


### PR DESCRIPTION
## Summary
- add `utils` package with new `time_utils` module
- provide `parse_timestamp` and `to_epoch_seconds`
- re-export new helpers from `utils` and adjust parsing
- document new utilities in README
- update tests for new behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b6e581990832ba940f19f442fbbcb