### PR TITLE
Make output_dir optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ the file:
 
 ## Output
 
-The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--job-id` is given the folder `<output_dir>/<job-id>/` is used instead. If the folder already exists run with `--overwrite` to replace it. The directory includes:
+The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--job-id` is given the folder `<output_dir>/<job-id>/` is used instead. If `--output_dir` is omitted it defaults to `results`. If the folder already exists run with `--overwrite` to replace it. The directory includes:
 
 - `summary.json` – calibration and fit summary.
 - `config_used.json` – copy of the configuration used.

--- a/analyze.py
+++ b/analyze.py
@@ -384,8 +384,11 @@ def parse_args(argv=None):
     p.add_argument(
         "--output_dir",
         "-o",
-        required=True,
-        help="Directory under which to create a timestamped analysis folder (override with --job-id)",
+        default="results",
+        help=(
+            "Directory under which to create a timestamped analysis folder "
+            "(override with --job-id; default: results)"
+        ),
     )
     p.add_argument(
         "--timezone",


### PR DESCRIPTION
## Summary
- allow `--output_dir` to be omitted by giving it a default
- document the default in the README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d75e3454832baeb2051ef8589c80