### PR TITLE
Restrict NumPy version for SciPy wheels

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.20,<2
+numpy>=1.23.5,<2.3
 scipy>=1.11.4
 matplotlib>=3.3
 pytest>=6.0


### PR DESCRIPTION
## Summary
- limit NumPy to `<2.3` for compatibility with SciPy 1.13 wheels

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ef3d1054832ba9db33809c8ee6a3