### PR TITLE
Deprecate utils time helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ This repository provides a complete pipeline to analyze electrostatic radon moni
 - `efficiency.py`: Efficiency calculations and BLUE combination helpers.
 - `systematics.py`: Scan for systematic uncertainties (optional).
 - `plot_utils.py`: Plotting routines for spectrum and time-series.
-- `utils.py`: Miscellaneous utilities providing `parse_datetime`,
-  `parse_timestamp` and `to_epoch_seconds` for time conversion, JSON
-  validation, and count-rate conversions.
+- `utils.py`: Miscellaneous utilities providing `parse_datetime` and other
+  helpers. Time conversion functions such as `parse_timestamp` and
+  `to_epoch_seconds` reside in `utils.time_utils`.
 - `tests/`: `pytest` unit tests for calibration, fitting, and I/O.
 
 ## Installation
@@ -556,18 +556,18 @@ Example configuration to tighten the cut (set it to `null` to disable):
 
 ## Utility Conversions
 
-`utils.py` provides simple helpers to convert count rates, parse times and
-search for peak centroids:
+`utils.py` provides simple helpers to convert count rates and search for peak
+centroids. Time parsing utilities are available from `utils.time_utils`:
 
 - `cps_to_cpd(rate_cps)` converts counts/s to counts/day.
 - `cps_to_bq(rate_cps, volume_liters=None)` returns the activity in Bq, or
   Bq/m^3 when a detector volume is supplied.
 - `parse_datetime(value)` converts ISO‑8601 strings, numeric seconds or
   `datetime` objects to a timezone-aware `pandas.Timestamp` in UTC.
-- `parse_timestamp(value)` returns the same as `parse_datetime` but accepts
-  numbers, ISO‑8601 strings or `datetime` objects and always yields a UTC
-  `pandas.Timestamp`.
-- `to_epoch_seconds(ts_or_str)` converts these inputs to Unix seconds.
+- `parse_timestamp(value)` from `utils.time_utils` accepts the same inputs and
+  always yields a UTC `pandas.Timestamp`.
+- `to_epoch_seconds(ts_or_str)` from `utils.time_utils` converts these inputs to
+  Unix seconds.
 - `find_adc_bin_peaks(adc_values, expected, window=50, prominence=0.0, width=None)`
   histogramises the raw ADC spectrum, searches for maxima near each expected
   centroid and returns a `{peak: adc_centroid}` mapping in ADC units.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,13 +11,11 @@ from utils import (
     cps_to_cpd,
     cps_to_bq,
     find_adc_bin_peaks,
-    parse_timestamp,
-    to_epoch_seconds,
-    parse_time,
     parse_time_arg,
     to_seconds,
     LITERS_PER_M3,
 )
+from utils.time_utils import parse_timestamp, to_epoch_seconds
 
 
 def test_cps_to_cpd():
@@ -52,28 +50,28 @@ def test_find_adc_bin_peaks_basic():
     assert result["p2"] == pytest.approx(20.5)
 
 
-def test_parse_time_int():
-    assert parse_time(42) == pytest.approx(42.0)
+def test_to_epoch_seconds_int():
+    assert to_epoch_seconds(42) == pytest.approx(42.0)
 
 
-def test_parse_time_float():
-    assert parse_time(42.5) == pytest.approx(42.5)
+def test_to_epoch_seconds_float():
+    assert to_epoch_seconds(42.5) == pytest.approx(42.5)
 
 
-def test_parse_time_numeric_str():
-    assert parse_time("42") == pytest.approx(42.0)
+def test_to_epoch_seconds_numeric_str():
+    assert to_epoch_seconds("42") == pytest.approx(42.0)
 
 
-def test_parse_time_numeric_str_float():
-    assert parse_time("42.5") == pytest.approx(42.5)
+def test_to_epoch_seconds_numeric_str_float():
+    assert to_epoch_seconds("42.5") == pytest.approx(42.5)
 
 
-def test_parse_time_iso_no_fraction():
-    assert parse_time("1970-01-01T00:00:00Z") == pytest.approx(0.0)
+def test_to_epoch_seconds_iso_no_fraction():
+    assert to_epoch_seconds("1970-01-01T00:00:00Z") == pytest.approx(0.0)
 
 
-def test_parse_time_iso_fraction():
-    assert parse_time("1970-01-01T00:00:00.5Z") == pytest.approx(0.5)
+def test_to_epoch_seconds_iso_fraction():
+    assert to_epoch_seconds("1970-01-01T00:00:00.5Z") == pytest.approx(0.5)
 
 
 def test_parse_time_naive_timezone():

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -8,7 +8,8 @@ import argparse
 from datetime import datetime, timezone, tzinfo, timedelta
 from dateutil import parser as date_parser
 from dateutil.tz import gettz
-from .time_utils import parse_timestamp, to_epoch_seconds
+from .time_utils import parse_timestamp as _parse_timestamp, to_epoch_seconds
+import warnings
 
 __all__ = [
     "to_native",
@@ -18,11 +19,9 @@ __all__ = [
     "cps_to_bq",
     "to_utc_datetime",
     "parse_time_arg",
-    "parse_timestamp",
     "to_epoch_seconds",
     "parse_datetime",
     "to_seconds",
-    "parse_time",
     "LITERS_PER_M3",
 ]
 
@@ -250,9 +249,25 @@ def to_seconds(series: pd.Series) -> np.ndarray:
     return series.astype("int64").to_numpy() / 1e9
 
 
-def parse_time(s, tz="UTC") -> float:
-    """Parse a timestamp string, number or ``datetime`` into Unix seconds."""
+def parse_timestamp(value):
+    """Deprecated wrapper for :func:`utils.time_utils.parse_timestamp`."""
 
+    warnings.warn(
+        "utils.parse_timestamp is deprecated; use utils.time_utils.parse_timestamp",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _parse_timestamp(value)
+
+
+def parse_time(s, tz="UTC") -> float:
+    """Deprecated wrapper for :func:`utils.time_utils.to_epoch_seconds`."""
+
+    warnings.warn(
+        "utils.parse_time is deprecated; use utils.time_utils.to_epoch_seconds",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return to_epoch_seconds(s)
 
 


### PR DESCRIPTION
## Summary
- deprecate `parse_time` and `parse_timestamp` in `utils`
- update README for `utils.time_utils`
- switch tests to use `utils.time_utils`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b761f667c832bbd46e7d0a79fd345