### PR TITLE
Add negative radon activity check

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,9 @@ activity versus time.  When either `--ambient-file` or
 `--ambient-concentration` is supplied an additional plot
 `equivalent_air.png` shows the volume of ambient air containing the same
 activity.
+If this radon activity evaluates to a negative value the program raises a
+`ValueError`, indicating that the baseline subtraction or decay fits should be
+checked.
 The Po‑214 activity alone is plotted in `radon_activity_po214.png`. When
 ambient concentration data are available, `equivalent_air_po214.png`
 shows the equivalent air volume derived from this Po‑214 activity.

--- a/analyze.py
+++ b/analyze.py
@@ -1963,6 +1963,11 @@ def main(argv=None):
         rate218, err218, eff_po218, rate214, err214, eff_po214
     )
 
+    if A_radon < 0:
+        raise ValueError(
+            "Computed radon activity is below zero; check baseline subtraction or fit results"
+        )
+
     # Convert activity to a concentration per liter of monitor volume and the
     # total amount of radon present in just the assay sample.
     conc, dconc, total_bq, dtotal_bq = compute_total_radon(

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -1,6 +1,8 @@
 import sys
 from pathlib import Path
 import pytest
+import json
+import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from radon_activity import (
@@ -11,6 +13,7 @@ from radon_activity import (
 )
 import math
 import numpy as np
+import analyze
 
 
 def test_compute_radon_activity_weighted():
@@ -287,3 +290,59 @@ def test_radon_delta_invalid_half_life():
         radon_delta(0.0, 2.0, 1.0, 0.1, 2.0, 0.2, 0.0)
     with pytest.raises(ValueError):
         radon_delta(0.0, 2.0, 1.0, 0.1, 2.0, 0.2, -5.0)
+
+
+def test_main_negative_radon_activity(tmp_path, monkeypatch):
+    """Pipeline fails when radon activity is negative."""
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame(
+        {
+            "fUniqueID": [1],
+            "fBits": [0],
+            "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")],
+            "adc": [8],
+            "fchannel": [1],
+        }
+    )
+    data_path = tmp_path / "data.csv"
+    df.to_csv(data_path, index=False)
+
+    from calibration import CalibrationResult
+
+    cal_mock = CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0)
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "write_summary", lambda *a, **k: str(tmp_path))
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "apply_burst_filter", lambda df, cfg, mode="rate": (df, 0))
+
+    import radon_activity as ra
+
+    monkeypatch.setattr(ra, "compute_radon_activity", lambda *a, **k: (-1.0, 0.5))
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+
+    with pytest.raises(ValueError, match="Computed radon activity is below zero"):
+        analyze.main()


### PR DESCRIPTION
## Summary
- detect negative radon activity in `analyze.py`
- document the new failure mode in README
- cover the behaviour with a new unit test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy.exceptions')*

------
https://chatgpt.com/codex/tasks/task_e_6862a5d7f764832bb5de354f3093fa88