### PR TITLE
Update column defaults

### DIFF
--- a/config_defaults.json
+++ b/config_defaults.json
@@ -6,5 +6,9 @@
     },
     "time_fit": {
         "window_po218": [3.05e6, 3.25e6]
+    },
+    "columns": {
+        "timestamp": "timestamp",
+        "adc": "adc"
     }
 }


### PR DESCRIPTION
## Summary
- add default column names for `timestamp` and `adc`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f414d3a4832b9ec258bce9c46df1