### PR TITLE
Clamp negative radon activity in summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,8 @@ activity versus time.  When either `--ambient-file` or
 `--ambient-concentration` is supplied an additional plot
 `equivalent_air.png` shows the volume of ambient air containing the same
 activity.
+When the extrapolated radon activity is negative a warning is logged and
+the value is clamped to zero before converting it to a concentration.
 The Po‑214 activity alone is plotted in `radon_activity_po214.png`. When
 ambient concentration data are available, `equivalent_air_po214.png`
 shows the equivalent air volume derived from this Po‑214 activity.

--- a/analyze.py
+++ b/analyze.py
@@ -1963,6 +1963,12 @@ def main(argv=None):
         rate218, err218, eff_po218, rate214, err214, eff_po214
     )
 
+    if A_radon < 0:
+        logging.warning(
+            "Negative radon activity %.3f Bq - using 0", A_radon
+        )
+        A_radon = 0.0
+
     # Convert activity to a concentration per liter of monitor volume and the
     # total amount of radon present in just the assay sample.
     conc, dconc, total_bq, dtotal_bq = compute_total_radon(

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -1,8 +1,27 @@
 import sys
+import json
 from pathlib import Path
 import pytest
+import logging
+import pandas as pd
+import numpy as np
+from dataclasses import asdict
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import types, importlib.machinery
+_pkg = types.ModuleType("RMTest")
+_pkg.__spec__ = importlib.machinery.ModuleSpec("RMTest", loader=None, is_package=True)
+_pkg.__path__ = []
+_vcheck = types.ModuleType("RMTest.version_check")
+_vcheck.check_versions = lambda: None
+sys.modules.setdefault("RMTest", _pkg)
+sys.modules.setdefault("RMTest.version_check", _vcheck)
+sys.modules.setdefault("version_check", _vcheck)
+
+import radon_activity
+from calibration import CalibrationResult
+from fitting import FitResult, FitParams
 from radon_activity import (
     compute_radon_activity,
     compute_total_radon,
@@ -10,7 +29,6 @@ from radon_activity import (
     radon_delta,
 )
 import math
-import numpy as np
 
 
 def test_compute_radon_activity_weighted():
@@ -287,3 +305,77 @@ def test_radon_delta_invalid_half_life():
         radon_delta(0.0, 2.0, 1.0, 0.1, 2.0, 0.2, 0.0)
     with pytest.raises(ValueError):
         radon_delta(0.0, 2.0, 1.0, 0.1, 2.0, 0.2, -5.0)
+
+
+def test_negative_radon_activity_clamped(tmp_path, monkeypatch, caplog):
+    import analyze
+
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "baseline": {"monitor_volume_l": 10.0, "sample_volume_l": 5.0},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": True, "window_po214": [7, 9], "hl_po214": [1.0, 0.0], "eff_po214": [1.0, 0.0], "flags": {}},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1],
+        "fBits": [0],
+        "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")],
+        "adc": [8],
+        "fchannel": [1],
+    })
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+
+    monkeypatch.setattr(radon_activity, "compute_radon_activity", lambda *a, **k: (-5.0, 0.5))
+
+    captured = {}
+
+    def fake_write(out_dir, summary, timestamp=None):
+        captured["summary"] = asdict(summary)
+        d = Path(out_dir) / (timestamp or "x")
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config", str(cfg_path),
+        "--input", str(data_path),
+        "--output_dir", str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+
+    with caplog.at_level(logging.WARNING):
+        analyze.main()
+
+    summary = captured.get("summary", {})
+    radon_res = summary.get("radon_results", {})
+    assert radon_res.get("radon_activity_Bq", {}).get("value") == pytest.approx(0.0)
+    assert radon_res.get("radon_activity_Bq", {}).get("uncertainty") == pytest.approx(0.5)
+    assert radon_res.get("radon_concentration_Bq_per_L", {}).get("value") == pytest.approx(0.0)
+    assert radon_res.get("total_radon_in_sample_Bq", {}).get("value") == pytest.approx(0.0)
+    assert "Negative radon activity" in caplog.text


### PR DESCRIPTION
## Summary
- clamp negative radon activity to zero in analyze.py
- document clamping behaviour in README
- test new behaviour in `tests/test_radon_activity.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68621df6f3d8832ba81027af07cc6583