### PR TITLE
Implement centralized time utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ This repository provides a complete pipeline to analyze electrostatic radon moni
 - `efficiency.py`: Efficiency calculations and BLUE combination helpers.
 - `systematics.py`: Scan for systematic uncertainties (optional).
 - `plot_utils.py`: Plotting routines for spectrum and time-series.
-- `utils.py`: Miscellaneous utilities providing `parse_datetime`,
-  `parse_timestamp` and `to_epoch_seconds` for time conversion, JSON
-  validation, and count-rate conversions.
+- `utils.py`: Miscellaneous utilities providing JSON validation and
+  count-rate conversions. Time helpers are available via
+  `utils.time_utils.parse_timestamp` and `utils.time_utils.to_epoch_seconds`.
 - `tests/`: `pytest` unit tests for calibration, fitting, and I/O.
 
 ## Installation
@@ -73,7 +73,7 @@ The input file must be a comma-separated table with these columns:
 - `fBits` – status bits or flags
 - `timestamp` – event timestamp in seconds
   (either numeric Unix seconds or an ISO‑8601 string; parsed directly to
-  timezone-aware ``pandas.Timestamp`` values via `parse_datetime`)
+  timezone-aware ``pandas.Timestamp`` values via `time_utils.parse_timestamp`)
 - `adc` – raw ADC value
 - `fchannel` – acquisition channel
 
@@ -127,8 +127,8 @@ For example:
 ```python
 from utils import cps_to_bq
 activity_bq_m3 = cps_to_bq(fit_result["E_Po214"], volume_liters=10.0)
-from utils import parse_datetime
-t0 = parse_datetime("2023-07-31T00:00:00Z")
+from utils.time_utils import parse_timestamp
+t0 = parse_timestamp("2023-07-31T00:00:00Z")
 ```
 
 When using ``compute_radon_activity`` you should pass the fitted rates
@@ -196,7 +196,7 @@ All other time-related fields (`analysis_end_time`, `spike_end_time`,
 `spike_periods`, `run_periods`, `radon_interval` and
 `baseline.range`) likewise accept absolute timestamps in ISO 8601
 format or numeric seconds.  All of these values are parsed with
-`parse_datetime` so the same formats apply everywhere.
+`time_utils.parse_timestamp` so the same formats apply everywhere.
 
 `analysis_end_time` may be specified to stop processing after the given
 timestamp while `spike_end_time` discards all events before its value.
@@ -562,12 +562,10 @@ search for peak centroids:
 - `cps_to_cpd(rate_cps)` converts counts/s to counts/day.
 - `cps_to_bq(rate_cps, volume_liters=None)` returns the activity in Bq, or
   Bq/m^3 when a detector volume is supplied.
-- `parse_datetime(value)` converts ISO‑8601 strings, numeric seconds or
-  `datetime` objects to a timezone-aware `pandas.Timestamp` in UTC.
-- `parse_timestamp(value)` returns the same as `parse_datetime` but accepts
-  numbers, ISO‑8601 strings or `datetime` objects and always yields a UTC
-  `pandas.Timestamp`.
-- `to_epoch_seconds(ts_or_str)` converts these inputs to Unix seconds.
+- `time_utils.parse_timestamp(value)` converts ISO‑8601 strings, numeric seconds
+  or `datetime` objects to a timezone-aware `pandas.Timestamp` in UTC.
+- `time_utils.to_epoch_seconds(ts_or_str)` converts these inputs to Unix
+  seconds.
 - `find_adc_bin_peaks(adc_values, expected, window=50, prominence=0.0, width=None)`
   histogramises the raw ADC spectrum, searches for maxima near each expected
   centroid and returns a `{peak: adc_centroid}` mapping in ADC units.

--- a/analyze.py
+++ b/analyze.py
@@ -106,8 +106,12 @@ from utils import (
     parse_time_arg,
     to_utc_datetime,
 )
