### PR TITLE
Introduce time utilities and refactor timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository provides a complete pipeline to analyze electrostatic radon moni
 - `efficiency.py`: Efficiency calculations and BLUE combination helpers.
 - `systematics.py`: Scan for systematic uncertainties (optional).
 - `plot_utils.py`: Plotting routines for spectrum and time-series.
-- `utils.py`: Miscellaneous utilities providing `parse_datetime` for
+- `utils.py`: Miscellaneous utilities providing `time_utils.parse_timestamp` for
   time conversion, JSON validation, and count-rate conversions.
 - `tests/`: `pytest` unit tests for calibration, fitting, and I/O.
 
@@ -72,7 +72,7 @@ The input file must be a comma-separated table with these columns:
 - `fBits` – status bits or flags
 - `timestamp` – event timestamp in seconds
   (either numeric Unix seconds or an ISO‑8601 string; parsed directly to
-  timezone-aware ``pandas.Timestamp`` values via `parse_datetime`)
+  timezone-aware ``pandas.Timestamp`` values via `time_utils.parse_timestamp`)
 - `adc` – raw ADC value
 - `fchannel` – acquisition channel
 
@@ -126,8 +126,8 @@ For example:
 ```python
 from utils import cps_to_bq
 activity_bq_m3 = cps_to_bq(fit_result["E_Po214"], volume_liters=10.0)
-from utils import parse_datetime
-t0 = parse_datetime("2023-07-31T00:00:00Z")
+from utils.time_utils import parse_timestamp
+t0 = parse_timestamp("2023-07-31T00:00:00Z")
 ```
 
 When using ``compute_radon_activity`` you should pass the fitted rates
@@ -195,7 +195,7 @@ All other time-related fields (`analysis_end_time`, `spike_end_time`,
 `spike_periods`, `run_periods`, `radon_interval` and
 `baseline.range`) likewise accept absolute timestamps in ISO 8601
 format or numeric seconds.  All of these values are parsed with
-`parse_datetime` so the same formats apply everywhere.
+`time_utils.parse_timestamp` so the same formats apply everywhere.
 
 `analysis_end_time` may be specified to stop processing after the given
 timestamp while `spike_end_time` discards all events before its value.
@@ -555,14 +555,16 @@ Example configuration to tighten the cut (set it to `null` to disable):
 
 ## Utility Conversions
 
-`utils.py` provides simple helpers to convert count rates, parse times and
+`utils.py` provides simple helpers to convert count rates, while
+`utils/time_utils.py` offers time conversion utilities. Together they
 search for peak centroids:
 
 - `cps_to_cpd(rate_cps)` converts counts/s to counts/day.
 - `cps_to_bq(rate_cps, volume_liters=None)` returns the activity in Bq, or
   Bq/m^3 when a detector volume is supplied.
-- `parse_datetime(value)` converts ISO‑8601 strings, numeric seconds or
+- `parse_timestamp(value)` converts ISO‑8601 strings, numeric seconds or
   `datetime` objects to a timezone-aware `pandas.Timestamp` in UTC.
+- `to_epoch_seconds(ts)` converts timestamps or strings to Unix seconds.
 - `find_adc_bin_peaks(adc_values, expected, window=50, prominence=0.0, width=None)`
   histogramises the raw ADC spectrum, searches for maxima near each expected
   centroid and returns a `{peak: adc_centroid}` mapping in ADC units.

--- a/analyze.py
+++ b/analyze.py
@@ -106,7 +106,8 @@ from utils import (
     parse_time_arg,
     to_utc_datetime,
 )
