### PR TITLE
Refactor timestamp utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ This repository provides a complete pipeline to analyze electrostatic radon moni
 - `efficiency.py`: Efficiency calculations and BLUE combination helpers.
 - `systematics.py`: Scan for systematic uncertainties (optional).
 - `plot_utils.py`: Plotting routines for spectrum and time-series.
-- `utils.py`: Miscellaneous utilities providing `parse_datetime` for
-  time conversion, JSON validation, and count-rate conversions.
+- `utils.py`: Miscellaneous utilities for count-rate conversions and other helpers.
+- `time_utils.parse_timestamp` converts strings or numbers to timezone-aware
+  `pandas.Timestamp` objects.
 - `tests/`: `pytest` unit tests for calibration, fitting, and I/O.
 
 ## Installation
@@ -72,7 +73,7 @@ The input file must be a comma-separated table with these columns:
 - `fBits` – status bits or flags
 - `timestamp` – event timestamp in seconds
   (either numeric Unix seconds or an ISO‑8601 string; parsed directly to
-  timezone-aware ``pandas.Timestamp`` values via `parse_datetime`)
+  timezone-aware ``pandas.Timestamp`` values via `time_utils.parse_timestamp`)
 - `adc` – raw ADC value
 - `fchannel` – acquisition channel
 
@@ -125,9 +126,10 @@ For example:
 
 ```python
 from utils import cps_to_bq
+from utils.time_utils import parse_timestamp
+
 activity_bq_m3 = cps_to_bq(fit_result["E_Po214"], volume_liters=10.0)
-from utils import parse_datetime
-t0 = parse_datetime("2023-07-31T00:00:00Z")
+t0 = parse_timestamp("2023-07-31T00:00:00Z")
 ```
 
 When using ``compute_radon_activity`` you should pass the fitted rates
@@ -195,7 +197,7 @@ All other time-related fields (`analysis_end_time`, `spike_end_time`,
 `spike_periods`, `run_periods`, `radon_interval` and
 `baseline.range`) likewise accept absolute timestamps in ISO 8601
 format or numeric seconds.  All of these values are parsed with
-`parse_datetime` so the same formats apply everywhere.
+`time_utils.parse_timestamp` so the same formats apply everywhere.
 
 `analysis_end_time` may be specified to stop processing after the given
 timestamp while `spike_end_time` discards all events before its value.
@@ -555,14 +557,14 @@ Example configuration to tighten the cut (set it to `null` to disable):
 
 ## Utility Conversions
 
-`utils.py` provides simple helpers to convert count rates, parse times and
-search for peak centroids:
+`utils.py` provides simple helpers to convert count rates while
+`time_utils` offers timestamp utilities:
 
 - `cps_to_cpd(rate_cps)` converts counts/s to counts/day.
 - `cps_to_bq(rate_cps, volume_liters=None)` returns the activity in Bq, or
   Bq/m^3 when a detector volume is supplied.
-- `parse_datetime(value)` converts ISO‑8601 strings, numeric seconds or
-  `datetime` objects to a timezone-aware `pandas.Timestamp` in UTC.
+- `time_utils.parse_timestamp(value)` converts ISO‑8601 strings, numeric seconds
+  or `datetime` objects to a timezone-aware `pandas.Timestamp` in UTC.
 - `find_adc_bin_peaks(adc_values, expected, window=50, prominence=0.0, width=None)`
   histogramises the raw ADC spectrum, searches for maxima near each expected
   centroid and returns a `{peak: adc_centroid}` mapping in ADC units.

--- a/analyze.py
+++ b/analyze.py
@@ -106,8 +106,12 @@ from utils import (
     parse_time_arg,
     to_utc_datetime,
 )
