### PR TITLE
Remove efficiency priors

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -353,7 +353,13 @@ def _model_uncertainty(centers, widths, fit_obj, iso, cfg, normalise):
         "Po210": default_const.get("Po210", PO210).half_life_s,
     }[iso]
     hl = cfg.get("time_fit", {}).get(f"hl_{iso.lower()}", [hl_default])[0]
-    eff = cfg.get("time_fit", {}).get(f"eff_{iso.lower()}", [1.0])[0]
+    eff_entry = cfg.get("time_fit", {}).get(f"eff_{iso.lower()}")
+    if isinstance(eff_entry, list):
+        eff = eff_entry[0]
+    elif eff_entry is None:
+        eff = 1.0
+    else:
+        eff = eff_entry
     lam = math.log(2.0) / float(hl)
     dE = params.get("dE_corrected", params.get(f"dE_{iso}", 0.0))
     dN0 = params.get(f"dN0_{iso}", 0.0)
@@ -1565,10 +1571,12 @@ def main(argv=None):
         priors_time = {}
 
         # Efficiency prior per isotope
-        eff_val = cfg["time_fit"].get(
-            f"eff_{iso.lower()}", [1.0, 0.0]
-        )
-        priors_time["eff"] = tuple(eff_val)
+        eff_val = cfg["time_fit"].get(f"eff_{iso.lower()}")
+        if eff_val is not None:
+            if isinstance(eff_val, list):
+                priors_time["eff"] = tuple(eff_val)
+            else:
+                priors_time["eff"] = (float(eff_val), 0.0)
 
         # Half-life prior (user must supply [T₁/₂, σ(T₁/₂)] in seconds)
         hl_key = f"hl_{iso.lower()}"
@@ -1593,9 +1601,13 @@ def main(argv=None):
             if iso in isotopes_to_subtract:
                 baseline_counts[iso] = n0_count
 
-            eff = cfg["time_fit"].get(
-                f"eff_{iso.lower()}", [1.0]
-            )[0]
+            eff_entry = cfg["time_fit"].get(f"eff_{iso.lower()}")
+            if isinstance(eff_entry, list):
+                eff = eff_entry[0]
+            elif eff_entry is None:
+                eff = 1.0
+            else:
+                eff = eff_entry
             if baseline_live_time > 0 and eff > 0:
                 n0_activity = n0_count / (baseline_live_time * eff)
                 n0_sigma = np.sqrt(n0_count) / (baseline_live_time * eff)
@@ -1653,9 +1665,13 @@ def main(argv=None):
 
             analysis_counts = float(np.sum(iso_events["weight"]))
             iso_counts_raw[iso] = analysis_counts
-            eff = cfg["time_fit"].get(
-                f"eff_{iso.lower()}", [1.0]
-            )[0]
+            eff_entry = cfg["time_fit"].get(f"eff_{iso.lower()}")
+            if isinstance(eff_entry, list):
+                eff = eff_entry[0]
+            elif eff_entry is None:
+                eff = 1.0
+            else:
+                eff = eff_entry
             live_time_iso = iso_live_time.get(iso, 0.0)
             if eff > 0 and live_time_iso > 0:
                 c_rate = analysis_counts / (live_time_iso * eff)
@@ -1690,8 +1706,8 @@ def main(argv=None):
                         f"hl_{iso.lower()}", [np.nan]
                     )[0],
                     "efficiency": cfg["time_fit"].get(
-                        f"eff_{iso.lower()}", [1.0]
-                    )[0],
+                        f"eff_{iso.lower()}"
+                    ),
                 }
             },
             "fit_background": not cfg["time_fit"]["flags"].get(
@@ -1926,7 +1942,13 @@ def main(argv=None):
     baseline_unc = {}
     if baseline_live_time > 0:
         for iso, n in baseline_counts.items():
-            eff = cfg["time_fit"].get(f"eff_{iso.lower()}", [1.0])[0]
+            eff_entry = cfg["time_fit"].get(f"eff_{iso.lower()}")
+            if isinstance(eff_entry, list):
+                eff = eff_entry[0]
+            elif eff_entry is None:
+                eff = 1.0
+            else:
+                eff = eff_entry
             if eff > 0:
                 baseline_rates[iso] = n / (baseline_live_time * eff)
                 baseline_unc[iso] = np.sqrt(n) / (baseline_live_time * eff)
@@ -1954,7 +1976,13 @@ def main(argv=None):
         err_fit = params.get(f"dE_{iso}", 0.0)
         live_time_iso = iso_live_time.get(iso, 0.0)
         count = iso_counts_raw.get(iso, baseline_counts.get(iso, 0.0))
-        eff = cfg["time_fit"].get(f"eff_{iso.lower()}", [1.0])[0]
+        eff_entry = cfg["time_fit"].get(f"eff_{iso.lower()}")
+        if isinstance(eff_entry, list):
+            eff = eff_entry[0]
+        elif eff_entry is None:
+            eff = 1.0
+        else:
+            eff = eff_entry
         base_cnt = baseline_counts.get(iso, 0.0)
         s = scales.get(iso, 1.0)
 

--- a/config.yaml
+++ b/config.yaml
@@ -105,15 +105,9 @@ time_fit:
   window_po210:
   - 5.2
   - 5.4
-  eff_po214:
-  - 0.4
-  - 0.05
-  eff_po218:
-  - 0.2
-  - 0.05
-  eff_po210:
-  - 0.1
-  - 0.05
+  eff_po214: null
+  eff_po218: null
+  eff_po210: null
   hl_po214:
   - 328320
   - 0.0

--- a/tests/test_nll_weight_sum.py
+++ b/tests/test_nll_weight_sum.py
@@ -31,6 +31,7 @@ def test_weighted_nll_analytic_matches_numeric():
     fix_b_map = {"Po214": False}
     fix_n0_map = {"Po214": False}
     param_indices = {"E_Po214": 0, "B_Po214": 1, "N0_Po214": 2}
+    var_eff_map = {"Po214": False}
 
     analytic_nll = _neg_log_likelihood_time(
         params,
@@ -44,6 +45,7 @@ def test_weighted_nll_analytic_matches_numeric():
         fix_b_map,
         fix_n0_map,
         param_indices,
+        var_eff_map,
     )
 
     def rate(t):

--- a/tests/test_time_series_weights.py
+++ b/tests/test_time_series_weights.py
@@ -71,6 +71,7 @@ def test_weighted_nll_matches_numeric_integration():
     fix_b_map = {"Po214": False}
     fix_n0_map = {"Po214": False}
     param_indices = {"E_Po214": 0, "B_Po214": 1, "N0_Po214": 2}
+    var_eff_map = {"Po214": False}
 
     analytic_nll = _neg_log_likelihood_time(
         params,
@@ -84,6 +85,7 @@ def test_weighted_nll_matches_numeric_integration():
         fix_b_map,
         fix_n0_map,
         param_indices,
+        var_eff_map,
     )
 
     def rate(t):


### PR DESCRIPTION
## Summary
- allow time-fit efficiencies to be omitted in config
- infer efficiency value when `eff_*` is undefined
- expose fitted efficiency scale in `fitting.fit_time_series`
- update integration tests for new `_neg_log_likelihood_time` signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab1bf10e4832b8f6353d1cd9b9075