### PR TITLE
Add basic smoke tests

### DIFF
--- a/tests/test_baseline_api.py
+++ b/tests/test_baseline_api.py
@@ -1,0 +1,67 @@
+import pytest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import baseline
+import baseline_utils
+from radon import subtract_baseline_counts as rb_counts, subtract_baseline_rate as rb_rate
+from radon.baseline import subtract_baseline_counts as rbc_counts, subtract_baseline_rate as rbc_rate
+import radmon
+
+
+def test_baseline_api_round_trip():
+    counts = 10
+    baseline_counts = 4
+    efficiency = 0.5
+    live_time = 20.0
+    baseline_live_time = 10.0
+    fit_rate = counts / live_time / efficiency
+    fit_sigma = (counts**0.5) / (live_time * efficiency)
+
+    res_utils = baseline_utils.subtract_baseline_counts(
+        counts, efficiency, live_time, baseline_counts, baseline_live_time
+    )
+    res_radon = rbc_counts(
+        counts, efficiency, live_time, baseline_counts, baseline_live_time
+    )
+    res_pkg = rb_counts(
+        counts, efficiency, live_time, baseline_counts, baseline_live_time
+    )
+    assert res_utils == pytest.approx(res_radon)
+    assert res_utils == pytest.approx(res_pkg)
+
+    rate_utils = baseline_utils.subtract_baseline_rate(
+        fit_rate,
+        fit_sigma,
+        counts,
+        efficiency,
+        live_time,
+        baseline_counts,
+        baseline_live_time,
+    )
+    rate_radon = rbc_rate(
+        fit_rate,
+        fit_sigma,
+        counts,
+        efficiency,
+        live_time,
+        baseline_counts,
+        baseline_live_time,
+    )
+    rate_pkg = rb_rate(
+        fit_rate,
+        fit_sigma,
+        counts,
+        efficiency,
+        live_time,
+        baseline_counts,
+        baseline_live_time,
+    )
+    assert rate_utils == pytest.approx(rate_radon)
+    assert rate_utils == pytest.approx(rate_pkg)
+
+    # alias exposures
+    assert baseline.subtract_baseline is baseline_utils.subtract
+    assert radmon.subtract_baseline is baseline.subtract_baseline

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+import matplotlib.pyplot as plt
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+
+
+def test_pipeline_smoke(tmp_path, monkeypatch):
+    """Run the full pipeline on a tiny dataset."""
+    data_dir = Path(__file__).resolve().parent / "data" / "mini_run"
+    csv = data_dir / "run.csv"
+    cfg = data_dir / "config.json"
+
+    # avoid writing plot files
+    monkeypatch.setattr(plt, "savefig", lambda *a, **k: None)
+
+    analyze.main(["-i", str(csv), "-c", str(cfg), "-o", str(tmp_path)])
+
+    summary_files = list(tmp_path.glob("*/summary.json"))
+    assert len(summary_files) == 1
+    with open(summary_files[0], "r") as f:
+        summary = json.load(f)
+    assert "time_fit" in summary

--- a/tests/test_plot_paths.py
+++ b/tests/test_plot_paths.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from plot_utils.paths import get_targets
+
+
+def test_get_targets_default(tmp_path):
+    out = tmp_path / "plot"
+    targets = get_targets(None, out)
+    assert list(targets.keys()) == ["png"]
+    assert targets["png"].suffix == ".png"
+
+
+def test_get_targets_config_formats(tmp_path):
+    out = tmp_path / "plot.png"
+    cfg = {"plotting": {"plot_save_formats": ["png", "pdf"]}}
+    targets = get_targets(cfg, out)
+    assert set(targets.keys()) == {"png", "pdf"}
+    assert targets["pdf"].suffix == ".pdf"


### PR DESCRIPTION
## Summary
- add pipeline smoke test for tiny sample run
- verify baseline helper API works across modules
- test plot path helper for file extension mapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b856ac3b0832ba68283fb032b00b2