-from utils import parse_datetime, to_seconds
-from utils.time_utils import to_datetime_utc, tz_convert_utc
+from utils.time_utils import (
+    parse_timestamp,
+    to_epoch_seconds,
+    to_datetime_utc,
+    tz_convert_utc,
+)
 from baseline_utils import (
     subtract_baseline_dataframe,
     subtract_baseline_counts,
@@ -225,10 +229,10 @@ def prepare_analysis_df(
     df_analysis = df.copy()
     ts = df_analysis["timestamp"]
     if not pd.api.types.is_datetime64_any_dtype(ts):
-        df_analysis["timestamp"] = ts.map(parse_datetime)
+        df_analysis["timestamp"] = ts.map(parse_timestamp)
     else:
         if ts.dt.tz is None:
-            df_analysis["timestamp"] = ts.map(parse_datetime)
+            df_analysis["timestamp"] = ts.map(parse_timestamp)
         else:
             df_analysis["timestamp"] = tz_convert_utc(ts)
 
@@ -815,7 +819,7 @@ def main(argv=None):
         events_all = load_events(args.input, column_map=cfg.get("columns"))
 
         # Parse timestamps to UTC ``Timestamp`` objects
-        events_all["timestamp"] = events_all["timestamp"].map(parse_datetime)
+        events_all["timestamp"] = events_all["timestamp"].map(parse_timestamp)
 
 
     except Exception as e:
@@ -1000,7 +1004,7 @@ def main(argv=None):
 
     if drift_rate != 0.0 or drift_mode != "linear" or drift_params is not None:
         try:
-            ts_seconds = to_seconds(df_analysis["timestamp"])
+            ts_seconds = df_analysis["timestamp"].map(to_epoch_seconds).to_numpy()
             df_analysis["adc"] = apply_linear_adc_shift(
                 df_analysis["adc"].values,
                 ts_seconds,
@@ -1575,7 +1579,7 @@ def main(argv=None):
             t0_dt = to_utc_datetime(t0_global)
             cut = t0_dt + timedelta(seconds=float(args.settle_s))
             iso_events = iso_events[iso_events["timestamp"] >= cut]
-        ts_vals = to_seconds(iso_events["timestamp"])
+        ts_vals = iso_events["timestamp"].map(to_epoch_seconds).to_numpy()
         times_dict = {iso: ts_vals}
         weights_map = {iso: iso_events["weight"].values}
         fit_cfg = {
@@ -1684,7 +1688,7 @@ def main(argv=None):
                 )
                 mask = probs > 0
                 filtered_df = df_analysis[mask]
-                ts_vals = to_seconds(filtered_df["timestamp"])
+                ts_vals = filtered_df["timestamp"].map(to_epoch_seconds).to_numpy()
                 times_dict = {iso: ts_vals}
                 weights_local = {iso: probs[mask]}
                 cfg_fit = {

--- a/baseline_utils.py
+++ b/baseline_utils.py
@@ -4,8 +4,7 @@ from datetime import datetime
 import numpy as np
 import pandas as pd
 
-from utils import parse_datetime
-from utils.time_utils import tz_localize_utc, tz_convert_utc
+from utils.time_utils import parse_timestamp, tz_localize_utc, tz_convert_utc
 from radon.baseline import (
     subtract_baseline_counts,
     subtract_baseline_rate,
@@ -61,7 +60,7 @@ def _to_datetime64(events: pd.DataFrame | pd.Series) -> np.ndarray:
         if getattr(ser.dtype, "tz", None) is None:
             ser = tz_localize_utc(ser)
     else:
-        ser = col.map(parse_datetime)
+        ser = col.map(parse_timestamp)
 
     ser = tz_convert_utc(ser)
     return ser.to_numpy(dtype="datetime64[ns]")
@@ -113,8 +112,8 @@ def apply_baseline_subtraction(
     if live_time_analysis is None:
         live_time_analysis = live_an
 
-    t0 = parse_datetime(t_base0)
-    t1 = parse_datetime(t_base1)
+    t0 = parse_timestamp(t_base0)
+    t1 = parse_timestamp(t_base1)
     ts_full = _to_datetime64(df_full)
     ts_int = ts_full.view("int64")
     t0_ns = t0.value

--- a/io_utils.py
+++ b/io_utils.py
@@ -14,8 +14,8 @@ from typing import Any, Iterator
 from constants import load_nuclide_overrides
 
 import numpy as np
-from utils import to_native, parse_datetime, to_seconds
-from utils.time_utils import tz_convert_utc
+from utils import to_native
+from utils.time_utils import parse_timestamp, to_epoch_seconds, tz_convert_utc
 import jsonschema
 
 
@@ -246,8 +246,8 @@ def ensure_dir(path):
         p.mkdir(parents=True, exist_ok=True)
 
 
-# parse_datetime is re-exported from utils for backward compatibility
-# The implementation now lives in utils.parse_datetime
+# parse_timestamp is provided by :mod:`utils.time_utils` and re-exported from
+# :mod:`utils` for backward compatibility with older code.
 
 
 def _merge_dicts(base: dict, override: dict) -> dict:
@@ -343,7 +343,7 @@ def load_events(csv_path, *, column_map=None):
     if "timestamp" in df.columns:
         def _safe_parse(val):
             try:
-                return parse_datetime(val)
+                return parse_timestamp(val)
             except Exception:
                 return pd.NaT
 
@@ -397,7 +397,7 @@ def apply_burst_filter(df, cfg=None, mode="rate"):
     df : pandas.DataFrame
         Event data containing a ``timestamp`` column. Values may be numeric
         epoch seconds or ``datetime64`` objects. All timestamps are first
-        converted to ``datetime64`` using :func:`parse_datetime` and the
+        converted to ``datetime64`` using :func:`parse_timestamp` and the
         DataFrame is updated accordingly. Seconds are only used internally for
         histogram calculations.
     cfg : dict, optional
@@ -429,14 +429,14 @@ def apply_burst_filter(df, cfg=None, mode="rate"):
 
     ts = out_df["timestamp"]
     if not pd.api.types.is_datetime64_any_dtype(ts):
-        ts = ts.map(parse_datetime)
+        ts = ts.map(parse_timestamp)
     else:
         if ts.dt.tz is None:
-            ts = ts.map(parse_datetime)
+            ts = ts.map(parse_timestamp)
         else:
             ts = tz_convert_utc(ts)
     out_df["timestamp"] = ts
-    times_sec = to_seconds(ts)
+    times_sec = ts.map(to_epoch_seconds).to_numpy()
 
     # ───── micro-burst veto ─────
     if mode in ("micro", "both"):
@@ -474,14 +474,14 @@ def apply_burst_filter(df, cfg=None, mode="rate"):
             # Recalculate times after removing events
             ts = out_df["timestamp"]
             if not pd.api.types.is_datetime64_any_dtype(ts):
-                ts = ts.map(parse_datetime)
+                ts = ts.map(parse_timestamp)
             else:
                 if ts.dt.tz is None:
-                    ts = ts.map(parse_datetime)
+                    ts = ts.map(parse_timestamp)
                 else:
                     ts = tz_convert_utc(ts)
             out_df["timestamp"] = ts
-            times_sec = to_seconds(ts)
+            times_sec = ts.map(to_epoch_seconds).to_numpy()
 
     # ───── rate-based veto ─────
     if mode in ("rate", "both"):

--- a/tests/test_interval_parsing.py
+++ b/tests/test_interval_parsing.py
@@ -5,7 +5,8 @@ from datetime import datetime, timezone, timedelta
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import analyze
-from utils import parse_time_arg, parse_datetime
+from utils import parse_time_arg
+from utils.time_utils import parse_timestamp
 from dateutil.tz import gettz
 import pandas as pd
 
@@ -31,10 +32,10 @@ def test_config_interval_parsing_to_datetime():
         "baseline": {"range": ["1970-01-01T00:00:01Z", "1970-01-01T00:00:02Z"]},
         "analysis": {"radon_interval": ["1970-01-01T00:00:03Z", "1970-01-01T00:00:04Z"]},
     }
-    b_start = parse_datetime(cfg["baseline"]["range"][0])
-    b_end = parse_datetime(cfg["baseline"]["range"][1])
-    r_start = parse_datetime(cfg["analysis"]["radon_interval"][0])
-    r_end = parse_datetime(cfg["analysis"]["radon_interval"][1])
+    b_start = parse_timestamp(cfg["baseline"]["range"][0])
+    b_end = parse_timestamp(cfg["baseline"]["range"][1])
+    r_start = parse_timestamp(cfg["analysis"]["radon_interval"][0])
+    r_end = parse_timestamp(cfg["analysis"]["radon_interval"][1])
     for dt in (b_start, b_end, r_start, r_end):
         assert dt.tzinfo is not None
         assert dt.tzinfo.utcoffset(dt) == timedelta(0)

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -17,7 +17,7 @@ from io_utils import (
     apply_burst_filter,
     Summary,
 )
-from utils import parse_datetime
+from utils.time_utils import parse_timestamp
 
 
 def test_load_config(tmp_path):
@@ -145,7 +145,7 @@ def test_load_events_column_aliases(tmp_path):
     df.to_csv(p, index=False)
     loaded = load_events(p)
     assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
-    assert list(loaded["timestamp"])[0] == parse_datetime(1000)
+    assert list(loaded["timestamp"])[0] == parse_timestamp(1000)
     assert list(loaded["adc"])[0] == 1250
     assert "time" not in loaded.columns
     assert "adc_ch" not in loaded.columns
@@ -172,7 +172,7 @@ def test_load_events_custom_columns(tmp_path):
     }
     loaded = load_events(p, column_map=column_map)
     assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
-    assert list(loaded["timestamp"])[0] == parse_datetime(1000)
+    assert list(loaded["timestamp"])[0] == parse_timestamp(1000)
     assert list(loaded["adc"])[0] == 1250
     assert "ftimestamps" not in loaded.columns
 
@@ -211,7 +211,7 @@ def test_load_events_string_nan(tmp_path):
     df.to_csv(p, index=False)
     loaded = load_events(p)
     assert len(loaded) == 1
-    assert loaded["timestamp"].iloc[0] == parse_datetime(1000)
+    assert loaded["timestamp"].iloc[0] == parse_timestamp(1000)
 
 
 def test_write_summary_and_copy_config(tmp_path):

--- a/tests/test_parse_datetime.py
+++ b/tests/test_parse_datetime.py
@@ -6,55 +6,55 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from utils import parse_datetime
+from utils.time_utils import parse_timestamp
 
 
-def test_parse_datetime_iso_string():
-    ts = parse_datetime("1970-01-01T00:00:00Z")
+def test_parse_timestamp_iso_string():
+    ts = parse_timestamp("1970-01-01T00:00:00Z")
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
-def test_parse_datetime_numeric():
-    ts = parse_datetime(42)
+def test_parse_timestamp_numeric():
+    ts = parse_timestamp(42)
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp(42, unit="s", tz="UTC")
 
 
-def test_parse_datetime_numeric_str():
-    ts = parse_datetime("42")
+def test_parse_timestamp_numeric_str():
+    ts = parse_timestamp("42")
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp(42, unit="s", tz="UTC")
 
 
-def test_parse_datetime_naive_datetime():
+def test_parse_timestamp_naive_datetime():
     dt = datetime(1970, 1, 1)
-    ts = parse_datetime(dt)
+    ts = parse_timestamp(dt)
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
-def test_parse_datetime_float():
-    ts = parse_datetime(42.5)
+def test_parse_timestamp_float():
+    ts = parse_timestamp(42.5)
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp(42.5, unit="s", tz="UTC")
 
 
-def test_parse_datetime_iso_without_tz():
-    ts = parse_datetime("1970-01-01T00:00:00")
+def test_parse_timestamp_iso_without_tz():
+    ts = parse_timestamp("1970-01-01T00:00:00")
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
-def test_parse_datetime_iso_with_offset():
-    ts = parse_datetime("1970-01-01T01:00:00+01:00")
+def test_parse_timestamp_iso_with_offset():
+    ts = parse_timestamp("1970-01-01T01:00:00+01:00")
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 
 
-def test_parse_datetime_datetime_with_tz():
+def test_parse_timestamp_datetime_with_tz():
     dt = datetime(1970, 1, 1, 1, tzinfo=timezone(timedelta(hours=1)))
-    ts = parse_datetime(dt)
+    ts = parse_timestamp(dt)
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp("1970-01-01T00:00:00Z")
 

--- a/utils/time_utils.py
+++ b/utils/time_utils.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+from typing import Union
+
 import pandas as pd
 from pandas.api.types import is_datetime64_any_dtype
 
@@ -43,9 +46,9 @@ def ensure_utc(series: pd.Series) -> pd.Series:
 
 
 
-def parse_timestamp(value):
-    """Return ``value`` parsed to a UTC ``pandas.Timestamp``."""
-    from datetime import datetime, timezone
+def parse_timestamp(value: Union[str, int, float, datetime, pd.Timestamp]) -> pd.Timestamp:
+    """Return ``value`` parsed to a UTC :class:`pandas.Timestamp`."""
+    from datetime import timezone
     from dateutil import parser as date_parser
 
     if isinstance(value, pd.Timestamp):
@@ -83,9 +86,9 @@ def parse_timestamp(value):
     raise ValueError(f"invalid timestamp: {value!r}")
 
 
-def to_epoch_seconds(ts_or_str) -> float:
-    """Return Unix epoch seconds for ``ts_or_str``."""
+def to_epoch_seconds(ts: Union[pd.Timestamp, str, int, float]) -> float:
+    """Return Unix epoch seconds for ``ts``."""
 
-    ts = parse_timestamp(ts_or_str)
-    return ts.timestamp()
+    ts_parsed = parse_timestamp(ts)
+    return ts_parsed.timestamp()
 


### PR DESCRIPTION
## Summary
- provide new parse_timestamp and to_epoch_seconds helpers in `utils/time_utils`
- delegate legacy helpers in `utils.__init__` to these functions
- refactor loaders and analysis code to use the new utilities
- update README and unit tests accordingly

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b766c6610832bacf58c82d75d30ac