### PR TITLE
Handle datetime arrays in plot_time_series

### DIFF
--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -114,6 +114,27 @@ def plot_time_series(
     if fit_results is None:
         fit_results = {}
 
+    # Convert timestamps to UNIX seconds when datetime64 or datetime objects
+    ts_array = np.asarray(all_timestamps)
+    if np.issubdtype(ts_array.dtype, "datetime64"):
+        all_timestamps = ts_array.astype("int64") / 1e9
+    elif np.issubdtype(ts_array.dtype, np.object_):
+        if ts_array.size > 0 and isinstance(ts_array.flat[0], datetime):
+            all_timestamps = np.array([dt.timestamp() for dt in ts_array], dtype=float)
+        else:
+            all_timestamps = ts_array.astype(float)
+    else:
+        all_timestamps = ts_array.astype(float)
+
+    if isinstance(t_start, datetime):
+        t_start = t_start.timestamp()
+    elif isinstance(t_start, np.datetime64):
+        t_start = float(t_start.astype("int64") / 1e9)
+    if isinstance(t_end, datetime):
+        t_end = t_end.timestamp()
+    elif isinstance(t_end, np.datetime64):
+        t_end = float(t_end.astype("int64") / 1e9)
+
     def _cfg_get(cfg, key, default=None):
         """Lookup ``key`` in ``cfg``.
 

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -804,3 +804,29 @@ def test_plot_time_series_uncertainty_band(tmp_path, monkeypatch):
     assert band_called.get("ok")
 
 
+def test_plot_time_series_datetime64(tmp_path):
+    times = np.array(
+        [
+            np.datetime64("1970-01-01T00:00:01"),
+            np.datetime64("1970-01-01T00:00:02"),
+            np.datetime64("1970-01-01T00:00:03"),
+        ]
+    )
+    energies = np.array([7.7, 7.8, 7.7])
+    cfg = basic_config()
+    cfg.update({"plot_time_binning_mode": "auto", "time_bins_fallback": 1})
+    out_png = tmp_path / "ts_dt.png"
+
+    plot_time_series(
+        times,
+        energies,
+        None,
+        times[0],
+        times[-1] + np.timedelta64(1, "s"),
+        cfg,
+        str(out_png),
+    )
+
+    assert out_png.exists()
+
+


### PR DESCRIPTION
## Summary
- make plot_time_series robust to datetime inputs
- test plotting with numpy.datetime64 timestamps

## Testing
- `pytest -k plot_utils -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c189e9430832b9f75b4ff5f67e60c