### PR TITLE
Update calibration defaults

### DIFF
--- a/config_defaults.json
+++ b/config_defaults.json
@@ -1,7 +1,8 @@
 {
     "allow_fallback": false,
     "calibration": {
-        "slope_MeV_per_ch": null
+        "slope_MeV_per_ch": null,
+        "intercept_MeV": null
     },
     "time_fit": {
         "window_po218": [3.05e6, 3.25e6]


### PR DESCRIPTION
## Summary
- add `intercept_MeV` to the calibration defaults

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c43ccf0a4832b8c69a94db914242b