### PR TITLE
Fix dependency versions for stable tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy>=1.23.5,<2.3
-scipy>=1.13
+numpy>=1.23.5,<2
+scipy>=1.12,<1.13
 matplotlib>=3.3
 pytest>=6.0
 pandas==1.5.3

--- a/version_check.py
+++ b/version_check.py
@@ -5,9 +5,9 @@ import scipy
 def check_versions():
     np_version = Version(numpy.__version__)
     sp_version = Version(scipy.__version__)
-    if np_version >= Version("2.3"):
+    if np_version >= Version("2"):
         raise RuntimeError(
-            f"NumPy {numpy.__version__} is not supported; install <2.3 for compatibility."
+            f"NumPy {numpy.__version__} is not supported; install <2 for compatibility."
         )
     if sp_version >= Version("1.13"):
         raise RuntimeError(


### PR DESCRIPTION
## Summary
- pin numpy below 2 and pin scipy to the 1.12 series in requirements
- enforce NumPy <2 in the runtime version check

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862a9d3ddb8832bb6c1f019effe663e