### PR TITLE
Implement Module F and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--j
  - `equivalent_air.png` – equivalent air volume plot when `--ambient-file` or
    `--ambient-concentration` is provided.
 
+The behaviour of the radon activity calculation is controlled by the
+`analysis_isotope` setting (or `--iso` on the command line).  The default
+`radon` mode combines the Po‑218 and Po‑214 rates.  Selecting `po214` or
+`po218` reports only the chosen isotope without performing the combination.
+
 The `time_fit` routine still fits only Po‑214 and Po‑218.
 When `window_po210` is provided the Po‑210 events are extracted and a
 time‑series histogram is produced without a decay fit. The `hl_po210`
@@ -432,7 +437,7 @@ regions appear alongside the dashed model lines.
 `plot_time_series` takes its half-life values from the `time_fit` section.
 Specify custom values using the keys `hl_po214`, `hl_po218` and `hl_po210`.
 When these keys are omitted, `hl_po214` and `hl_po218` fall back to their
-physical half-lives (≈164 µs and ≈183 s). `hl_po210` defaults to its physical
+physical half-lives (≈164 µs for Po‑214 and ≈183 s for Po‑218). `hl_po210` defaults to its physical
 half-life (≈138 days). These custom half-lives control the decay model drawn
 over the time-series histogram.
 The same values are used in the `time_fit` routine itself, so changing
@@ -518,6 +523,16 @@ Example snippet:
     "monitor_volume_l": 10.0,
     "sample_volume_l": 5.0,
     "isotopes_to_subtract": ["Po214", "Po218"]
