### PR TITLE
Implement debug activity breakdown

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1891,6 +1891,7 @@ def main(argv=None):
 
     corrected_rates = {}
     corrected_unc = {}
+    activity_rows = []
 
     for iso, fit in time_fit_results.items():
         params = _fit_params(fit)
@@ -1930,6 +1931,16 @@ def main(argv=None):
         baseline_unc[iso] = base_sigma
         corrected_rates[iso] = corr_rate
         corrected_unc[iso] = corr_sigma
+        activity_rows.append(
+            {
+                "iso": iso,
+                "raw_rate": params[f"E_{iso}"],
+                "baseline_rate": base_rate,
+                "corrected": corr_rate,
+                "err_raw": err_fit,
+                "err_corrected": corr_sigma,
+            }
+        )
 
     if baseline_rates:
         baseline_info["rate_Bq"] = baseline_rates
@@ -1988,6 +1999,11 @@ def main(argv=None):
         "value": total_bq,
         "uncertainty": dtotal_bq,
     }
+
+    if args.debug:
+        from radon_activity import print_activity_breakdown
+
+        print_activity_breakdown(activity_rows)
 
     if radon_interval is not None:
         from radon_activity import radon_delta

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -8,6 +8,7 @@ from radon_activity import (
     compute_total_radon,
     radon_activity_curve,
     radon_delta,
+    print_activity_breakdown,
 )
 import math
 import numpy as np
@@ -287,3 +288,28 @@ def test_radon_delta_invalid_half_life():
         radon_delta(0.0, 2.0, 1.0, 0.1, 2.0, 0.2, 0.0)
     with pytest.raises(ValueError):
         radon_delta(0.0, 2.0, 1.0, 0.1, 2.0, 0.2, -5.0)
+
+
+def test_print_activity_breakdown(capsys):
+    rows = [
+        {
+            "iso": "Po218",
+            "raw_rate": 0.112,
+            "baseline_rate": 0.027,
+            "corrected": 0.085,
+            "err_raw": 0.012,
+            "err_corrected": 0.01,
+        },
+        {
+            "iso": "Po214",
+            "raw_rate": 0.118,
+            "baseline_rate": 0.026,
+            "corrected": 0.092,
+            "err_raw": 0.013,
+            "err_corrected": 0.011,
+        },
+    ]
+
+    print_activity_breakdown(rows)
+    captured = capsys.readouterr().out
+    assert "Total radon" in captured


### PR DESCRIPTION
## Summary
- add print_activity_breakdown reporter
- output activity table when `--debug` is used
- test that the debug table prints correctly

## Testing
- `pytest tests/test_radon_activity.py::test_print_activity_breakdown -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867e62018a0832b9be41cbb95e1db6d