### PR TITLE
Add intercept check in fixed slope test

### DIFF
--- a/tests/test_fixed_slope.py
+++ b/tests/test_fixed_slope.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from calibration import derive_calibration_constants
 
 
@@ -20,4 +21,5 @@ def test_fixed_slope_calibration():
 
     res = derive_calibration_constants(adc, cfg)
     assert res["a"] == 0.00435
+    assert res["c"] == pytest.approx(-0.14, abs=0.02)
     assert res["calibration_valid"] is True


### PR DESCRIPTION
## Summary
- import pytest in `tests/test_fixed_slope.py`
- verify calibration intercept with approx check

## Testing
- `PYTHONPATH=. pytest tests/test_fixed_slope.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685c43cffd1c832bacfa52ff9e3949e0