### PR TITLE
Module 12 fixed slope calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ default is `400`.  Set it to `null` to skip the cut entirely.  The
 `analyze.py` pipeline applies this filter right after loading the event
 CSV.
 
+`slope_MeV_per_ch` fixes the ADC→MeV slope. When set, only the Po‑214 peak
+is used to compute the intercept and the two‑point calibration step is
+skipped.
+
 The command-line option `--noise-cutoff` overrides this value when
 provided. When you supply the option, its argument entirely replaces the
 value from the configuration file.

--- a/config_defaults.json
+++ b/config_defaults.json
@@ -1,5 +1,8 @@
 {
     "allow_fallback": false,
+    "calibration": {
+        "slope_MeV_per_ch": null
+    },
     "time_fit": {
         "window_po218": [3.05e6, 3.25e6]
     }

--- a/io_utils.py
+++ b/io_utils.py
@@ -184,6 +184,7 @@ CONFIG_SCHEMA = {
                 "use_emg": {"type": "boolean"},
                 "init_sigma_adc": {"type": "number", "minimum": 0},
                 "init_tau_adc": {"type": "number", "minimum": 0},
+                "slope_MeV_per_ch": {"type": ["number", "null"]},
                 "sanity_tolerance_mev": {"type": "number", "minimum": 0},
                 "known_energies": {"type": "object"},
             },

--- a/tests/test_fixed_slope.py
+++ b/tests/test_fixed_slope.py
@@ -1,0 +1,26 @@
+import numpy as np
+import pytest
+
+from calibration import derive_calibration_constants
+
+
+def test_fixed_slope_calibration():
+    rng = np.random.default_rng(0)
+    adc = rng.normal(1800, 2, 1000)
+
+    cfg = {
+        "calibration": {
+            "slope_MeV_per_ch": 0.00435,
+            "nominal_adc": {"Po214": 1800},
+            "peak_search_radius": 10,
+            "peak_prominence": 5,
+            "peak_width": 1,
+            "init_sigma_adc": 2.0,
+        }
+    }
+
+    res = derive_calibration_constants(adc, cfg)
+    idx = {exp: i for i, exp in enumerate(res._exponents)}
+    slope = res.coeffs[idx[1]]
+
+    assert slope == pytest.approx(0.00435)


### PR DESCRIPTION
## Summary
- support fixed slope calibration via `slope_MeV_per_ch`
- implement helper `fixed_slope_calibration`
- allow the key in config schema and defaults
- document in README
- test fixed slope calibration

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c3b569f68832b87da15aab3ce671d