### PR TITLE
Add timestamp utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ This repository provides a complete pipeline to analyze electrostatic radon moni
 - `efficiency.py`: Efficiency calculations and BLUE combination helpers.
 - `systematics.py`: Scan for systematic uncertainties (optional).
 - `plot_utils.py`: Plotting routines for spectrum and time-series.
-- `utils.py`: Miscellaneous utilities providing `parse_datetime` for
-  time conversion, JSON validation, and count-rate conversions.
+- `utils.py`: Miscellaneous utilities providing `parse_datetime`,
+  `parse_timestamp` and `to_epoch_seconds` for time conversion, JSON
+  validation, and count-rate conversions.
 - `tests/`: `pytest` unit tests for calibration, fitting, and I/O.
 
 ## Installation
@@ -563,6 +564,10 @@ search for peak centroids:
   Bq/m^3 when a detector volume is supplied.
 - `parse_datetime(value)` converts ISO‑8601 strings, numeric seconds or
   `datetime` objects to a timezone-aware `pandas.Timestamp` in UTC.
+- `parse_timestamp(value)` returns the same as `parse_datetime` but accepts
+  numbers, ISO‑8601 strings or `datetime` objects and always yields a UTC
+  `pandas.Timestamp`.
+- `to_epoch_seconds(ts_or_str)` converts these inputs to Unix seconds.
 - `find_adc_bin_peaks(adc_values, expected, window=50, prominence=0.0, width=None)`
   histogramises the raw ADC spectrum, searches for maxima near each expected
   centroid and returns a `{peak: adc_centroid}` mapping in ADC units.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ from utils import (
     cps_to_bq,
     find_adc_bin_peaks,
     parse_timestamp,
+    to_epoch_seconds,
     parse_time,
     parse_time_arg,
     to_seconds,
@@ -80,15 +81,31 @@ def test_parse_time_naive_timezone():
 
 
 def test_parse_timestamp_numeric():
-    assert parse_timestamp(42) == pytest.approx(42.0)
+    ts = parse_timestamp(42)
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp(42, unit="s", tz="UTC")
 
 
 def test_parse_timestamp_iso():
-    assert parse_timestamp("1970-01-01T00:00:00Z") == pytest.approx(0.0)
+    ts = parse_timestamp("1970-01-01T00:00:00Z")
+    assert ts == pd.Timestamp(0, unit="s", tz="UTC")
 
 
 def test_parse_timestamp_datetime_naive():
-    assert parse_timestamp(datetime(1970, 1, 1)) == pytest.approx(0.0)
+    ts = parse_timestamp(datetime(1970, 1, 1))
+    assert ts == pd.Timestamp(0, unit="s", tz="UTC")
+
+
+def test_to_epoch_seconds_numeric():
+    assert to_epoch_seconds(42) == pytest.approx(42.0)
+
+
+def test_to_epoch_seconds_iso():
+    assert to_epoch_seconds("1970-01-01T00:00:00Z") == pytest.approx(0.0)
+
+
+def test_to_epoch_seconds_datetime():
+    assert to_epoch_seconds(datetime(1970, 1, 1, tzinfo=timezone.utc)) == pytest.approx(0.0)
 
 
 def test_to_seconds_datetime_series():

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -8,6 +8,7 @@ import argparse
 from datetime import datetime, timezone, tzinfo, timedelta
 from dateutil import parser as date_parser
 from dateutil.tz import gettz
+from .time_utils import parse_timestamp, to_epoch_seconds
 
 __all__ = [
     "to_native",
@@ -18,6 +19,7 @@ __all__ = [
     "to_utc_datetime",
     "parse_time_arg",
     "parse_timestamp",
+    "to_epoch_seconds",
     "parse_datetime",
     "to_seconds",
     "parse_time",
@@ -183,43 +185,6 @@ def cps_to_bq(rate_cps, volume_liters=None):
     return float(rate_cps) / volume_m3
 
 
-def parse_timestamp(s) -> float:
-    """Parse an ISO-8601 string, numeric seconds, or ``datetime``.
-
-    Any string without timezone information is interpreted as UTC.
-    The return value is the Unix epoch time in seconds (UTC).
-    """
-
-    if isinstance(s, (int, float)):
-        return float(s)
-
-    if isinstance(s, datetime):
-        dt = s
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        else:
-            dt = dt.astimezone(timezone.utc)
-        return float(dt.timestamp())
-
-    if isinstance(s, str):
-        try:
-            return float(s)
-        except ValueError:
-            pass
-
-        try:
-            dt = date_parser.isoparse(s)
-        except (ValueError, OverflowError) as e:
-            raise argparse.ArgumentTypeError(f"could not parse time: {s!r}") from e
-
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        else:
-            dt = dt.astimezone(timezone.utc)
-
-        return float(dt.timestamp())
-
-    raise argparse.ArgumentTypeError(f"could not parse time: {s!r}")
 
 
 def to_utc_datetime(value, tz="UTC") -> datetime:
@@ -288,7 +253,7 @@ def to_seconds(series: pd.Series) -> np.ndarray:
 def parse_time(s, tz="UTC") -> float:
     """Parse a timestamp string, number or ``datetime`` into Unix seconds."""
 
-    return parse_timestamp(s)
+    return to_epoch_seconds(s)
 
 
 def parse_time_arg(val, tz="UTC") -> datetime:


### PR DESCRIPTION
## Summary
- implement `parse_timestamp` and `to_epoch_seconds` in `time_utils`
- expose these helpers from `utils` and adjust `parse_time`
- update README for the new utilities
- test the new helpers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b715a2fc0832b836beb801012c2a5