### PR TITLE
Add negative activity exit policy flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,6 +643,10 @@ The Po‑214 activity alone is plotted in `radon_activity_po214.png`. When
 ambient concentration data are available, `equivalent_air_po214.png`
 shows the equivalent air volume derived from this Po‑214 activity.
 
+If the combined activity of Po‑214 and Po‑218 is negative it is clamped to
+zero by default and the pipeline aborts.  Pass `--allow-negative-activity`
+to continue processing with a total radon value of `0 Bq`.
+
 ## Efficiency Calculations
 
 `efficiency.py` implements helpers to derive efficiencies from spike,

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -1,5 +1,6 @@
 allow_fallback: false
 allow_negative_baseline: false
+allow_negative_activity: false
 calibration:
   slope_MeV_per_ch: null
   intercept_MeV: null

--- a/io_utils.py
+++ b/io_utils.py
@@ -111,6 +111,7 @@ CONFIG_SCHEMA = {
         },
         "allow_fallback": {"type": "boolean"},
         "allow_negative_baseline": {"type": "boolean"},
+        "allow_negative_activity": {"type": "boolean"},
         "spectral_fit": {
             "type": "object",
             "properties": {"expected_peaks": {"type": "object"}},

--- a/radon_activity.py
+++ b/radon_activity.py
@@ -165,6 +165,8 @@ def compute_total_radon(
     err_bq: float,
     monitor_volume: float,
     sample_volume: float,
+    *,
+    allow_negative_activity: bool = False,
 ) -> Tuple[float, float, float, float]:
     """Convert activity into concentration and total radon in the sample volume.
 
@@ -175,7 +177,7 @@ def compute_total_radon(
     Both ``monitor_volume`` and ``sample_volume`` must be non-negative.  A
     ``ValueError`` is raised if ``monitor_volume`` is not positive, if
     ``sample_volume`` is negative, if ``err_bq`` is negative, or if
-    ``activity_bq`` is negative.
+    ``activity_bq`` is negative while ``allow_negative_activity`` is ``False``.
 
     Returns
     -------
@@ -200,7 +202,12 @@ def compute_total_radon(
     if err_bq < 0:
         raise ValueError("err_bq must be non-negative")
 
+    was_neg = activity_bq < 0
     activity_bq, err_bq = clamp_non_negative(activity_bq, err_bq)
+    if was_neg and not allow_negative_activity:
+        raise RuntimeError(
+            "Negative activity encountered. Re-run with --allow_negative_activity to override"
+        )
     if math.isnan(activity_bq):
         raise ValueError("activity_bq must not be NaN")
     if err_bq == 0:

--- a/tests/test_interval_parsing.py
+++ b/tests/test_interval_parsing.py
@@ -39,3 +39,12 @@ def test_config_interval_parsing_to_datetime():
     for dt in (b_start, b_end, r_start, r_end):
         assert dt.tzinfo is not None
         assert dt.tzinfo.utcoffset(dt) == timedelta(0)
+
+def test_parse_allow_negative_activity():
+    args = analyze.parse_args([
+        "--config", "cfg.json",
+        "--input", "data.csv",
+        "--output_dir", "out",
+        "--allow-negative-activity",
+    ])
+    assert args.allow_negative_activity is True

--- a/tests/test_negative_activity_policy.py
+++ b/tests/test_negative_activity_policy.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+import matplotlib.pyplot as plt
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+import radon_activity
+from dataclasses import asdict
+
+
+def _setup(monkeypatch):
+    data_dir = Path(__file__).resolve().parent / "data" / "mini_run"
+    csv = data_dir / "run.csv"
+    cfg = data_dir / "config.json"
+    monkeypatch.setattr(plt, "savefig", lambda *a, **k: None)
+    monkeypatch.setattr(radon_activity, "compute_radon_activity", lambda *a, **k: (-1.0, 0.5))
+    return csv, cfg
+
+
+def test_negative_activity_exit(tmp_path, monkeypatch):
+    csv, cfg = _setup(monkeypatch)
+    with pytest.raises(SystemExit) as excinfo:
+        analyze.main(["-i", str(csv), "-c", str(cfg), "-o", str(tmp_path)])
+    assert excinfo.value.code == 1
+
+
+def test_negative_activity_allowed(tmp_path, monkeypatch):
+    csv, cfg = _setup(monkeypatch)
+    captured = {}
+
+    def fake_write(out_dir, summary, timestamp=None):
+        captured["summary"] = asdict(summary)
+        d = Path(out_dir) / (timestamp or "x")
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    analyze.main([
+        "-i",
+        str(csv),
+        "-c",
+        str(cfg),
+        "-o",
+        str(tmp_path),
+        "--allow-negative-activity",
+    ])
+
+    summary = captured.get("summary", {})
+    assert summary["radon_results"]["total_radon_in_sample_Bq"]["value"] == pytest.approx(0.0)

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -198,9 +198,16 @@ def test_clamp_non_negative():
     assert err == pytest.approx(0.01)
 
 
-def test_compute_total_radon_negative_activity_bq_clamped(caplog):
+def test_compute_total_radon_negative_activity_default_raises():
+    with pytest.raises(RuntimeError):
+        compute_total_radon(-1.0, 0.5, 10.0, 1.0)
+
+
+def test_compute_total_radon_negative_activity_allowed(caplog):
     with caplog.at_level(logging.WARNING):
-        conc, dconc, tot, dtot = compute_total_radon(-1.0, 0.5, 10.0, 1.0)
+        conc, dconc, tot, dtot = compute_total_radon(
+            -1.0, 0.5, 10.0, 1.0, allow_negative_activity=True
+        )
     assert conc == pytest.approx(0.0)
     assert dconc == pytest.approx(0.05)
     assert tot == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- add `--allow-negative-activity` CLI flag to control abort behaviour
- clamp negative radon in `compute_total_radon` and raise `RuntimeError` when flag disabled
- propagate error through `analyze.py` and exit with non-zero code
- support new option in configuration schema and defaults
- document behaviour in README
- add tests for new policy and update existing tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686836164d30832b97269b986baaed7e