-from utils import parse_datetime, to_seconds
-from utils.time_utils import to_datetime_utc, tz_convert_utc
+from utils.time_utils import (
+    parse_timestamp,
+    to_epoch_seconds,
+    to_datetime_utc,
+    tz_convert_utc,
+)
 from baseline_utils import (
     subtract_baseline_dataframe,
     subtract_baseline_counts,
@@ -224,13 +228,7 @@ def prepare_analysis_df(
 
     df_analysis = df.copy()
     ts = df_analysis["timestamp"]
-    if not pd.api.types.is_datetime64_any_dtype(ts):
-        df_analysis["timestamp"] = ts.map(parse_datetime)
-    else:
-        if ts.dt.tz is None:
-            df_analysis["timestamp"] = ts.map(parse_datetime)
-        else:
-            df_analysis["timestamp"] = tz_convert_utc(ts)
+    df_analysis["timestamp"] = ts.map(parse_timestamp)
 
     if spike_end is not None:
         df_analysis = df_analysis[df_analysis["timestamp"] >= spike_end].reset_index(drop=True)
@@ -815,7 +813,7 @@ def main(argv=None):
         events_all = load_events(args.input, column_map=cfg.get("columns"))
 
         # Parse timestamps to UTC ``Timestamp`` objects
-        events_all["timestamp"] = events_all["timestamp"].map(parse_datetime)
+        events_all["timestamp"] = events_all["timestamp"].map(parse_timestamp)
 
 
     except Exception as e:
@@ -1000,7 +998,7 @@ def main(argv=None):
 
     if drift_rate != 0.0 or drift_mode != "linear" or drift_params is not None:
         try:
-            ts_seconds = to_seconds(df_analysis["timestamp"])
+            ts_seconds = df_analysis["timestamp"].map(to_epoch_seconds).to_numpy()
             df_analysis["adc"] = apply_linear_adc_shift(
                 df_analysis["adc"].values,
                 ts_seconds,
@@ -1575,7 +1573,7 @@ def main(argv=None):
             t0_dt = to_utc_datetime(t0_global)
             cut = t0_dt + timedelta(seconds=float(args.settle_s))
             iso_events = iso_events[iso_events["timestamp"] >= cut]
-        ts_vals = to_seconds(iso_events["timestamp"])
+        ts_vals = iso_events["timestamp"].map(to_epoch_seconds).to_numpy()
         times_dict = {iso: ts_vals}
         weights_map = {iso: iso_events["weight"].values}
         fit_cfg = {
@@ -1684,7 +1682,7 @@ def main(argv=None):
                 )
                 mask = probs > 0
                 filtered_df = df_analysis[mask]
-                ts_vals = to_seconds(filtered_df["timestamp"])
+                ts_vals = filtered_df["timestamp"].map(to_epoch_seconds).to_numpy()
                 times_dict = {iso: ts_vals}
                 weights_local = {iso: probs[mask]}
                 cfg_fit = {

--- a/baseline_utils.py
+++ b/baseline_utils.py
@@ -4,8 +4,7 @@ from datetime import datetime
 import numpy as np
 import pandas as pd
 
-from utils import parse_datetime
-from utils.time_utils import tz_localize_utc, tz_convert_utc
+from utils.time_utils import tz_localize_utc, tz_convert_utc, parse_timestamp
 from radon.baseline import (
     subtract_baseline_counts,
     subtract_baseline_rate,
@@ -61,7 +60,7 @@ def _to_datetime64(events: pd.DataFrame | pd.Series) -> np.ndarray:
         if getattr(ser.dtype, "tz", None) is None:
             ser = tz_localize_utc(ser)
     else:
-        ser = col.map(parse_datetime)
+        ser = col.map(parse_timestamp)
 
     ser = tz_convert_utc(ser)
     return ser.to_numpy(dtype="datetime64[ns]")
@@ -113,8 +112,8 @@ def apply_baseline_subtraction(
     if live_time_analysis is None:
         live_time_analysis = live_an
 
-    t0 = parse_datetime(t_base0)
-    t1 = parse_datetime(t_base1)
+    t0 = parse_timestamp(t_base0)
+    t1 = parse_timestamp(t_base1)
     ts_full = _to_datetime64(df_full)
     ts_int = ts_full.view("int64")
     t0_ns = t0.value

--- a/io_utils.py
+++ b/io_utils.py
@@ -14,8 +14,8 @@ from typing import Any, Iterator
 from constants import load_nuclide_overrides
 
 import numpy as np
-from utils import to_native, parse_datetime, to_seconds
-from utils.time_utils import tz_convert_utc
+from utils import to_native
+from utils.time_utils import tz_convert_utc, parse_timestamp, to_epoch_seconds
 import jsonschema
 
 
@@ -247,7 +247,7 @@ def ensure_dir(path):
 
 
 # parse_datetime is re-exported from utils for backward compatibility
-# The implementation now lives in utils.parse_datetime
+# The implementation now delegates to :func:`utils.time_utils.parse_timestamp`
 
 
 def _merge_dicts(base: dict, override: dict) -> dict:
@@ -343,7 +343,7 @@ def load_events(csv_path, *, column_map=None):
     if "timestamp" in df.columns:
         def _safe_parse(val):
             try:
-                return parse_datetime(val)
+                return parse_timestamp(val)
             except Exception:
                 return pd.NaT
 
@@ -397,7 +397,7 @@ def apply_burst_filter(df, cfg=None, mode="rate"):
     df : pandas.DataFrame
         Event data containing a ``timestamp`` column. Values may be numeric
         epoch seconds or ``datetime64`` objects. All timestamps are first
-        converted to ``datetime64`` using :func:`parse_datetime` and the
+        converted to ``datetime64`` using :func:`utils.time_utils.parse_timestamp` and the
         DataFrame is updated accordingly. Seconds are only used internally for
         histogram calculations.
     cfg : dict, optional
@@ -428,15 +428,8 @@ def apply_burst_filter(df, cfg=None, mode="rate"):
     out_df = df.copy()
 
     ts = out_df["timestamp"]
-    if not pd.api.types.is_datetime64_any_dtype(ts):
-        ts = ts.map(parse_datetime)
-    else:
-        if ts.dt.tz is None:
-            ts = ts.map(parse_datetime)
-        else:
-            ts = tz_convert_utc(ts)
-    out_df["timestamp"] = ts
-    times_sec = to_seconds(ts)
+    out_df["timestamp"] = ts.map(parse_timestamp)
+    times_sec = out_df["timestamp"].map(to_epoch_seconds).to_numpy()
 
     # ───── micro-burst veto ─────
     if mode in ("micro", "both"):
@@ -474,14 +467,14 @@ def apply_burst_filter(df, cfg=None, mode="rate"):
             # Recalculate times after removing events
             ts = out_df["timestamp"]
             if not pd.api.types.is_datetime64_any_dtype(ts):
-                ts = ts.map(parse_datetime)
+                ts = ts.map(parse_timestamp)
             else:
                 if ts.dt.tz is None:
-                    ts = ts.map(parse_datetime)
+                    ts = ts.map(parse_timestamp)
                 else:
                     ts = tz_convert_utc(ts)
             out_df["timestamp"] = ts
-            times_sec = to_seconds(ts)
+            times_sec = out_df["timestamp"].map(to_epoch_seconds).to_numpy()
 
     # ───── rate-based veto ─────
     if mode in ("rate", "both"):

--- a/tests/test_time_utils_new.py
+++ b/tests/test_time_utils_new.py
@@ -1,9 +1,12 @@
 import pandas as pd
+import pytest
 from utils.time_utils import (
     to_datetime_utc,
     tz_localize_utc,
     tz_convert_utc,
     ensure_utc,
+    parse_timestamp,
+    to_epoch_seconds,
 )
 
 
@@ -28,3 +31,10 @@ def test_ensure_utc():
     ser_aware = pd.Series(pd.date_range("1970-01-01", periods=2, freq="s", tz="US/Eastern"))
     assert str(ensure_utc(ser_naive).dtype) == "datetime64[ns, UTC]"
     assert str(ensure_utc(ser_aware).dtype) == "datetime64[ns, UTC]"
+
+
+def test_parse_timestamp_and_epoch():
+    ts = parse_timestamp("1970-01-01T00:00:01Z")
+    assert isinstance(ts, pd.Timestamp)
+    assert str(ts.tz) == "UTC"
+    assert to_epoch_seconds(ts) == pytest.approx(1.0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,12 +11,12 @@ from utils import (
     cps_to_cpd,
     cps_to_bq,
     find_adc_bin_peaks,
-    parse_timestamp,
     parse_time,
     parse_time_arg,
     to_seconds,
     LITERS_PER_M3,
 )
+from utils.time_utils import parse_timestamp, to_epoch_seconds
 
 
 def test_cps_to_cpd():
@@ -80,15 +80,24 @@ def test_parse_time_naive_timezone():
 
 
 def test_parse_timestamp_numeric():
-    assert parse_timestamp(42) == pytest.approx(42.0)
+    ts = parse_timestamp(42)
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp(42, unit="s", tz="UTC")
+    assert to_epoch_seconds(ts) == pytest.approx(42.0)
 
 
 def test_parse_timestamp_iso():
-    assert parse_timestamp("1970-01-01T00:00:00Z") == pytest.approx(0.0)
+    ts = parse_timestamp("1970-01-01T00:00:00Z")
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
+    assert to_epoch_seconds(ts) == pytest.approx(0.0)
 
 
 def test_parse_timestamp_datetime_naive():
-    assert parse_timestamp(datetime(1970, 1, 1)) == pytest.approx(0.0)
+    ts = parse_timestamp(datetime(1970, 1, 1))
+    assert isinstance(ts, pd.Timestamp)
+    assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
+    assert to_epoch_seconds(ts) == pytest.approx(0.0)
 
 
 def test_to_seconds_datetime_series():


### PR DESCRIPTION
## Summary
- add `parse_timestamp` and `to_epoch_seconds` utilities
- update code to use new helpers in analysis and IO utilities
- ensure baseline utilities and loaders keep UTC dtype
- adjust tests and documentation for new timestamp helpers

## Testing
- `pytest tests/test_utils.py tests/test_time_utils_new.py tests/test_timestamp_dtype.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b737809d8832baa533b2e433b32b5