### PR TITLE
Add timestamp utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,10 @@ search for peak centroids:
   Bq/m^3 when a detector volume is supplied.
 - `parse_datetime(value)` converts ISO‑8601 strings, numeric seconds or
   `datetime` objects to a timezone-aware `pandas.Timestamp` in UTC.
+- `parse_timestamp(value)` parses the same inputs but always returns a
+  timezone-aware `pandas.Timestamp` in UTC.
+- `to_epoch_seconds(ts_or_str)` converts a timestamp or string to Unix
+  seconds as `float`.
 - `find_adc_bin_peaks(adc_values, expected, window=50, prominence=0.0, width=None)`
   histogramises the raw ADC spectrum, searches for maxima near each expected
   centroid and returns a `{peak: adc_centroid}` mapping in ADC units.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ from utils import (
     cps_to_bq,
     find_adc_bin_peaks,
     parse_timestamp,
+    to_epoch_seconds,
     parse_time,
     parse_time_arg,
     to_seconds,
@@ -80,15 +81,29 @@ def test_parse_time_naive_timezone():
 
 
 def test_parse_timestamp_numeric():
-    assert parse_timestamp(42) == pytest.approx(42.0)
+    ts = parse_timestamp(42)
+    assert isinstance(ts, pd.Timestamp)
+    assert ts.tzinfo is not None and str(ts.tzinfo) == "UTC"
+    assert ts.value == pd.Timestamp(42, unit="s", tz="UTC").value
 
 
 def test_parse_timestamp_iso():
-    assert parse_timestamp("1970-01-01T00:00:00Z") == pytest.approx(0.0)
+    ts = parse_timestamp("1970-01-01T00:00:00Z")
+    assert ts == pd.Timestamp(0, unit="s", tz="UTC")
 
 
 def test_parse_timestamp_datetime_naive():
-    assert parse_timestamp(datetime(1970, 1, 1)) == pytest.approx(0.0)
+    ts = parse_timestamp(datetime(1970, 1, 1))
+    assert ts == pd.Timestamp(0, unit="s", tz="UTC")
+
+
+def test_to_epoch_seconds_numeric():
+    assert to_epoch_seconds(42) == pytest.approx(42.0)
+
+
+def test_to_epoch_seconds_timestamp():
+    ts = pd.Timestamp(1.5, unit="s", tz="UTC")
+    assert to_epoch_seconds(ts) == pytest.approx(1.5)
 
 
 def test_to_seconds_datetime_series():

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -9,6 +9,8 @@ from datetime import datetime, timezone, tzinfo, timedelta
 from dateutil import parser as date_parser
 from dateutil.tz import gettz
 
+from .time_utils import parse_timestamp, to_epoch_seconds
+
 __all__ = [
     "to_native",
     "find_adc_bin_peaks",
@@ -18,6 +20,7 @@ __all__ = [
     "to_utc_datetime",
     "parse_time_arg",
     "parse_timestamp",
+    "to_epoch_seconds",
     "parse_datetime",
     "to_seconds",
     "parse_time",
@@ -183,44 +186,6 @@ def cps_to_bq(rate_cps, volume_liters=None):
     return float(rate_cps) / volume_m3
 
 
-def parse_timestamp(s) -> float:
-    """Parse an ISO-8601 string, numeric seconds, or ``datetime``.
-
-    Any string without timezone information is interpreted as UTC.
-    The return value is the Unix epoch time in seconds (UTC).
-    """
-
-    if isinstance(s, (int, float)):
-        return float(s)
-
-    if isinstance(s, datetime):
-        dt = s
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        else:
-            dt = dt.astimezone(timezone.utc)
-        return float(dt.timestamp())
-
-    if isinstance(s, str):
-        try:
-            return float(s)
-        except ValueError:
-            pass
-
-        try:
-            dt = date_parser.isoparse(s)
-        except (ValueError, OverflowError) as e:
-            raise argparse.ArgumentTypeError(f"could not parse time: {s!r}") from e
-
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        else:
-            dt = dt.astimezone(timezone.utc)
-
-        return float(dt.timestamp())
-
-    raise argparse.ArgumentTypeError(f"could not parse time: {s!r}")
-
 
 def to_utc_datetime(value, tz="UTC") -> datetime:
     """Return ``value`` converted to a UTC ``datetime`` object."""
@@ -288,7 +253,7 @@ def to_seconds(series: pd.Series) -> np.ndarray:
 def parse_time(s, tz="UTC") -> float:
     """Parse a timestamp string, number or ``datetime`` into Unix seconds."""
 
-    return parse_timestamp(s)
+    return to_epoch_seconds(s)
 
 
 def parse_time_arg(val, tz="UTC") -> datetime:

--- a/utils/time_utils.py
+++ b/utils/time_utils.py
@@ -6,6 +6,8 @@ __all__ = [
     "tz_localize_utc",
     "tz_convert_utc",
     "ensure_utc",
+    "parse_timestamp",
+    "to_epoch_seconds",
 ]
 
 
@@ -38,4 +40,35 @@ def ensure_utc(series: pd.Series) -> pd.Series:
     if getattr(series.dtype, "tz", None) is None:
         return tz_localize_utc(series)
     return tz_convert_utc(series)
+
+
+def parse_timestamp(value) -> pd.Timestamp:
+    """Return ``value`` parsed as a UTC ``pandas.Timestamp``."""
+
+    if isinstance(value, pd.Timestamp):
+        ts = value
+    elif isinstance(value, (int, float)):
+        ts = pd.to_datetime(float(value), unit="s", utc=True)
+    elif isinstance(value, str):
+        try:
+            num = float(value)
+        except ValueError:
+            ts = pd.to_datetime(value, utc=True)
+        else:
+            ts = pd.to_datetime(num, unit="s", utc=True)
+    else:
+        ts = pd.to_datetime(value, utc=True)
+
+    if ts.tzinfo is None:
+        ts = ts.tz_localize("UTC")
+    else:
+        ts = ts.tz_convert("UTC")
+    return ts
+
+
+def to_epoch_seconds(ts_or_str) -> float:
+    """Return Unix epoch seconds for ``ts_or_str``."""
+
+    return parse_timestamp(ts_or_str).timestamp()
+
 


### PR DESCRIPTION
## Summary
- implement `parse_timestamp` and `to_epoch_seconds` in `utils/time_utils`
- re-export new helpers via `utils` package
- adapt time parsing utilities and tests
- document the new helpers in README

## Testing
- `pytest tests/test_utils.py::test_parse_time_numeric_str tests/test_utils.py::test_parse_time_numeric_str_float -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b715a2fc0832b836beb801012c2a5