### PR TITLE
Fix default plot_time_style doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,8 +393,8 @@ Values with this suffix are automatically converted to MeV.
 Each entry is optional and only affects the scan when present.
 
 `plot_time_style` chooses how the histogram is drawn in the time-series
-plot.  Use `"steps"` (default) for a stepped histogram or `"lines"` to
-connect bin centers with straight lines.  The line style is useful when
+plot.  Use `"lines"` (default) to connect bin centers with straight lines
+or `"steps"` for a stepped histogram.  The line style is useful when
 overlaying multiple isotopes so one does not obscure the other.
 
 `overlay_isotopes` under `plotting` keeps both isotope windows intact


### PR DESCRIPTION
## Summary
- document `plot_time_style` default as `"lines"`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pymc')*

------
https://chatgpt.com/codex/tasks/task_e_685c49086c98832ba48912b3b48b9f6a