### PR TITLE
Refactor timestamp utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ This repository provides a complete pipeline to analyze electrostatic radon moni
 - `efficiency.py`: Efficiency calculations and BLUE combination helpers.
 - `systematics.py`: Scan for systematic uncertainties (optional).
 - `plot_utils.py`: Plotting routines for spectrum and time-series.
-- `utils.py`: Miscellaneous utilities providing `parse_datetime` for
-  time conversion, JSON validation, and count-rate conversions.
+ - `utils.py`: Miscellaneous utilities providing JSON helpers and
+   count-rate conversions. Timestamp utilities are in `utils.time_utils`.
 - `tests/`: `pytest` unit tests for calibration, fitting, and I/O.
 
 ## Installation
@@ -72,7 +72,8 @@ The input file must be a comma-separated table with these columns:
 - `fBits` – status bits or flags
 - `timestamp` – event timestamp in seconds
   (either numeric Unix seconds or an ISO‑8601 string; parsed directly to
-  timezone-aware ``pandas.Timestamp`` values via `parse_datetime`)
+  timezone-aware ``pandas.Timestamp`` values via
+  `time_utils.parse_timestamp`)
 - `adc` – raw ADC value
 - `fchannel` – acquisition channel
 
@@ -126,8 +127,8 @@ For example:
 ```python
 from utils import cps_to_bq
 activity_bq_m3 = cps_to_bq(fit_result["E_Po214"], volume_liters=10.0)
-from utils import parse_datetime
-t0 = parse_datetime("2023-07-31T00:00:00Z")
+from utils.time_utils import parse_timestamp
+t0 = parse_timestamp("2023-07-31T00:00:00Z")
 ```
 
 When using ``compute_radon_activity`` you should pass the fitted rates
@@ -195,7 +196,7 @@ All other time-related fields (`analysis_end_time`, `spike_end_time`,
 `spike_periods`, `run_periods`, `radon_interval` and
 `baseline.range`) likewise accept absolute timestamps in ISO 8601
 format or numeric seconds.  All of these values are parsed with
-`parse_datetime` so the same formats apply everywhere.
+`time_utils.parse_timestamp` so the same formats apply everywhere.
 
 `analysis_end_time` may be specified to stop processing after the given
 timestamp while `spike_end_time` discards all events before its value.
@@ -561,8 +562,9 @@ search for peak centroids:
 - `cps_to_cpd(rate_cps)` converts counts/s to counts/day.
 - `cps_to_bq(rate_cps, volume_liters=None)` returns the activity in Bq, or
   Bq/m^3 when a detector volume is supplied.
-- `parse_datetime(value)` converts ISO‑8601 strings, numeric seconds or
-  `datetime` objects to a timezone-aware `pandas.Timestamp` in UTC.
+- `time_utils.parse_timestamp(value)` converts ISO‑8601 strings, numeric
+  seconds or `datetime` objects to a timezone-aware `pandas.Timestamp`
+  in UTC.
 - `find_adc_bin_peaks(adc_values, expected, window=50, prominence=0.0, width=None)`
   histogramises the raw ADC spectrum, searches for maxima near each expected
   centroid and returns a `{peak: adc_centroid}` mapping in ADC units.

--- a/baseline_utils.py
+++ b/baseline_utils.py
@@ -4,8 +4,7 @@ from datetime import datetime
 import numpy as np
 import pandas as pd
 
