### PR TITLE
Fix mypy errors and clean baseline utils

### DIFF
--- a/baseline_utils.py
+++ b/baseline_utils.py
@@ -12,92 +12,23 @@ from radon.baseline import (
 )
 
 
-class BaselineError(Exception):
-    """Raised when baseline diagnostics fail."""
+class BaselineError(RuntimeError):
+    """Raised when baseline subtraction diagnostics fail."""
 
+    pass
 
-def summarize_baseline(cfg: dict, isotopes: list[str]) -> dict[str, tuple[float, float, float]]:
-    """Return baseline diagnostics for *isotopes*.
-
-    Parameters
-    ----------
-    cfg : dict
-        Configuration dictionary containing ``baseline`` and ``time_fit`` sections.
-    isotopes : list of str
-        Isotopes to include in the summary.
-
-    Returns
-    -------
-    dict
-        Mapping of isotope name to ``(raw_rate, baseline_rate, corrected_rate)`` tuples.
-    """
-
-    bl_cfg = cfg.get("baseline")
-    if not bl_cfg:
-        raise BaselineError("baseline configuration missing")
-
-    paths = bl_cfg.get("files")
-    if not paths:
-        raise BaselineError("baseline.files not specified")
-    if isinstance(paths, str):
-        paths = [paths]
-
-    rng = bl_cfg.get("range")
-    if not rng or len(rng) != 2:
-        raise BaselineError("baseline.range must contain [start, end]")
-    start, end = rng
-
-    monitor_vol = float(bl_cfg.get("monitor_volume_l", 0.0))
-    sample_vol = float(bl_cfg.get("sample_volume_l", 0.0))
-    dilution = compute_dilution_factor(monitor_vol, sample_vol)
-
-    events = []
-    for p in paths:
-        df = load_events(p, start=start, end=end)
-        if not df.empty:
-            events.append(df)
-    if not events:
-        raise BaselineError("no baseline events")
-    df_bl = pd.concat(events, ignore_index=True)
-
-    ts = df_bl["timestamp"].astype("int64")
-    live = float((ts.max() - ts.min()) / 1e9)
-    if live <= 0:
-        raise BaselineError("zero live-time in baseline range")
-
-    results = {}
-    for iso in isotopes:
-        win = cfg.get("time_fit", {}).get(f"window_{iso.lower()}")
-        if not win:
-            continue
-        lo, hi = win
-        mask = (df_bl.get("energy_MeV", df_bl["adc"]) >= lo) & (
-            df_bl.get("energy_MeV", df_bl["adc"]) <= hi
-        )
-        counts = int(mask.sum())
-        raw_rate = counts / live if live > 0 else 0.0
-        baseline_rate = raw_rate * dilution
-        results[iso] = (raw_rate, baseline_rate, raw_rate - baseline_rate)
-
-    return results
 
 __all__ = [
     "BaselineError",
-    "summarize_baseline",
     "compute_dilution_factor",
+    "apply_baseline_subtraction",
     "subtract_baseline_dataframe",
     "subtract_baseline_counts",
     "subtract_baseline_rate",
     "rate_histogram",
+    "subtract",
     "summarize_baseline",
-    "BaselineError",
 ]
-
-
-class BaselineError(RuntimeError):
-    """Raised when baseline subtraction yields negative rates."""
-
-    pass
 
 
 

--- a/radon_activity.py
+++ b/radon_activity.py
@@ -372,11 +372,11 @@ def print_activity_breakdown(rows: list[dict[str, object]]) -> None:
     rate214 = err214 = None
     for row in rows:
         if row.get("iso") == "Po218":
-            rate218 = float(row.get("corrected", 0.0))
-            err218 = float(row.get("err_corrected", 0.0))
+            rate218 = float(cast(float, row.get("corrected", 0.0)))
+            err218 = float(cast(float, row.get("err_corrected", 0.0)))
         elif row.get("iso") == "Po214":
-            rate214 = float(row.get("corrected", 0.0))
-            err214 = float(row.get("err_corrected", 0.0))
+            rate214 = float(cast(float, row.get("corrected", 0.0)))
+            err214 = float(cast(float, row.get("err_corrected", 0.0)))
 
     total, sigma = compute_radon_activity(rate218, err218, 1.0, rate214, err214, 1.0)
     print(f"Total radon: {total:.3f} ± {sigma:.3f} Bq")


### PR DESCRIPTION
## Summary
- remove duplicate baseline helpers and error class
- handle type checking in `radon_activity.print_activity_breakdown`

## Testing
- `mypy --config-file mypy.ini`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686aac8d68ec832b931f0b11b5925bbd