### PR TITLE
Add CLI calibration method option

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -517,6 +517,14 @@ def parse_args(argv=None):
         ),
     )
     p.add_argument(
+        "--calibration-method",
+        choices=["two-point", "auto"],
+        help=(
+            "Energy calibration method. Providing this option overrides "
+            "`calibration.method` in config.yaml"
+        ),
+    )
+    p.add_argument(
         "--settle-s",
         type=float,
         help="Discard events occurring this many seconds after the start",
@@ -825,6 +833,10 @@ def main(argv=None):
             int(args.noise_cutoff),
         )
         cfg.setdefault("calibration", {})["noise_cutoff"] = int(args.noise_cutoff)
+
+    if args.calibration_method is not None:
+        _log_override("calibration", "method", args.calibration_method)
+        cfg.setdefault("calibration", {})["method"] = args.calibration_method
 
     if args.allow_negative_baseline:
         cfg["allow_negative_baseline"] = True

--- a/tests/test_calibration_method_cli.py
+++ b/tests/test_calibration_method_cli.py
@@ -1,0 +1,66 @@
+import json
+import sys
+from pathlib import Path
+import pandas as pd
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+from calibration import CalibrationResult
+
+
+def test_calibration_method_cli_overrides(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {"method": "two-point"},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({"fUniqueID": [1], "fBits": [0], "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")], "adc": [1], "fchannel": [1]})
+    data_path = tmp_path / "data.csv"
+    df.to_csv(data_path, index=False)
+
+    called = {}
+
+    def fake_two(*a, **k):
+        called["two"] = True
+        return CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0)
+
+    def fake_auto(*a, **k):
+        called["auto"] = True
+        return CalibrationResult(coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0)
+
+    monkeypatch.setattr(analyze, "derive_calibration_constants", fake_two)
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", fake_auto)
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "apply_burst_filter", lambda df, cfg, mode="rate": (df, 0))
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "write_summary", lambda *a, **k: str(tmp_path / "x"))
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+        "--calibration-method",
+        "auto",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert called.get("auto") is True
+    assert called.get("two") is None
+


### PR DESCRIPTION
## Summary
- allow setting calibration method via CLI
- test command line override for calibration method

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686aafaff2b4832b885439098a1eb372