### PR TITLE
Update default column names

### DIFF
--- a/config.json
+++ b/config.json
@@ -16,8 +16,8 @@
 
     },
     "columns": {
-        "timestamp": "timestamps",
-        "adc": "adc_channels"
+        "timestamp": "timestamp",
+        "adc": "adc"
     },
     "baseline": {
         "range": ["2023-08-01T00:00:00Z", "2023-08-02T23:59:59Z"],

--- a/config_defaults.json
+++ b/config_defaults.json
@@ -6,5 +6,9 @@
     },
     "time_fit": {
         "window_po218": [3.05e6, 3.25e6]
+    },
+    "columns": {
+        "timestamp": "timestamp",
+        "adc": "adc"
     }
 }


### PR DESCRIPTION
## Summary
- set default column names to `timestamp` and `adc`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: numpy/pandas binary incompatibility)*

------
https://chatgpt.com/codex/tasks/task_e_6861f414d3a4832b9ec258bce9c46df1