### PR TITLE
Enable free efficiency parameters in time fit

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -109,15 +109,9 @@ time_fit:
   window_po210:
   - 5.2
   - 5.4
-  eff_po214:
-  - 0.4
-  - 0.05
-  eff_po218:
-  - 0.2
-  - 0.05
-  eff_po210:
-  - 0.1
-  - 0.05
+  eff_po214: null
+  eff_po218: null
+  eff_po210: null
   hl_po214:
   - 328320
   - 0.0


### PR DESCRIPTION
## Summary
- remove efficiency priors from config
- allow time-series fit to treat detection efficiency as a free parameter when unspecified
- handle optional efficiency values throughout analysis

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab7ef2b68832bbd6d8aeee8bde008