### PR TITLE
Deprecate utils time parsers

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,12 +11,11 @@ from utils import (
     cps_to_cpd,
     cps_to_bq,
     find_adc_bin_peaks,
-    parse_timestamp,
-    parse_time,
     parse_time_arg,
     to_seconds,
     LITERS_PER_M3,
 )
+from utils.time_utils import parse_timestamp, to_epoch_seconds
 
 
 def test_cps_to_cpd():
@@ -51,28 +50,28 @@ def test_find_adc_bin_peaks_basic():
     assert result["p2"] == pytest.approx(20.5)
 
 
-def test_parse_time_int():
-    assert parse_time(42) == pytest.approx(42.0)
+def test_to_epoch_int():
+    assert to_epoch_seconds(42) == pytest.approx(42.0)
 
 
-def test_parse_time_float():
-    assert parse_time(42.5) == pytest.approx(42.5)
+def test_to_epoch_float():
+    assert to_epoch_seconds(42.5) == pytest.approx(42.5)
 
 
-def test_parse_time_numeric_str():
-    assert parse_time("42") == pytest.approx(42.0)
+def test_to_epoch_numeric_str():
+    assert to_epoch_seconds("42") == pytest.approx(42.0)
 
 
-def test_parse_time_numeric_str_float():
-    assert parse_time("42.5") == pytest.approx(42.5)
+def test_to_epoch_numeric_str_float():
+    assert to_epoch_seconds("42.5") == pytest.approx(42.5)
 
 
-def test_parse_time_iso_no_fraction():
-    assert parse_time("1970-01-01T00:00:00Z") == pytest.approx(0.0)
+def test_to_epoch_iso_no_fraction():
+    assert to_epoch_seconds("1970-01-01T00:00:00Z") == pytest.approx(0.0)
 
 
-def test_parse_time_iso_fraction():
-    assert parse_time("1970-01-01T00:00:00.5Z") == pytest.approx(0.5)
+def test_to_epoch_iso_fraction():
+    assert to_epoch_seconds("1970-01-01T00:00:00.5Z") == pytest.approx(0.5)
 
 
 def test_parse_time_naive_timezone():

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -17,10 +17,8 @@ __all__ = [
     "cps_to_bq",
     "to_utc_datetime",
     "parse_time_arg",
-    "parse_timestamp",
     "parse_datetime",
     "to_seconds",
-    "parse_time",
     "LITERS_PER_M3",
 ]
 
@@ -183,43 +181,6 @@ def cps_to_bq(rate_cps, volume_liters=None):
     return float(rate_cps) / volume_m3
 
 
-def parse_timestamp(s) -> float:
-    """Parse an ISO-8601 string, numeric seconds, or ``datetime``.
-
-    Any string without timezone information is interpreted as UTC.
-    The return value is the Unix epoch time in seconds (UTC).
-    """
-
-    if isinstance(s, (int, float)):
-        return float(s)
-
-    if isinstance(s, datetime):
-        dt = s
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        else:
-            dt = dt.astimezone(timezone.utc)
-        return float(dt.timestamp())
-
-    if isinstance(s, str):
-        try:
-            return float(s)
-        except ValueError:
-            pass
-
-        try:
-            dt = date_parser.isoparse(s)
-        except (ValueError, OverflowError) as e:
-            raise argparse.ArgumentTypeError(f"could not parse time: {s!r}") from e
-
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        else:
-            dt = dt.astimezone(timezone.utc)
-
-        return float(dt.timestamp())
-
-    raise argparse.ArgumentTypeError(f"could not parse time: {s!r}")
 
 
 def to_utc_datetime(value, tz="UTC") -> datetime:
@@ -283,13 +244,6 @@ def to_seconds(series: pd.Series) -> np.ndarray:
     else:
         series = series.dt.tz_convert("UTC")
     return series.astype("int64").to_numpy() / 1e9
-
-
-def parse_time(s, tz="UTC") -> float:
-    """Parse a timestamp string, number or ``datetime`` into Unix seconds."""
-
-    return parse_timestamp(s)
-
 
 def parse_time_arg(val, tz="UTC") -> datetime:
     """Parse a time argument into a UTC ``datetime`` object.

--- a/utils/time_utils.py
+++ b/utils/time_utils.py
@@ -1,11 +1,15 @@
 import pandas as pd
 from pandas.api.types import is_datetime64_any_dtype
+from datetime import datetime, timezone
+from dateutil import parser as date_parser
 
 __all__ = [
     "to_datetime_utc",
     "tz_localize_utc",
     "tz_convert_utc",
     "ensure_utc",
+    "parse_timestamp",
+    "to_epoch_seconds",
 ]
 
 
@@ -38,4 +42,49 @@ def ensure_utc(series: pd.Series) -> pd.Series:
     if getattr(series.dtype, "tz", None) is None:
         return tz_localize_utc(series)
     return tz_convert_utc(series)
+
+
+def parse_timestamp(value) -> float:
+    """Parse an ISO-8601 string, numeric seconds or datetime-like object."""
+
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    if isinstance(value, pd.Timestamp):
+        if value.tzinfo is None:
+            value = value.tz_localize("UTC")
+        else:
+            value = value.tz_convert("UTC")
+        return float(value.timestamp())
+
+    if isinstance(value, datetime):
+        dt = value
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        else:
+            dt = dt.astimezone(timezone.utc)
+        return float(dt.timestamp())
+
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            pass
+        try:
+            dt = date_parser.isoparse(value)
+        except (ValueError, OverflowError) as e:
+            raise ValueError(f"could not parse time: {value!r}") from e
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        else:
+            dt = dt.astimezone(timezone.utc)
+        return float(dt.timestamp())
+
+    raise ValueError(f"could not parse time: {value!r}")
+
+
+def to_epoch_seconds(value) -> float:
+    """Return ``value`` converted to Unix epoch seconds."""
+
+    return parse_timestamp(value)
 


### PR DESCRIPTION
## Summary
- remove `parse_time` and `parse_timestamp` from `utils`
- add `parse_timestamp` and new `to_epoch_seconds` to `utils.time_utils`
- update tests to use the new helpers

## Testing
- `pytest tests/test_utils.py::test_to_epoch_int -q`
- `pytest -q` *(fails: 41 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685b71c245a0832bbf813410a567b245