### PR TITLE
Deprecate parse_time

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,12 +11,11 @@ from utils import (
     cps_to_cpd,
     cps_to_bq,
     find_adc_bin_peaks,
-    parse_timestamp,
-    parse_time,
     parse_time_arg,
     to_seconds,
     LITERS_PER_M3,
 )
+from time_utils import parse_timestamp, to_epoch_seconds
 
 
 def test_cps_to_cpd():
@@ -51,28 +50,28 @@ def test_find_adc_bin_peaks_basic():
     assert result["p2"] == pytest.approx(20.5)
 
 
-def test_parse_time_int():
-    assert parse_time(42) == pytest.approx(42.0)
+def test_parse_timestamp_int():
+    assert parse_timestamp(42) == pytest.approx(42.0)
 
 
-def test_parse_time_float():
-    assert parse_time(42.5) == pytest.approx(42.5)
+def test_parse_timestamp_float():
+    assert parse_timestamp(42.5) == pytest.approx(42.5)
 
 
-def test_parse_time_numeric_str():
-    assert parse_time("42") == pytest.approx(42.0)
+def test_parse_timestamp_numeric_str():
+    assert parse_timestamp("42") == pytest.approx(42.0)
 
 
-def test_parse_time_numeric_str_float():
-    assert parse_time("42.5") == pytest.approx(42.5)
+def test_parse_timestamp_numeric_str_float():
+    assert parse_timestamp("42.5") == pytest.approx(42.5)
 
 
-def test_parse_time_iso_no_fraction():
-    assert parse_time("1970-01-01T00:00:00Z") == pytest.approx(0.0)
+def test_parse_timestamp_iso_no_fraction():
+    assert parse_timestamp("1970-01-01T00:00:00Z") == pytest.approx(0.0)
 
 
-def test_parse_time_iso_fraction():
-    assert parse_time("1970-01-01T00:00:00.5Z") == pytest.approx(0.5)
+def test_parse_timestamp_iso_fraction():
+    assert parse_timestamp("1970-01-01T00:00:00.5Z") == pytest.approx(0.5)
 
 
 def test_parse_time_naive_timezone():
@@ -101,3 +100,8 @@ def test_to_seconds_numeric_series():
     ser = pd.Series([0.0, 1.5, 2.2])
     out = to_seconds(ser)
     assert np.allclose(out, [0.0, 1.5, 2.2])
+
+
+def test_to_epoch_seconds_scalar():
+    out = to_epoch_seconds("1970-01-01T00:00:01Z")
+    assert np.allclose(out, [1.0])

--- a/time_utils.py
+++ b/time_utils.py
@@ -1,0 +1,72 @@
+"""Time parsing helpers."""
+
+import argparse
+from datetime import datetime, timezone
+from dateutil import parser as date_parser
+from typing import Any, Sequence
+
+import numpy as np
+
+try:
+    import pandas as pd
+except Exception:  # pragma: no cover - pandas is optional
+    pd = None
+
+from utils import parse_datetime
+
+__all__ = ["parse_timestamp", "to_epoch_seconds"]
+
+
+def parse_timestamp(value: Any) -> float:
+    """Return Unix epoch seconds from ``value``.
+
+    ``value`` may be a numeric value, ``datetime`` instance or an ISO-8601
+    string. Strings lacking timezone information are interpreted as UTC.
+    The result is always seconds since the Unix epoch in UTC.
+    """
+
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    if isinstance(value, datetime):
+        dt = value
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        else:
+            dt = dt.astimezone(timezone.utc)
+        return float(dt.timestamp())
+
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            pass
+        try:
+            dt = date_parser.isoparse(value)
+        except (ValueError, OverflowError) as e:
+            raise argparse.ArgumentTypeError(f"could not parse time: {value!r}") from e
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        else:
+            dt = dt.astimezone(timezone.utc)
+        return float(dt.timestamp())
+
+    raise argparse.ArgumentTypeError(f"could not parse time: {value!r}")
+
+
+def to_epoch_seconds(value: Any) -> np.ndarray:
+    """Convert timestamps to float seconds."""
+
+    if pd is not None and isinstance(value, pd.Series):
+        if not pd.api.types.is_datetime64_any_dtype(value):
+            return value.astype(float).to_numpy()
+        if getattr(value.dtype, "tz", None) is None:
+            value = value.map(parse_datetime)
+        else:
+            value = value.dt.tz_convert("UTC")
+        return value.astype("int64").to_numpy() / 1e9
+
+    if isinstance(value, (list, tuple, np.ndarray)):
+        return np.asarray([parse_timestamp(v) for v in value], dtype=float)
+
+    return np.asarray([parse_timestamp(value)], dtype=float)

--- a/utils.py
+++ b/utils.py
@@ -5,6 +5,7 @@ from scipy.signal import find_peaks
 import math
 from dataclasses import is_dataclass, asdict
 import argparse
+import warnings
 from datetime import datetime, timezone, tzinfo, timedelta
 from dateutil import parser as date_parser
 from dateutil.tz import gettz
@@ -17,10 +18,8 @@ __all__ = [
     "cps_to_bq",
     "to_utc_datetime",
     "parse_time_arg",
-    "parse_timestamp",
     "parse_datetime",
     "to_seconds",
-    "parse_time",
     "LITERS_PER_M3",
 ]
 
@@ -184,42 +183,16 @@ def cps_to_bq(rate_cps, volume_liters=None):
 
 
 def parse_timestamp(s) -> float:
-    """Parse an ISO-8601 string, numeric seconds, or ``datetime``.
+    """Deprecated wrapper for :func:`time_utils.parse_timestamp`."""
 
-    Any string without timezone information is interpreted as UTC.
-    The return value is the Unix epoch time in seconds (UTC).
-    """
+    warnings.warn(
+        "utils.parse_timestamp is deprecated; use time_utils.parse_timestamp instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    from time_utils import parse_timestamp as _parse_timestamp
 
-    if isinstance(s, (int, float)):
-        return float(s)
-
-    if isinstance(s, datetime):
-        dt = s
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        else:
-            dt = dt.astimezone(timezone.utc)
-        return float(dt.timestamp())
-
-    if isinstance(s, str):
-        try:
-            return float(s)
-        except ValueError:
-            pass
-
-        try:
-            dt = date_parser.isoparse(s)
-        except (ValueError, OverflowError) as e:
-            raise argparse.ArgumentTypeError(f"could not parse time: {s!r}") from e
-
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        else:
-            dt = dt.astimezone(timezone.utc)
-
-        return float(dt.timestamp())
-
-    raise argparse.ArgumentTypeError(f"could not parse time: {s!r}")
+    return _parse_timestamp(s)
 
 
 def to_utc_datetime(value, tz="UTC") -> datetime:
@@ -286,9 +259,16 @@ def to_seconds(series: pd.Series) -> np.ndarray:
 
 
 def parse_time(s, tz="UTC") -> float:
-    """Parse a timestamp string, number or ``datetime`` into Unix seconds."""
+    """Deprecated wrapper for :func:`time_utils.parse_timestamp`."""
 
-    return parse_timestamp(s)
+    warnings.warn(
+        "utils.parse_time is deprecated; use time_utils.parse_timestamp instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    from time_utils import parse_timestamp as _parse_timestamp
+
+    return _parse_timestamp(s)
 
 
 def parse_time_arg(val, tz="UTC") -> datetime:


### PR DESCRIPTION
## Summary
- move timestamp helpers to `time_utils.py`
- keep `parse_time` and `parse_timestamp` in `utils.py` only as wrappers
- update tests to use the new module

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7010e8cc832b94f470c64a66e36d