### PR TITLE
Handle negative radon activity correctly

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1194,7 +1194,11 @@ def main(argv=None):
     baseline_info = {}
     baseline_counts = {}
     baseline_cfg = cfg.get("baseline", {})
-    isotopes_to_subtract = baseline_cfg.get("isotopes_to_subtract", ["Po214", "Po218"])
+    isotopes_to_subtract = baseline_cfg.get(
+        "isotopes_to_subtract", ["Po214", "Po218"]
+    )
+    if args.baseline_mode == "none":
+        isotopes_to_subtract = []
     baseline_range = None
     if args.baseline_range:
         _log_override("baseline", "range", args.baseline_range)

--- a/radon_activity.py
+++ b/radon_activity.py
@@ -203,11 +203,16 @@ def compute_total_radon(
         raise ValueError("err_bq must be non-negative")
 
     was_neg = activity_bq < 0
-    activity_bq, err_bq = clamp_non_negative(activity_bq, err_bq)
-    if was_neg and not allow_negative_activity:
-        raise RuntimeError(
-            "Negative activity encountered. Re-run with --allow_negative_activity to override"
+    if was_neg:
+        if not allow_negative_activity:
+            raise RuntimeError(
+                "Negative activity encountered. Re-run with --allow_negative_activity to override"
+            )
+        logging.warning(
+            f"Negative activity (value = {activity_bq:.2f} Bq)"
         )
+    else:
+        activity_bq, err_bq = clamp_non_negative(activity_bq, err_bq)
     if math.isnan(activity_bq):
         raise ValueError("activity_bq must not be NaN")
     if err_bq == 0:

--- a/tests/test_negative_activity_policy.py
+++ b/tests/test_negative_activity_policy.py
@@ -49,4 +49,6 @@ def test_negative_activity_allowed(tmp_path, monkeypatch):
     ])
 
     summary = captured.get("summary", {})
-    assert summary["radon_results"]["total_radon_in_sample_Bq"]["value"] == pytest.approx(0.0)
+    radon_res = summary["radon_results"]
+    assert radon_res["radon_concentration_Bq_per_L"]["value"] < 0.0
+    assert radon_res["total_radon_in_sample_Bq"]["value"] == pytest.approx(0.0)

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -208,11 +208,11 @@ def test_compute_total_radon_negative_activity_allowed(caplog):
         conc, dconc, tot, dtot = compute_total_radon(
             -1.0, 0.5, 10.0, 1.0, allow_negative_activity=True
         )
-    assert conc == pytest.approx(0.0)
+    assert conc == pytest.approx(-0.1)
     assert dconc == pytest.approx(0.05)
-    assert tot == pytest.approx(0.0)
+    assert tot == pytest.approx(-0.1)
     assert dtot == pytest.approx(0.05)
-    assert "Clamped negative activity" in caplog.text
+    assert "Negative activity" in caplog.text
 
 
 def test_radon_activity_curve():


### PR DESCRIPTION
## Summary
- respect `--baseline-mode none` by skipping isotope subtraction
- preserve negative activity when `--allow-negative-activity` flag is given
- update tests for new behavior

## Testing
- `pytest -q` *(fails: 50 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686aa09e4718832bae381e2fcd23d64a