### PR TITLE
Add isotope mode configuration

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -417,6 +417,11 @@ def parse_args(argv=None):
         help="Background removal strategy (default: all)",
     )
     p.add_argument(
+        "--iso",
+        choices=["radon", "po218", "po214"],
+        help="Analysis isotope mode (overrides analysis_isotope in config.yaml)",
+    )
+    p.add_argument(
 
         "--allow-negative-baseline",
         action="store_true",
@@ -825,6 +830,15 @@ def main(argv=None):
             int(args.noise_cutoff),
         )
         cfg.setdefault("calibration", {})["noise_cutoff"] = int(args.noise_cutoff)
+
+    if args.iso is not None:
+        prev = cfg.get("analysis_isotope")
+        if prev is not None and prev != args.iso:
+            logging.info(
+                f"Overriding analysis_isotope={prev!r} with {args.iso!r} from CLI"
+            )
+        cfg["analysis_isotope"] = args.iso
+    assert cfg.get("analysis_isotope", "radon") in {"radon", "po218", "po214"}
 
     if args.allow_negative_baseline:
         cfg["allow_negative_baseline"] = True

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,5 @@
 allow_fallback: true
+analysis_isotope: radon
 pipeline:
   log_level: INFO
   random_seed: null

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -1,4 +1,5 @@
 allow_fallback: false
+analysis_isotope: radon
 allow_negative_baseline: false
 allow_negative_activity: false
 calibration:

--- a/constants.py
+++ b/constants.py
@@ -3,6 +3,8 @@
 
 import numpy as np
 from dataclasses import dataclass
+from pathlib import Path
+import yaml
 
 # Minimum allowed value for the exponential tail constant used in EMG fits.
 _TAU_MIN = 1e-6
@@ -54,10 +56,31 @@ class NuclideConst:
     Q_value_MeV: float | None = None
 
 
-PO214 = NuclideConst(half_life_s=1.64e-4)
-PO218 = NuclideConst(half_life_s=183.0)
-PO210 = NuclideConst(half_life_s=138.376 * 24 * 3600)
-RN222 = NuclideConst(half_life_s=3.8 * 86400.0)
+def _read_yaml_defaults() -> dict:
+    path = Path(__file__).resolve().with_name("constants.yaml")
+    if not path.is_file():
+        return {}
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    return data.get("nuclide_constants", {})
+
+
+_YAML_DEFAULTS = _read_yaml_defaults()
+
+PO214 = NuclideConst(
+    half_life_s=float(_YAML_DEFAULTS.get("Po214", {}).get("half_life_s", 1.64e-4))
+)
+PO218 = NuclideConst(
+    half_life_s=float(_YAML_DEFAULTS.get("Po218", {}).get("half_life_s", 183.0))
+)
+PO210 = NuclideConst(
+    half_life_s=float(
+        _YAML_DEFAULTS.get("Po210", {}).get("half_life_s", 138.376 * 24 * 3600)
+    )
+)
+RN222 = NuclideConst(
+    half_life_s=float(_YAML_DEFAULTS.get("Rn222", {}).get("half_life_s", 3.8 * 86400.0))
+)
 
 
 _NUCLIDE_DEFAULTS = {

--- a/constants.yaml
+++ b/constants.yaml
@@ -1,0 +1,5 @@
+nuclide_constants:
+  Rn222: { half_life_s: 330350.4 }
+  Po218: { half_life_s: 186.0 }
+  Po214: { half_life_s: 1.64e-4 }
+  Po210: { half_life_s: 1.1956e7 }

--- a/io_utils.py
+++ b/io_utils.py
@@ -112,6 +112,7 @@ CONFIG_SCHEMA = {
         "allow_fallback": {"type": "boolean"},
         "allow_negative_baseline": {"type": "boolean"},
         "allow_negative_activity": {"type": "boolean"},
+        "analysis_isotope": {"type": "string", "enum": ["radon", "po218", "po214"]},
         "spectral_fit": {
             "type": "object",
             "properties": {"expected_peaks": {"type": "object"}},
@@ -344,6 +345,8 @@ def load_config(config_path):
 
     cfg["nuclide_constants"] = load_nuclide_overrides(cfg)
 
+    if "analysis_isotope" not in cfg:
+        cfg["analysis_isotope"] = "radon"
     # CONFIG_SCHEMA validation already checks required keys
 
     return cfg

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -8,7 +8,7 @@ from constants import PO210, load_nuclide_overrides, load_half_life_overrides
 
 
 def test_po210_default():
-    assert PO210.half_life_s == pytest.approx(138.376 * 24 * 3600)
+    assert PO210.half_life_s == pytest.approx(1.1956e7)
 
 
 def test_po210_override():

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -436,6 +436,37 @@ def test_load_config_invalid_half_life(tmp_path):
         load_config(p)
 
 
+def test_load_config_invalid_analysis_isotope(tmp_path):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "analysis_isotope": "bad",
+        "spectral_fit": {"expected_peaks": {"Po210": 1}},
+        "time_fit": {"do_time_fit": True},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    p = tmp_path / "cfg.json"
+    with open(p, "w") as f:
+        json.dump(cfg, f)
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        load_config(p)
+
+
+def test_load_config_default_analysis_isotope(tmp_path):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "spectral_fit": {"expected_peaks": {"Po210": 1}},
+        "time_fit": {"do_time_fit": True},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    p = tmp_path / "cfg.json"
+    with open(p, "w") as f:
+        json.dump(cfg, f)
+    loaded = load_config(p)
+    assert loaded["analysis_isotope"] in {"radon", "po218", "po214"}
+
+
 def test_load_config_invalid_baseline(tmp_path):
     cfg = {
         "pipeline": {"log_level": "INFO"},


### PR DESCRIPTION
## Summary
- add `constants.yaml` with nuclide defaults
- support new `analysis_isotope` option with CLI `--iso`
- validate isotope option in `io_utils` and `analyze`
- load nuclide constants from YAML
- cover new behaviour in unit tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab14514f4832bbff4763c9445aef8