### PR TITLE
Refactor time parsing utilities

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,12 +11,11 @@ from utils import (
     cps_to_cpd,
     cps_to_bq,
     find_adc_bin_peaks,
-    parse_timestamp,
-    parse_time,
     parse_time_arg,
     to_seconds,
     LITERS_PER_M3,
 )
+from utils.time_utils import parse_timestamp, to_epoch_seconds
 
 
 def test_cps_to_cpd():
@@ -52,27 +51,27 @@ def test_find_adc_bin_peaks_basic():
 
 
 def test_parse_time_int():
-    assert parse_time(42) == pytest.approx(42.0)
+    assert to_epoch_seconds(42) == pytest.approx(42.0)
 
 
 def test_parse_time_float():
-    assert parse_time(42.5) == pytest.approx(42.5)
+    assert to_epoch_seconds(42.5) == pytest.approx(42.5)
 
 
 def test_parse_time_numeric_str():
-    assert parse_time("42") == pytest.approx(42.0)
+    assert to_epoch_seconds("42") == pytest.approx(42.0)
 
 
 def test_parse_time_numeric_str_float():
-    assert parse_time("42.5") == pytest.approx(42.5)
+    assert to_epoch_seconds("42.5") == pytest.approx(42.5)
 
 
 def test_parse_time_iso_no_fraction():
-    assert parse_time("1970-01-01T00:00:00Z") == pytest.approx(0.0)
+    assert to_epoch_seconds("1970-01-01T00:00:00Z") == pytest.approx(0.0)
 
 
 def test_parse_time_iso_fraction():
-    assert parse_time("1970-01-01T00:00:00.5Z") == pytest.approx(0.5)
+    assert to_epoch_seconds("1970-01-01T00:00:00.5Z") == pytest.approx(0.5)
 
 
 def test_parse_time_naive_timezone():
@@ -80,15 +79,21 @@ def test_parse_time_naive_timezone():
 
 
 def test_parse_timestamp_numeric():
-    assert parse_timestamp(42) == pytest.approx(42.0)
+    assert to_epoch_seconds(42) == pytest.approx(42.0)
 
 
 def test_parse_timestamp_iso():
-    assert parse_timestamp("1970-01-01T00:00:00Z") == pytest.approx(0.0)
+    assert to_epoch_seconds("1970-01-01T00:00:00Z") == pytest.approx(0.0)
 
 
 def test_parse_timestamp_datetime_naive():
-    assert parse_timestamp(datetime(1970, 1, 1)) == pytest.approx(0.0)
+    assert to_epoch_seconds(datetime(1970, 1, 1)) == pytest.approx(0.0)
+
+
+def test_parse_timestamp_returns_datetime():
+    dt = parse_timestamp("1970-01-01T00:00:00Z")
+    assert isinstance(dt, datetime)
+    assert dt == datetime(1970, 1, 1, tzinfo=timezone.utc)
 
 
 def test_to_seconds_datetime_series():

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -17,10 +17,8 @@ __all__ = [
     "cps_to_bq",
     "to_utc_datetime",
     "parse_time_arg",
-    "parse_timestamp",
     "parse_datetime",
     "to_seconds",
-    "parse_time",
     "LITERS_PER_M3",
 ]
 
@@ -183,45 +181,6 @@ def cps_to_bq(rate_cps, volume_liters=None):
     return float(rate_cps) / volume_m3
 
 
-def parse_timestamp(s) -> float:
-    """Parse an ISO-8601 string, numeric seconds, or ``datetime``.
-
-    Any string without timezone information is interpreted as UTC.
-    The return value is the Unix epoch time in seconds (UTC).
-    """
-
-    if isinstance(s, (int, float)):
-        return float(s)
-
-    if isinstance(s, datetime):
-        dt = s
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        else:
-            dt = dt.astimezone(timezone.utc)
-        return float(dt.timestamp())
-
-    if isinstance(s, str):
-        try:
-            return float(s)
-        except ValueError:
-            pass
-
-        try:
-            dt = date_parser.isoparse(s)
-        except (ValueError, OverflowError) as e:
-            raise argparse.ArgumentTypeError(f"could not parse time: {s!r}") from e
-
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        else:
-            dt = dt.astimezone(timezone.utc)
-
-        return float(dt.timestamp())
-
-    raise argparse.ArgumentTypeError(f"could not parse time: {s!r}")
-
-
 def to_utc_datetime(value, tz="UTC") -> datetime:
     """Return ``value`` converted to a UTC ``datetime`` object."""
 
@@ -283,12 +242,6 @@ def to_seconds(series: pd.Series) -> np.ndarray:
     else:
         series = series.dt.tz_convert("UTC")
     return series.astype("int64").to_numpy() / 1e9
-
-
-def parse_time(s, tz="UTC") -> float:
-    """Parse a timestamp string, number or ``datetime`` into Unix seconds."""
-
-    return parse_timestamp(s)
 
 
 def parse_time_arg(val, tz="UTC") -> datetime:


### PR DESCRIPTION
## Summary
- remove `parse_time` and `parse_timestamp` from `utils/__init__.py`
- add `parse_timestamp` and `to_epoch_seconds` implementations to `utils/time_utils`
- update tests to use the new time utility functions

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b71c245a0832bbf813410a567b245