### PR TITLE
Implement pure config merge and validate required keys

### DIFF
--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -64,7 +64,7 @@ def test_load_config_missing_section(tmp_path):
     p = tmp_path / "cfg.json"
     with open(p, "w") as f:
         json.dump(cfg, f)
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         load_config(p)
 
 


### PR DESCRIPTION
## Summary
- add `merge_cfg` for functional config merging
- validate required keys before applying defaults
- adjust unit test for required key error

## Testing
- `python -m py_compile io_utils.py analyze.py`
- `pytest -q` *(fails: Package 'numpy' is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_685b7a243574832b90d77382b7a8bcd3