### PR TITLE
Add fallback control and strict baseline checks

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+    "allow_fallback": false,
     "pipeline": {
         "log_level": "INFO",
         "random_seed": null

--- a/config_defaults.json
+++ b/config_defaults.json
@@ -1,4 +1,5 @@
 {
+    "allow_fallback": false,
     "time_fit": {
         "window_po218": [3.05e6, 3.25e6]
     }

--- a/io_utils.py
+++ b/io_utils.py
@@ -108,6 +108,7 @@ CONFIG_SCHEMA = {
             },
             "required": ["log_level"],
         },
+        "allow_fallback": {"type": "boolean"},
         "spectral_fit": {
             "type": "object",
             "properties": {"expected_peaks": {"type": "object"}},

--- a/tests/test_adc_drift.py
+++ b/tests/test_adc_drift.py
@@ -11,9 +11,10 @@ from fitting import FitResult, FitParams
 from dataclasses import asdict
 
 
-def _write_basic(tmp_path, drift_rate, mode="linear", params=None):
+def _write_basic(tmp_path, drift_rate, mode="linear", params=None, *, allow_fallback=False):
     cfg = {
         "pipeline": {"log_level": "INFO"},
+        "allow_fallback": allow_fallback,
         "calibration": {},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {"do_time_fit": False},
@@ -42,7 +43,7 @@ def _write_basic(tmp_path, drift_rate, mode="linear", params=None):
 
 
 def test_adc_drift_applied(tmp_path, monkeypatch):
-    cfg_path, data_path = _write_basic(tmp_path, 1.0)
+    cfg_path, data_path = _write_basic(tmp_path, 1.0, allow_fallback=True)
     captured = {}
 
     def fake_shift(adc, ts, rate, t_ref=None, mode="linear", params=None):
@@ -256,7 +257,7 @@ def test_adc_drift_piecewise_cfg(tmp_path, monkeypatch):
 
 def test_adc_drift_warning_on_failure(tmp_path, monkeypatch, capsys):
     """ADC drift correction failure should emit a warning but not abort."""
-    cfg_path, data_path = _write_basic(tmp_path, 1.0)
+    cfg_path, data_path = _write_basic(tmp_path, 1.0, allow_fallback=True)
 
     def bad_shift(*a, **k):
         raise ValueError("boom")

--- a/tests/test_baseline_range_empty.py
+++ b/tests/test_baseline_range_empty.py
@@ -16,6 +16,7 @@ from fitting import FitResult, FitParams
 def test_cli_baseline_range_empty(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},
+        "allow_fallback": True,
         "baseline": {"range": [0, 5], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
         "calibration": {},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},


### PR DESCRIPTION
## Summary
- add `allow_fallback` setting to configs and schema
- raise `RuntimeError` when baseline events are missing unless fallback is allowed
- re-raise errors in calibration, drift correction, baseline extraction and noise estimation when fallback is disabled
- adapt tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b81edbcdc832b83822c1c0be34be3