-from utils import parse_datetime
-from utils.time_utils import tz_localize_utc, tz_convert_utc
+from utils.time_utils import parse_timestamp
 from radon.baseline import (
     subtract_baseline_counts,
     subtract_baseline_rate,
@@ -56,15 +55,8 @@ def _to_datetime64(events: pd.DataFrame | pd.Series) -> np.ndarray:
     else:
         col = events
 
-    if pd.api.types.is_datetime64_any_dtype(col):
-        ser = col
-        if getattr(ser.dtype, "tz", None) is None:
-            ser = tz_localize_utc(ser)
-    else:
-        ser = col.map(parse_datetime)
-
-    ser = tz_convert_utc(ser)
-    return ser.to_numpy(dtype="datetime64[ns]")
+    ser = pd.Series(col).map(parse_timestamp)
+    return ser.dt.tz_convert("UTC").to_numpy(dtype="datetime64[ns]")
 
 
 def rate_histogram(df: pd.DataFrame, bins) -> tuple[np.ndarray, float]:
@@ -113,8 +105,8 @@ def apply_baseline_subtraction(
     if live_time_analysis is None:
         live_time_analysis = live_an
 
-    t0 = parse_datetime(t_base0)
-    t1 = parse_datetime(t_base1)
+    t0 = parse_timestamp(t_base0)
+    t1 = parse_timestamp(t_base1)
     ts_full = _to_datetime64(df_full)
     ts_int = ts_full.view("int64")
     t0_ns = t0.value

--- a/tests/test_interval_parsing.py
+++ b/tests/test_interval_parsing.py
@@ -5,7 +5,8 @@ from datetime import datetime, timezone, timedelta
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import analyze
-from utils import parse_time_arg, parse_datetime
+from utils import parse_time_arg
+from utils.time_utils import parse_timestamp
 from dateutil.tz import gettz
 import pandas as pd
 
@@ -31,10 +32,10 @@ def test_config_interval_parsing_to_datetime():
         "baseline": {"range": ["1970-01-01T00:00:01Z", "1970-01-01T00:00:02Z"]},
         "analysis": {"radon_interval": ["1970-01-01T00:00:03Z", "1970-01-01T00:00:04Z"]},
     }
-    b_start = parse_datetime(cfg["baseline"]["range"][0])
-    b_end = parse_datetime(cfg["baseline"]["range"][1])
-    r_start = parse_datetime(cfg["analysis"]["radon_interval"][0])
-    r_end = parse_datetime(cfg["analysis"]["radon_interval"][1])
+    b_start = parse_timestamp(cfg["baseline"]["range"][0])
+    b_end = parse_timestamp(cfg["baseline"]["range"][1])
+    r_start = parse_timestamp(cfg["analysis"]["radon_interval"][0])
+    r_end = parse_timestamp(cfg["analysis"]["radon_interval"][1])
     for dt in (b_start, b_end, r_start, r_end):
         assert dt.tzinfo is not None
         assert dt.tzinfo.utcoffset(dt) == timedelta(0)

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -17,7 +17,7 @@ from io_utils import (
     apply_burst_filter,
     Summary,
 )
-from utils import parse_datetime
+from utils.time_utils import parse_timestamp
 
 
 def test_load_config(tmp_path):
@@ -145,7 +145,7 @@ def test_load_events_column_aliases(tmp_path):
     df.to_csv(p, index=False)
     loaded = load_events(p)
     assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
-    assert list(loaded["timestamp"])[0] == parse_datetime(1000)
+    assert list(loaded["timestamp"])[0] == parse_timestamp(1000)
     assert list(loaded["adc"])[0] == 1250
     assert "time" not in loaded.columns
     assert "adc_ch" not in loaded.columns
@@ -172,7 +172,7 @@ def test_load_events_custom_columns(tmp_path):
     }
     loaded = load_events(p, column_map=column_map)
     assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
-    assert list(loaded["timestamp"])[0] == parse_datetime(1000)
+    assert list(loaded["timestamp"])[0] == parse_timestamp(1000)
     assert list(loaded["adc"])[0] == 1250
     assert "ftimestamps" not in loaded.columns
 
@@ -211,7 +211,7 @@ def test_load_events_string_nan(tmp_path):
     df.to_csv(p, index=False)
     loaded = load_events(p)
     assert len(loaded) == 1
-    assert loaded["timestamp"].iloc[0] == parse_datetime(1000)
+    assert loaded["timestamp"].iloc[0] == parse_timestamp(1000)
 
 
 def test_write_summary_and_copy_config(tmp_path):

--- a/tests/test_parse_datetime.py
+++ b/tests/test_parse_datetime.py
@@ -6,55 +6,55 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from utils import parse_datetime
+from utils.time_utils import parse_timestamp
 
 
-def test_parse_datetime_iso_string():
-    ts = parse_datetime("1970-01-01T00:00:00Z")
+def test_parse_timestamp_iso_string():
+    ts = parse_timestamp("1970-01-01T00:00:00Z")
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
-def test_parse_datetime_numeric():
-    ts = parse_datetime(42)
+def test_parse_timestamp_numeric():
+    ts = parse_timestamp(42)
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp(42, unit="s", tz="UTC")
 
 
-def test_parse_datetime_numeric_str():
-    ts = parse_datetime("42")
+def test_parse_timestamp_numeric_str():
+    ts = parse_timestamp("42")
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp(42, unit="s", tz="UTC")
 
 
-def test_parse_datetime_naive_datetime():
+def test_parse_timestamp_naive_datetime():
     dt = datetime(1970, 1, 1)
-    ts = parse_datetime(dt)
+    ts = parse_timestamp(dt)
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
-def test_parse_datetime_float():
-    ts = parse_datetime(42.5)
+def test_parse_timestamp_float():
+    ts = parse_timestamp(42.5)
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp(42.5, unit="s", tz="UTC")
 
 
-def test_parse_datetime_iso_without_tz():
-    ts = parse_datetime("1970-01-01T00:00:00")
+def test_parse_timestamp_iso_without_tz():
+    ts = parse_timestamp("1970-01-01T00:00:00")
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
-def test_parse_datetime_iso_with_offset():
-    ts = parse_datetime("1970-01-01T01:00:00+01:00")
+def test_parse_timestamp_iso_with_offset():
+    ts = parse_timestamp("1970-01-01T01:00:00+01:00")
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
-def test_parse_datetime_datetime_with_tz():
+def test_parse_timestamp_datetime_with_tz():
     dt = datetime(1970, 1, 1, 1, tzinfo=timezone(timedelta(hours=1)))
