### PR TITLE
Pin compatible numpy/scipy versions and add runtime check

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -6,6 +6,9 @@ from .efficiency import (
     calc_decay_efficiency,
     blue_combine,
 )
+from .version_check import check_versions as _check_versions
+
+_check_versions()
 
 __all__ = [
     "calc_spike_efficiency",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy>=1.20,<2
-scipy>=1.11.4
+numpy>=1.23.5,<2.3
+scipy>=1.11.4,<1.13
 matplotlib>=3.3
 pytest>=6.0
 pandas==1.5.3

--- a/version_check.py
+++ b/version_check.py
@@ -1,0 +1,15 @@
+from packaging.version import Version
+import numpy
+import scipy
+
+def check_versions():
+    np_version = Version(numpy.__version__)
+    sp_version = Version(scipy.__version__)
+    if np_version >= Version("2.3"):
+        raise RuntimeError(
+            f"NumPy {numpy.__version__} is not supported; install <2.3 for compatibility."
+        )
+    if sp_version >= Version("1.13"):
+        raise RuntimeError(
+            f"SciPy {scipy.__version__} is not supported; install <1.13 or upgrade SciPy to one built for NumPy {numpy.__version__}."
+        )


### PR DESCRIPTION
## Summary
- enforce narrower numpy and scipy version ranges
- add a runtime check that raises an error if incompatible versions are imported

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ef3d1054832ba9db33809c8ee6a3