+}
+```
+
+For long background measurements spanning weeks the same configuration
+can be reused with the radon half-life in the time-fit section:
+
+```yaml
+"time_fit": {
+    "hl_po214": [328320, 0.0],
+    "hl_po218": [328320, 0.0]
 }
 ```
 

--- a/analyze.py
+++ b/analyze.py
@@ -715,6 +715,11 @@ def main(argv=None):
         print(f"ERROR: Could not load config '{args.config}': {e}")
         sys.exit(1)
 
+    consts = cfg.get("nuclide_constants", {})
+    po214 = consts.get("Po214")
+    if po214 is not None:
+        assert po214.half_life_s < 1e3
+
     def _log_override(section, key, new_val):
         prev = cfg.get(section, {}).get(key)
         if prev is not None and prev != new_val:
@@ -1275,6 +1280,7 @@ def main(argv=None):
 
     monitor_vol = float(baseline_cfg.get("monitor_volume_l", 605.0))
     sample_vol = float(baseline_cfg.get("sample_volume_l", 0.0))
+    assert sample_vol > 0
     base_events = pd.DataFrame()
     baseline_live_time = 0.0
     mask_base = None
@@ -2081,6 +2087,10 @@ def main(argv=None):
             iso: vals["uncertainty"]
             for iso, vals in baseline_info["corrected_activity"].items()
         }
+        if "Po214" in baseline_info["corrected_activity"]:
+            assert (
+                baseline_info["corrected_activity"]["Po214"]["value"] >= 0
+            )
 
     try:
         _ = summarize_baseline(

--- a/config.yaml
+++ b/config.yaml
@@ -31,7 +31,7 @@ baseline:
   - '2023-09-28T00:00:00Z'
   - '2023-10-28T23:59:59Z'
   monitor_volume_l: 605.0
-  sample_volume_l: 0.0
+  sample_volume_l: 5.0
   isotopes_to_subtract:
   - noise
 burst_filter:

--- a/examples/analysis_demo.ipynb
+++ b/examples/analysis_demo.ipynb
@@ -1,0 +1,39 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Radon Monitor Analysis Example\n",
+    "This notebook runs the analysis pipeline using the provided configuration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import analyze\n",
+    "analyze.main([\n",
+    "    '--config', 'config.yaml',\n",
+    "    '--input', 'example_input.csv',\n",
+    "    '--output_dir', 'example_results'\n",
+    "])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/config_fixed_slope.json
+++ b/examples/config_fixed_slope.json
@@ -18,7 +18,7 @@
     "baseline": {
         "range": ["2023-08-01T00:00:00Z", "2023-08-31T23:59:59Z"],
         "monitor_volume_l": 605.0,
-        "sample_volume_l": 0.0,
+        "sample_volume_l": 5.0,
         "isotopes_to_subtract": ["Po214", "Po218"]
     },
     "burst_filter": {

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -2152,7 +2152,7 @@ def test_hl_po210_default_used(tmp_path, monkeypatch):
 def test_time_fields_written_back(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},
-        "baseline": {"range": ["0", "1"], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "baseline": {"range": ["0", "1"], "monitor_volume_l": 605.0, "sample_volume_l": 1.0},
         "analysis": {
             "analysis_end_time": "1970-01-01T00:00:05Z",
             "spike_end_time": "1970-01-01T00:00:00Z",

--- a/tests/test_baseline_flow.py
+++ b/tests/test_baseline_flow.py
@@ -15,7 +15,7 @@ def test_baseline_event_from_unfiltered_data(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},
         "calibration": {"noise_cutoff": 5},
-        "baseline": {"range": [0, 2], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "baseline": {"range": [0, 2], "monitor_volume_l": 605.0, "sample_volume_l": 1.0},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {"do_time_fit": False},
         "systematics": {"enable": False},

--- a/tests/test_baseline_noise_propagation.py
+++ b/tests/test_baseline_noise_propagation.py
@@ -15,7 +15,7 @@ from fitting import FitResult, FitParams
 def test_baseline_noise_propagation(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},
-        "baseline": {"range": [0, 5], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "baseline": {"range": [0, 5], "monitor_volume_l": 605.0, "sample_volume_l": 1.0},
         "calibration": {"noise_cutoff": 8},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {

--- a/tests/test_baseline_range_cli.py
+++ b/tests/test_baseline_range_cli.py
@@ -16,7 +16,7 @@ from fitting import FitResult, FitParams
 def test_baseline_range_cli_overrides_config(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},
-        "baseline": {"range": [0, 5], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "baseline": {"range": [0, 5], "monitor_volume_l": 605.0, "sample_volume_l": 1.0},
         "calibration": {},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {

--- a/tests/test_baseline_range_empty.py
+++ b/tests/test_baseline_range_empty.py
@@ -17,7 +17,7 @@ def test_cli_baseline_range_empty(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},
         "allow_fallback": True,
-        "baseline": {"range": [0, 5], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "baseline": {"range": [0, 5], "monitor_volume_l": 605.0, "sample_volume_l": 1.0},
         "calibration": {},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {

--- a/tests/test_cli_baseline_range.py
+++ b/tests/test_cli_baseline_range.py
@@ -16,7 +16,7 @@ from fitting import FitResult, FitParams
 def test_cli_baseline_range_overrides_config(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},
-        "baseline": {"range": [0, 5], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "baseline": {"range": [0, 5], "monitor_volume_l": 605.0, "sample_volume_l": 1.0},
         "calibration": {},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {

--- a/tests/test_cli_baseline_range_iso.py
+++ b/tests/test_cli_baseline_range_iso.py
@@ -16,7 +16,7 @@ from fitting import FitResult, FitParams
 def test_cli_baseline_range_iso_strings(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},
-        "baseline": {"range": [0, 5], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "baseline": {"range": [0, 5], "monitor_volume_l": 605.0, "sample_volume_l": 1.0},
         "calibration": {},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
@@ -112,7 +112,7 @@ def test_cli_baseline_range_iso_strings(tmp_path, monkeypatch):
 def test_cli_baseline_range_timezone(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},
-        "baseline": {"range": [0, 5], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "baseline": {"range": [0, 5], "monitor_volume_l": 605.0, "sample_volume_l": 1.0},
         "calibration": {},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {

--- a/tests/test_cli_baseline_range_override2.py
+++ b/tests/test_cli_baseline_range_override2.py
@@ -16,7 +16,7 @@ from fitting import FitResult, FitParams
 def test_cli_baseline_range_overrides_config_again(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},
-        "baseline": {"range": [0, 5], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "baseline": {"range": [0, 5], "monitor_volume_l": 605.0, "sample_volume_l": 1.0},
         "calibration": {},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {

--- a/tests/test_cli_negative_baseline.py
+++ b/tests/test_cli_negative_baseline.py
@@ -20,7 +20,7 @@ from dataclasses import asdict
 def _common_setup(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},
-        "baseline": {"range": [0, 5], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "baseline": {"range": [0, 5], "monitor_volume_l": 605.0, "sample_volume_l": 1.0},
         "calibration": {},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -470,7 +470,7 @@ def test_load_config_default_analysis_isotope(tmp_path):
 def test_load_config_invalid_baseline(tmp_path):
     cfg = {
         "pipeline": {"log_level": "INFO"},
-        "baseline": {"monitor_volume_l": -1, "sample_volume_l": 0.0},
+        "baseline": {"monitor_volume_l": -1, "sample_volume_l": 1.0},
         "spectral_fit": {"expected_peaks": {"Po210": 1}},
         "time_fit": {"do_time_fit": True},
         "systematics": {"enable": False},

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -16,7 +16,7 @@ from calibration import CalibrationResult
 def test_time_window_filters_events(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},
-        "baseline": {"range": ["1970-01-01T00:00:00Z", "1970-01-01T00:00:05Z"], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "baseline": {"range": ["1970-01-01T00:00:00Z", "1970-01-01T00:00:05Z"], "monitor_volume_l": 605.0, "sample_volume_l": 1.0},
         "calibration": {},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
@@ -99,7 +99,7 @@ def test_time_window_filters_events(tmp_path, monkeypatch):
 def test_invalid_baseline_range_raises(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},
-        "baseline": {"range": ["1970-01-01T00:00:05Z", "1970-01-01T00:00:02Z"], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "baseline": {"range": ["1970-01-01T00:00:05Z", "1970-01-01T00:00:02Z"], "monitor_volume_l": 605.0, "sample_volume_l": 1.0},
         "calibration": {},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
         "time_fit": {
@@ -155,7 +155,7 @@ def test_invalid_baseline_range_raises(tmp_path, monkeypatch):
 def test_time_window_filters_events_config(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},
-        "baseline": {"range": ["1970-01-01T00:00:00Z", "1970-01-01T00:00:05Z"], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "baseline": {"range": ["1970-01-01T00:00:00Z", "1970-01-01T00:00:05Z"], "monitor_volume_l": 605.0, "sample_volume_l": 1.0},
         "analysis": {"analysis_end_time": "1970-01-01T00:00:06Z", "spike_end_time": "1970-01-01T00:00:01Z"},
         "calibration": {},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
@@ -235,7 +235,7 @@ def test_time_window_filters_events_config(tmp_path, monkeypatch):
 def test_run_period_filters_events(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},
-        "baseline": {"range": ["1970-01-01T00:00:00Z", "1970-01-01T00:00:01Z"], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "baseline": {"range": ["1970-01-01T00:00:00Z", "1970-01-01T00:00:01Z"], "monitor_volume_l": 605.0, "sample_volume_l": 1.0},
         "analysis": {"run_periods": [["1970-01-01T00:00:01Z", "1970-01-01T00:00:06Z"]]},
         "calibration": {},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
@@ -323,7 +323,7 @@ def test_run_period_filters_events(tmp_path, monkeypatch):
 def test_baseline_range_iso_strings(tmp_path, monkeypatch, start, end):
     cfg = {
         "pipeline": {"log_level": "INFO"},
-        "baseline": {"range": [start, end], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "baseline": {"range": [start, end], "monitor_volume_l": 605.0, "sample_volume_l": 1.0},
         "analysis": {"analysis_end_time": "1970-01-01T00:00:06Z", "spike_end_time": "1970-01-01T00:00:01Z"},
         "calibration": {},
         "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
@@ -404,7 +404,7 @@ def test_baseline_range_iso_strings(tmp_path, monkeypatch, start, end):
 def test_unified_filter_combined_windows(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},
-        "baseline": {"range": ["1970-01-01T00:00:00Z", "1970-01-01T00:00:01Z"], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "baseline": {"range": ["1970-01-01T00:00:00Z", "1970-01-01T00:00:01Z"], "monitor_volume_l": 605.0, "sample_volume_l": 1.0},
         "analysis": {
             "run_periods": [["1970-01-01T00:00:01Z", "1970-01-01T00:00:04Z"]],
             "spike_periods": [["1970-01-01T00:00:02Z", "1970-01-01T00:00:02.5Z"]],


### PR DESCRIPTION
## Summary
- enforce new runtime assertions in analyze
- require positive sample volume in configuration
- document isotope modes and long baseline workflows
- adjust test configs for new assertion
- add example notebook

## Testing
- `pytest -q` *(fails: Package 'numpy' is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_686abf38a1ac832babbedb42c2025e91