### PR TITLE
Add runtime assertions and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,10 +431,10 @@ regions appear alongside the dashed model lines.
 
 `plot_time_series` takes its half-life values from the `time_fit` section.
 Specify custom values using the keys `hl_po214`, `hl_po218` and `hl_po210`.
-When these keys are omitted, `hl_po214` and `hl_po218` fall back to their
-physical half-lives (≈164 µs and ≈183 s). `hl_po210` defaults to its physical
-half-life (≈138 days). These custom half-lives control the decay model drawn
-over the time-series histogram.
+When these keys are omitted, `hl_po214` and `hl_po218` fall back to the
+physical values of 1.64×10⁻⁴ s and 186 s respectively. `hl_po210`
+defaults to 1.1956×10⁷ s (≈138 days). These custom half-lives control the
+decay model drawn over the time-series histogram.
 The same values are used in the `time_fit` routine itself, so changing
 `hl_po214` or `hl_po218` affects both the unbinned fit and the overlay in
 `plot_time_series`. For monitoring that spans multiple days you may set
@@ -457,9 +457,8 @@ discard the first seconds of data before the decay fit.
 
 When the data covers months or more, the short half-lives of Po‑218 and
 Po‑214 no longer matter.  The defaults therefore set `hl_po214` and
-`hl_po218` to the radon half-life (≈3.8 days) so the fit tracks the slowly
-varying radon concentration.  The configuration values are in seconds;
-3.8 days corresponds to roughly `3.8 * 86400 ≈ 3.3e5` seconds.
+`hl_po218` to the radon half-life (330350.4 s ≈3.8 days) so the fit tracks the
+slowly varying radon concentration.
 
 Example snippet:
 
@@ -538,6 +537,23 @@ python analyze.py --config assay.json --input run.csv --output_dir results \
 python analyze.py --config assay.json --input run.csv --output_dir results \
     --baseline_range 2023-07-01T00:00:00Z 2023-07-03T00:00:00Z \
     --baseline-mode none
