### PR TITLE
Update default column names

### DIFF
--- a/config.json
+++ b/config.json
@@ -16,8 +16,8 @@
 
     },
     "columns": {
-        "timestamp": "timestamps",
-        "adc": "adc_channels"
+        "timestamp": "timestamp",
+        "adc": "adc"
     },
     "baseline": {
         "range": ["2023-08-01T00:00:00Z", "2023-08-02T23:59:59Z"],


### PR DESCRIPTION
## Summary
- adjust columns in `config.json` to use canonical names `timestamp` and `adc`

## Testing
- `pytest -q` *(fails: Package 'numpy' is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_6861f414d3a4832b9ec258bce9c46df1