-    ts = parse_datetime(dt)
+    ts = parse_timestamp(dt)
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,12 +11,11 @@ from utils import (
     cps_to_cpd,
     cps_to_bq,
     find_adc_bin_peaks,
-    parse_timestamp,
     parse_time,
     parse_time_arg,
-    to_seconds,
     LITERS_PER_M3,
 )
+from utils.time_utils import parse_timestamp, to_epoch_seconds
 
 
 def test_cps_to_cpd():
@@ -80,24 +79,28 @@ def test_parse_time_naive_timezone():
 
 
 def test_parse_timestamp_numeric():
-    assert parse_timestamp(42) == pytest.approx(42.0)
+    assert parse_timestamp(42) == pd.Timestamp(42, unit="s", tz="UTC")
 
 
 def test_parse_timestamp_iso():
-    assert parse_timestamp("1970-01-01T00:00:00Z") == pytest.approx(0.0)
+    assert parse_timestamp("1970-01-01T00:00:00Z") == pd.Timestamp(
+        "1970-01-01T00:00:00Z"
+    )
 
 
 def test_parse_timestamp_datetime_naive():
-    assert parse_timestamp(datetime(1970, 1, 1)) == pytest.approx(0.0)
+    assert parse_timestamp(datetime(1970, 1, 1)) == pd.Timestamp(
+        "1970-01-01T00:00:00Z"
+    )
 
 
-def test_to_seconds_datetime_series():
+def test_to_epoch_seconds_datetime_series():
     ser = pd.Series(pd.to_datetime([0, 1, 2], unit="s", utc=True))
-    out = to_seconds(ser)
+    out = ser.map(to_epoch_seconds).to_numpy()
     assert np.allclose(out, [0.0, 1.0, 2.0])
 
 
-def test_to_seconds_numeric_series():
+def test_to_epoch_seconds_numeric_series():
     ser = pd.Series([0.0, 1.5, 2.2])
-    out = to_seconds(ser)
+    out = ser.map(to_epoch_seconds).to_numpy()
     assert np.allclose(out, [0.0, 1.5, 2.2])

--- a/utils/time_utils.py
+++ b/utils/time_utils.py
@@ -1,11 +1,17 @@
+from __future__ import annotations
+
 import pandas as pd
 from pandas.api.types import is_datetime64_any_dtype
+from datetime import datetime, timezone
+from dateutil import parser as date_parser
 
 __all__ = [
     "to_datetime_utc",
     "tz_localize_utc",
     "tz_convert_utc",
     "ensure_utc",
+    "parse_timestamp",
+    "to_epoch_seconds",
 ]
 
 
@@ -38,4 +44,48 @@ def ensure_utc(series: pd.Series) -> pd.Series:
     if getattr(series.dtype, "tz", None) is None:
         return tz_localize_utc(series)
     return tz_convert_utc(series)
+
+
+def parse_timestamp(value: str | int | float | datetime) -> pd.Timestamp:
+    """Return ``value`` parsed as a UTC ``Timestamp``."""
+
+    if isinstance(value, pd.Timestamp):
+        ts = value
+    elif isinstance(value, (int, float)):
+        ts = pd.Timestamp(float(value), unit="s", tz="UTC")
+    elif isinstance(value, datetime):
+        if value.tzinfo is None:
+            ts = pd.Timestamp(value, tz="UTC")
+        else:
+            ts = pd.Timestamp(value).tz_convert("UTC")
+    elif isinstance(value, str):
+        try:
+            ts = pd.Timestamp(float(value), unit="s", tz="UTC")
+        except ValueError:
+            dt = date_parser.isoparse(value)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            else:
+                dt = dt.astimezone(timezone.utc)
+            ts = pd.Timestamp(dt)
+    else:
+        raise TypeError(f"Unsupported timestamp type: {type(value)!r}")
+
+    if ts.tzinfo is None:
+        ts = ts.tz_localize("UTC")
+    else:
+        ts = ts.tz_convert("UTC")
+    return ts
+
+
+def to_epoch_seconds(ts: pd.Timestamp | str | int | float) -> float:
+    """Return ``ts`` converted to Unix seconds (UTC)."""
+
+    if not isinstance(ts, pd.Timestamp):
+        ts = parse_timestamp(ts)
+    elif ts.tzinfo is None:
+        ts = ts.tz_localize("UTC")
+    else:
+        ts = ts.tz_convert("UTC")
+    return ts.value / 1e9
 


### PR DESCRIPTION
## Summary
- add `parse_timestamp` and `to_epoch_seconds` helpers in `utils.time_utils`
- refactor analysis and IO modules to use new time utilities
- adjust baseline utilities for new helpers
- update unit tests for new API
- document usage of `time_utils.parse_timestamp`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b737809d8832baa533b2e433b32b5