### PR TITLE
Check for negative radon

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1962,6 +1962,8 @@ def main(argv=None):
     A_radon, dA_radon = compute_radon_activity(
         rate218, err218, eff_po218, rate214, err214, eff_po214
     )
+    if A_radon < 0:
+        raise RuntimeError("negative radon activity computed")
 
     # Convert activity to a concentration per liter of monitor volume and the
     # total amount of radon present in just the assay sample.

--- a/tests/test_sample_radon.py
+++ b/tests/test_sample_radon.py
@@ -79,3 +79,59 @@ def test_total_radon_uses_sample_volume(tmp_path, monkeypatch):
     summary = captured.get("summary", {})
     expected = radon_activity.compute_total_radon(5.0, 0.5, 10.0, 5.0)[2]
     assert summary["radon_results"]["total_radon_in_sample_Bq"]["value"] == pytest.approx(expected)
+
+
+def test_negative_radon_activity_raises(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "baseline": {"monitor_volume_l": 10.0, "sample_volume_l": 5.0},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": True, "window_po214": [7, 9], "hl_po214": [1.0, 0.0], "eff_po214": [1.0, 0.0], "flags": {}},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1],
+        "fBits": [0],
+        "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")],
+        "adc": [8],
+        "fchannel": [1],
+    })
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0,0)), 0))
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+
+    monkeypatch.setattr(radon_activity, "compute_radon_activity", lambda *a, **k: (-1.0, 0.5))
+
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config", str(cfg_path),
+        "--input", str(data_path),
+        "--output_dir", str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+
+    with pytest.raises(RuntimeError, match="negative radon activity computed"):
+        analyze.main()


### PR DESCRIPTION
## Summary
- check for negative radon after computing activity
- add unit test for new runtime error

## Testing
- `pytest tests/test_sample_radon.py -q`
- `pytest -k radon_activity -q`

------
https://chatgpt.com/codex/tasks/task_e_6862a69dcc14832b8e4b50b4ec2c7a79