+```
+
+### Long Baseline Example
+
+A dedicated baseline run spanning several weeks can be re-used for
+multiple assays. First analyze the baseline period on its own:
+
+```bash
+python analyze.py --config examples/long_baseline.yaml --input baseline.csv \
+    --output_dir baseline_results --job-id baseline
+```
+
+Subsequent assay runs reference the same interval:
+
+```bash
+python analyze.py --config assay.yaml --input assay.csv --output_dir results \
+    --baseline_range 2023-07-01T00:00:00Z 2023-07-31T23:59:59Z
 ```
 
 ### Baseline Subtraction Details
@@ -646,6 +662,14 @@ shows the equivalent air volume derived from this Po‑214 activity.
 If the combined activity of Po‑214 and Po‑218 is negative it is clamped to
 zero by default and the pipeline aborts.  Pass `--allow-negative-activity`
 to continue processing with a total radon value of `0 Bq`.
+
+### Radon vs Po214 Mode
+
+The configuration key `analysis_isotope` selects how the radon activity is
+reported. The default value `radon` combines the Po‑218 and Po‑214 estimates
+using inverse-variance weighting. Setting it to `po214` or `po218` uses only
+the chosen progeny. The command line option `--iso` overrides this setting
+for a particular run.
 
 ## Efficiency Calculations
 

--- a/assertions_and_ci.py
+++ b/assertions_and_ci.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Mapping, Any
+
+__all__ = ["run_assertions"]
+
+def run_assertions(summary: Mapping[str, Any], constants: Mapping[str, Any], config: Mapping[str, Any]) -> None:
+    """Validate key runtime invariants.
+
+    Parameters
+    ----------
+    summary : mapping
+        Summary dictionary produced by ``analyze.py``.
+    constants : mapping
+        Dictionary of nuclide constants.
+    config : mapping
+        Loaded configuration dictionary.
+    """
+    assert summary["baseline"]["corrected_activity"]["Po214"]["value"] >= 0
+    assert constants["Po214"]["half_life_s"] < 1e3
+    assert config["baseline"]["sample_volume_l"] > 0

--- a/config.yaml
+++ b/config.yaml
@@ -31,7 +31,7 @@ baseline:
   - '2023-09-28T00:00:00Z'
   - '2023-10-28T23:59:59Z'
   monitor_volume_l: 605.0
-  sample_volume_l: 0.0
+  sample_volume_l: 1.0
   isotopes_to_subtract:
   - noise
 burst_filter:

--- a/examples/analysis_example.ipynb
+++ b/examples/analysis_example.ipynb
@@ -1,0 +1,35 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Long Baseline Analysis Example\n",
+    "This notebook demonstrates running the pipeline with the example configuration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from analyze import main\n",
+    "main([\"--config\", 'examples/long_baseline.yaml', \"--input\", 'example_input.csv', \"--output_dir\", 'demo_results'])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/config_fixed_slope.json
+++ b/examples/config_fixed_slope.json
@@ -18,7 +18,7 @@
     "baseline": {
         "range": ["2023-08-01T00:00:00Z", "2023-08-31T23:59:59Z"],
         "monitor_volume_l": 605.0,
-        "sample_volume_l": 0.0,
+        "sample_volume_l": 1.0,
         "isotopes_to_subtract": ["Po214", "Po218"]
     },
     "burst_filter": {

--- a/examples/long_baseline.yaml
+++ b/examples/long_baseline.yaml
@@ -1,0 +1,21 @@
+pipeline:
+  log_level: INFO
+
+baseline:
+  range:
+    - '2023-07-01T00:00:00Z'
+    - '2023-07-31T23:59:59Z'
+  monitor_volume_l: 605.0
+  sample_volume_l: 5.0
+  isotopes_to_subtract: [Po214, Po218]
+
+time_fit:
+  do_time_fit: true
+  hl_po214: [328320, 0.0]
+  hl_po218: [328320, 0.0]
+
+systematics:
+  enable: false
+
+plotting:
+  plot_save_formats: [png]

--- a/tests/test_assertions_and_ci.py
+++ b/tests/test_assertions_and_ci.py
@@ -1,0 +1,33 @@
+import pytest
+from assertions_and_ci import run_assertions
+
+
+def test_run_assertions_ok():
+    summary = {"baseline": {"corrected_activity": {"Po214": {"value": 0.1}}}}
+    constants = {"Po214": {"half_life_s": 0.000164}}
+    config = {"baseline": {"sample_volume_l": 1.0}}
+    run_assertions(summary, constants, config)
+
+
+def test_run_assertions_negative_activity():
+    summary = {"baseline": {"corrected_activity": {"Po214": {"value": -1.0}}}}
+    constants = {"Po214": {"half_life_s": 0.000164}}
+    config = {"baseline": {"sample_volume_l": 1.0}}
+    with pytest.raises(AssertionError):
+        run_assertions(summary, constants, config)
+
+
+def test_run_assertions_invalid_half_life():
+    summary = {"baseline": {"corrected_activity": {"Po214": {"value": 0.1}}}}
+    constants = {"Po214": {"half_life_s": 2000.0}}
+    config = {"baseline": {"sample_volume_l": 1.0}}
+    with pytest.raises(AssertionError):
+        run_assertions(summary, constants, config)
+
+
+def test_run_assertions_invalid_sample_volume():
+    summary = {"baseline": {"corrected_activity": {"Po214": {"value": 0.1}}}}
+    constants = {"Po214": {"half_life_s": 0.000164}}
+    config = {"baseline": {"sample_volume_l": 0.0}}
+    with pytest.raises(AssertionError):
+        run_assertions(summary, constants, config)


### PR DESCRIPTION
## Summary
- implement `assertions_and_ci.run_assertions`
- provide unit tests for new runtime assertions
- update default configuration files
- document half-life values, isotope mode and long baseline workflow
- add example notebook and long baseline config

## Testing
- `bash scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686abf38a1ac832babbedb42c2025e91