-from utils import parse_datetime, to_seconds
+from utils import to_seconds
+from utils.time_utils import parse_timestamp, to_epoch_seconds
 from baseline_utils import (
     subtract_baseline_dataframe,
     subtract_baseline_counts,
@@ -224,10 +225,10 @@ def prepare_analysis_df(
     df_analysis = df.copy()
     ts = df_analysis["timestamp"]
     if not pd.api.types.is_datetime64_any_dtype(ts):
-        df_analysis["timestamp"] = ts.map(parse_datetime)
+        df_analysis["timestamp"] = ts.map(parse_timestamp)
     else:
         if ts.dt.tz is None:
-            df_analysis["timestamp"] = ts.map(parse_datetime)
+            df_analysis["timestamp"] = ts.map(parse_timestamp)
         else:
             df_analysis["timestamp"] = ts.dt.tz_convert(timezone.utc)
 
@@ -813,8 +814,8 @@ def main(argv=None):
     try:
         events_all = load_events(args.input, column_map=cfg.get("columns"))
 
-        # Parse timestamps to UTC ``Timestamp`` objects
-        events_all["timestamp"] = events_all["timestamp"].map(parse_datetime)
+        # Ensure timestamps are UTC ``Timestamp`` objects
+        events_all["timestamp"] = events_all["timestamp"].map(parse_timestamp)
 
 
     except Exception as e:
@@ -1164,7 +1165,7 @@ def main(argv=None):
         t_end_base = baseline_range[1]
         if t_end_base <= t_start_base:
             raise ValueError("baseline_range end time must be greater than start time")
-        events_all_ts = pd.to_datetime(events_all["timestamp"], utc=True)
+        events_all_ts = events_all["timestamp"].map(parse_timestamp)
         mask_base_full = (events_all_ts >= t_start_base) & (events_all_ts < t_end_base)
         mask_base = (df_analysis["timestamp"] >= t_start_base) & (
             df_analysis["timestamp"] < t_end_base
@@ -1448,7 +1449,7 @@ def main(argv=None):
                 print(f"WARNING: No events found for {iso} in [{lo}, {hi}] MeV.")
                 continue
 
-            first_ts = pd.to_datetime(iso_events["timestamp"].iloc[0], utc=True)
+            first_ts = parse_timestamp(iso_events["timestamp"].iloc[0])
             t0_dt = to_utc_datetime(t0_global)
             settle = timedelta(seconds=float(args.settle_s or 0))
             t_start_fit_dt = max(first_ts, t0_dt + settle)
@@ -1641,7 +1642,7 @@ def main(argv=None):
         mask210 = (
             (df_analysis["energy_MeV"] >= lo)
             & (df_analysis["energy_MeV"] <= hi)
-            & (df_analysis["timestamp"] >= pd.to_datetime(t0_global, utc=True))
+            & (df_analysis["timestamp"] >= parse_timestamp(t0_global))
             & (df_analysis["timestamp"] <= t_end_global)
         )
         events_p210 = df_analysis[mask210]
@@ -2173,8 +2174,7 @@ def main(argv=None):
         from radon_activity import radon_activity_curve
 
         times = np.linspace(t0_global.timestamp(), t_end_global_ts, 100)
-        times_dt = pd.to_datetime(times, unit="s", utc=True)
-        t_rel = (times_dt - analysis_start).total_seconds()
+        t_rel = times - to_epoch_seconds(analysis_start)
 
         A214 = dA214 = None
         if "Po214" in time_fit_results:
@@ -2251,8 +2251,7 @@ def main(argv=None):
                 radon_interval[1].timestamp(),
                 50,
             )
-            times_trend_dt = pd.to_datetime(times_trend, unit="s", utc=True)
-            rel_trend = (times_trend_dt - analysis_start).total_seconds()
+            rel_trend = times_trend - to_epoch_seconds(analysis_start)
             A214_tr = None
             if "Po214" in time_fit_results:
                 fit_result = time_fit_results["Po214"]

--- a/baseline_utils.py
+++ b/baseline_utils.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import numpy as np
 import pandas as pd
 
-from utils import parse_datetime
+from utils.time_utils import parse_timestamp
 from radon.baseline import (
     subtract_baseline_counts,
     subtract_baseline_rate,
@@ -60,7 +60,7 @@ def _to_datetime64(events: pd.DataFrame | pd.Series) -> np.ndarray:
         if getattr(ser.dtype, "tz", None) is None:
             ser = ser.dt.tz_localize("UTC")
     else:
-        ser = col.map(parse_datetime)
+        ser = col.map(parse_timestamp)
 
     ser = ser.dt.tz_convert("UTC")
     return ser.to_numpy(dtype="datetime64[ns]")
@@ -112,8 +112,8 @@ def apply_baseline_subtraction(
     if live_time_analysis is None:
         live_time_analysis = live_an
 
-    t0 = parse_datetime(t_base0)
-    t1 = parse_datetime(t_base1)
+    t0 = parse_timestamp(t_base0)
+    t1 = parse_timestamp(t_base1)
     ts_full = _to_datetime64(df_full)
     ts_int = ts_full.view("int64")
     t0_ns = t0.value

--- a/io_utils.py
+++ b/io_utils.py
@@ -14,7 +14,8 @@ from typing import Any, Iterator
 from constants import load_nuclide_overrides
 
 import numpy as np
-from utils import to_native, parse_datetime, to_seconds
+from utils import to_native, to_seconds
+from utils.time_utils import parse_timestamp
 import jsonschema
 
 
@@ -245,8 +246,7 @@ def ensure_dir(path):
         p.mkdir(parents=True, exist_ok=True)
 
 
-# parse_datetime is re-exported from utils for backward compatibility
-# The implementation now lives in utils.parse_datetime
+# parse_timestamp is re-exported from utils.time_utils
 
 
 def _merge_dicts(base: dict, override: dict) -> dict:
@@ -342,7 +342,7 @@ def load_events(csv_path, *, column_map=None):
     if "timestamp" in df.columns:
         def _safe_parse(val):
             try:
-                return parse_datetime(val)
+                return parse_timestamp(val)
             except Exception:
                 return pd.NaT
 
@@ -396,7 +396,7 @@ def apply_burst_filter(df, cfg=None, mode="rate"):
     df : pandas.DataFrame
         Event data containing a ``timestamp`` column. Values may be numeric
         epoch seconds or ``datetime64`` objects. All timestamps are first
-        converted to ``datetime64`` using :func:`parse_datetime` and the
+        converted to ``datetime64`` using :func:`parse_timestamp` and the
         DataFrame is updated accordingly. Seconds are only used internally for
         histogram calculations.
     cfg : dict, optional
@@ -428,10 +428,10 @@ def apply_burst_filter(df, cfg=None, mode="rate"):
 
     ts = out_df["timestamp"]
     if not pd.api.types.is_datetime64_any_dtype(ts):
-        ts = ts.map(parse_datetime)
+        ts = ts.map(parse_timestamp)
     else:
         if ts.dt.tz is None:
-            ts = ts.map(parse_datetime)
+            ts = ts.map(parse_timestamp)
         else:
             ts = ts.dt.tz_convert("UTC")
     out_df["timestamp"] = ts
@@ -473,10 +473,10 @@ def apply_burst_filter(df, cfg=None, mode="rate"):
             # Recalculate times after removing events
             ts = out_df["timestamp"]
             if not pd.api.types.is_datetime64_any_dtype(ts):
-                ts = ts.map(parse_datetime)
+                ts = ts.map(parse_timestamp)
             else:
                 if ts.dt.tz is None:
-                    ts = ts.map(parse_datetime)
+                    ts = ts.map(parse_timestamp)
                 else:
                     ts = ts.dt.tz_convert("UTC")
             out_df["timestamp"] = ts

--- a/tests/test_interval_parsing.py
+++ b/tests/test_interval_parsing.py
@@ -5,7 +5,8 @@ from datetime import datetime, timezone, timedelta
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import analyze
-from utils import parse_time_arg, parse_datetime
+from utils import parse_time_arg
+from utils.time_utils import parse_timestamp
 from dateutil.tz import gettz
 import pandas as pd
 
@@ -31,10 +32,10 @@ def test_config_interval_parsing_to_datetime():
         "baseline": {"range": ["1970-01-01T00:00:01Z", "1970-01-01T00:00:02Z"]},
         "analysis": {"radon_interval": ["1970-01-01T00:00:03Z", "1970-01-01T00:00:04Z"]},
     }
-    b_start = parse_datetime(cfg["baseline"]["range"][0])
-    b_end = parse_datetime(cfg["baseline"]["range"][1])
-    r_start = parse_datetime(cfg["analysis"]["radon_interval"][0])
-    r_end = parse_datetime(cfg["analysis"]["radon_interval"][1])
+    b_start = parse_timestamp(cfg["baseline"]["range"][0])
+    b_end = parse_timestamp(cfg["baseline"]["range"][1])
+    r_start = parse_timestamp(cfg["analysis"]["radon_interval"][0])
+    r_end = parse_timestamp(cfg["analysis"]["radon_interval"][1])
     for dt in (b_start, b_end, r_start, r_end):
         assert dt.tzinfo is not None
         assert dt.tzinfo.utcoffset(dt) == timedelta(0)

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -17,7 +17,7 @@ from io_utils import (
     apply_burst_filter,
     Summary,
 )
-from utils import parse_datetime
+from utils.time_utils import parse_timestamp
 
 
 def test_load_config(tmp_path):
@@ -145,7 +145,7 @@ def test_load_events_column_aliases(tmp_path):
     df.to_csv(p, index=False)
     loaded = load_events(p)
     assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
-    assert list(loaded["timestamp"])[0] == parse_datetime(1000)
+    assert list(loaded["timestamp"])[0] == parse_timestamp(1000)
     assert list(loaded["adc"])[0] == 1250
     assert "time" not in loaded.columns
     assert "adc_ch" not in loaded.columns
@@ -172,7 +172,7 @@ def test_load_events_custom_columns(tmp_path):
     }
     loaded = load_events(p, column_map=column_map)
     assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
-    assert list(loaded["timestamp"])[0] == parse_datetime(1000)
+    assert list(loaded["timestamp"])[0] == parse_timestamp(1000)
     assert list(loaded["adc"])[0] == 1250
     assert "ftimestamps" not in loaded.columns
 
@@ -207,7 +207,7 @@ def test_load_events_string_nan(tmp_path):
     df.to_csv(p, index=False)
     loaded = load_events(p)
     assert len(loaded) == 1
-    assert loaded["timestamp"].iloc[0] == parse_datetime(1000)
+    assert loaded["timestamp"].iloc[0] == parse_timestamp(1000)
 
 
 def test_write_summary_and_copy_config(tmp_path):

--- a/tests/test_parse_datetime.py
+++ b/tests/test_parse_datetime.py
@@ -6,55 +6,55 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from utils import parse_datetime
+from utils.time_utils import parse_timestamp
 
 
 def test_parse_datetime_iso_string():
-    ts = parse_datetime("1970-01-01T00:00:00Z")
+    ts = parse_timestamp("1970-01-01T00:00:00Z")
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_numeric():
-    ts = parse_datetime(42)
+    ts = parse_timestamp(42)
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp(42, unit="s", tz="UTC")
 
 
 def test_parse_datetime_numeric_str():
-    ts = parse_datetime("42")
+    ts = parse_timestamp("42")
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp(42, unit="s", tz="UTC")
 
 
 def test_parse_datetime_naive_datetime():
     dt = datetime(1970, 1, 1)
-    ts = parse_datetime(dt)
+    ts = parse_timestamp(dt)
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_float():
-    ts = parse_datetime(42.5)
+    ts = parse_timestamp(42.5)
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp(42.5, unit="s", tz="UTC")
 
 
 def test_parse_datetime_iso_without_tz():
-    ts = parse_datetime("1970-01-01T00:00:00")
+    ts = parse_timestamp("1970-01-01T00:00:00")
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_iso_with_offset():
-    ts = parse_datetime("1970-01-01T01:00:00+01:00")
+    ts = parse_timestamp("1970-01-01T01:00:00+01:00")
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
 def test_parse_datetime_datetime_with_tz():
     dt = datetime(1970, 1, 1, 1, tzinfo=timezone(timedelta(hours=1)))
-    ts = parse_datetime(dt)
+    ts = parse_timestamp(dt)
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,12 +11,12 @@ from utils import (
     cps_to_cpd,
     cps_to_bq,
     find_adc_bin_peaks,
-    parse_timestamp,
     parse_time,
     parse_time_arg,
     to_seconds,
     LITERS_PER_M3,
 )
+from utils.time_utils import parse_timestamp, to_epoch_seconds
 
 
 def test_cps_to_cpd():
@@ -80,15 +80,19 @@ def test_parse_time_naive_timezone():
 
 
 def test_parse_timestamp_numeric():
-    assert parse_timestamp(42) == pytest.approx(42.0)
+    assert parse_timestamp(42) == pd.Timestamp(42, unit="s", tz="UTC")
 
 
 def test_parse_timestamp_iso():
-    assert parse_timestamp("1970-01-01T00:00:00Z") == pytest.approx(0.0)
+    assert parse_timestamp("1970-01-01T00:00:00Z") == pd.Timestamp(
+        "1970-01-01T00:00:00Z"
+    )
 
 
 def test_parse_timestamp_datetime_naive():
-    assert parse_timestamp(datetime(1970, 1, 1)) == pytest.approx(0.0)
+    assert parse_timestamp(datetime(1970, 1, 1)) == pd.Timestamp(
+        "1970-01-01T00:00:00Z"
+    )
 
 
 def test_to_seconds_datetime_series():

--- a/utils/time_utils.py
+++ b/utils/time_utils.py
@@ -1,0 +1,47 @@
+import pandas as pd
+from datetime import datetime
+from dateutil import parser as date_parser
+
+__all__ = ["parse_timestamp", "to_epoch_seconds"]
+
+
+def _is_numeric_string(s: str) -> bool:
+    try:
+        float(s)
+        return True
+    except ValueError:
+        return False
+
+
+def parse_timestamp(value: str | int | float | datetime) -> pd.Timestamp:
+    """Return ``value`` converted to a UTC ``pandas.Timestamp``."""
+
+    if isinstance(value, pd.Timestamp):
+        ts = value
+    elif isinstance(value, datetime):
+        ts = pd.Timestamp(value)
+    elif isinstance(value, (int, float)) or (isinstance(value, str) and _is_numeric_string(value)):
+        ts = pd.to_datetime(float(value), unit="s", utc=True)
+    else:
+        try:
+            ts = pd.to_datetime(value, utc=True)
+        except Exception as e:
+            try:
+                ts = pd.Timestamp(date_parser.isoparse(str(value)))
+                ts = ts.tz_localize("UTC") if ts.tzinfo is None else ts.tz_convert("UTC")
+            except Exception:
+                raise ValueError(f"invalid timestamp: {value!r}") from e
+    if ts.tzinfo is None:
+        ts = ts.tz_localize("UTC")
+    else:
+        ts = ts.tz_convert("UTC")
+    return ts
+
+
+def to_epoch_seconds(ts: pd.Timestamp | str | int | float) -> float:
+    """Return Unix epoch seconds for ``ts``."""
+
+    if isinstance(ts, (int, float)):
+        return float(ts)
+    return float(parse_timestamp(ts).timestamp())
+


### PR DESCRIPTION
## Summary
- add `utils/time_utils.py` with helpers for timestamp parsing and epoch conversion
- rework `utils` into a package and delegate old helpers to the new module
- replace direct `pd.to_datetime` calls with `parse_timestamp`/`to_epoch_seconds`
- ensure loaders and baseline utilities keep UTC timestamp dtype
- update documentation and tests to use the new functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b6ee714d0832ba40251da227bb06d