### PR TITLE
Add baseline subtract returning error

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -113,11 +113,11 @@ from utils.time_utils import (
     tz_convert_utc,
 )
 from baseline_utils import (
-    subtract_baseline_dataframe,
     subtract_baseline_counts,
     subtract_baseline_rate,
     compute_dilution_factor,
 )
+import baseline
 
 
 def _fit_params(obj: FitResult | Mapping[str, float] | None) -> FitParams:
@@ -1237,7 +1237,7 @@ def main(argv=None):
         t_base0 = args.baseline_range[0]
         t_base1 = args.baseline_range[1]
         edges = adc_hist_edges(df_analysis["adc"].values, hist_bins)
-        df_analysis = subtract_baseline_dataframe(
+        df_analysis, _ = baseline.subtract(
             df_analysis,
             events_all,
             bins=edges,

--- a/baseline.py
+++ b/baseline.py
@@ -1,5 +1,6 @@
-from baseline_utils import rate_histogram, subtract_baseline_dataframe
+from baseline_utils import rate_histogram, subtract
 
-subtract_baseline = subtract_baseline_dataframe
+# Backwards compatibility
+subtract_baseline = subtract
 
-__all__ = ["rate_histogram", "subtract_baseline", "subtract_baseline_dataframe"]
+__all__ = ["rate_histogram", "subtract", "subtract_baseline"]

--- a/baseline_noise.py
+++ b/baseline_noise.py
@@ -1,8 +1,9 @@
 import numpy as np
 from scipy.optimize import curve_fit
 from constants import CURVE_FIT_MAX_EVALS
+from baseline_utils import subtract
 
-__all__ = ["estimate_baseline_noise"]
+__all__ = ["estimate_baseline_noise", "subtract"]
 
 
 def _constant(x, A):

--- a/tests/test_baseline_datetime.py
+++ b/tests/test_baseline_datetime.py
@@ -26,7 +26,7 @@ def test_subtract_baseline_datetime_column():
     df_bl = pd.DataFrame({"timestamp": ts_bl, "adc": np.tile([1,2,3,4,5],10)})
     df_full = pd.concat([df_an, df_bl], ignore_index=True)
     bins = np.arange(0, 7)
-    out = baseline.subtract_baseline(
+    out, _ = baseline.subtract(
         df_an,
         df_full,
         bins=bins,

--- a/tests/test_datetime_pipeline.py
+++ b/tests/test_datetime_pipeline.py
@@ -31,7 +31,7 @@ def test_datetime_pipeline(tmp_path):
     assert str(loaded["timestamp"].dtype) == "datetime64[ns, UTC]"
 
     bins = np.arange(0, 5)
-    subtracted = baseline.subtract_baseline(
+    subtracted, _ = baseline.subtract(
         loaded,
         loaded,
         bins=bins,

--- a/tests/test_timestamp_dtype.py
+++ b/tests/test_timestamp_dtype.py
@@ -30,7 +30,7 @@ def test_subtract_baseline_preserves_dtype():
     ts = pd.date_range("1970-01-01", periods=3, freq="s", tz="UTC")
     df = pd.DataFrame({"timestamp": ts, "adc": [1, 2, 3]})
     bins = np.arange(0, 5)
-    out = baseline.subtract_baseline(
+    out, _ = baseline.subtract(
         df,
         df,
         bins=bins,


### PR DESCRIPTION
## Summary
- implement `baseline_utils.subtract` with quadrature error propagation
- expose new helper in `baseline` and `baseline_noise`
- use `baseline.subtract` in `analyze.py`
- update tests to call `baseline.subtract`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7eb8b308832b811bec41ae1710c6