### PR TITLE
Implement baseline subtraction check

### DIFF
--- a/radon/baseline.py
+++ b/radon/baseline.py
@@ -7,6 +7,12 @@ import numpy as np
 __all__ = ["subtract_baseline_counts", "subtract_baseline_rate"]
 
 
+def _validate_subtraction(isotopes):
+    allowed = {"noise"}
+    if not set(isotopes) <= allowed:
+        raise ValueError("Only 'noise' may be subtracted from radon baseline")
+
+
 def _scaling_factor(
     dt_window: float,
     dt_baseline: float,
@@ -20,7 +26,7 @@ def _scaling_factor(
 
     scale = float(dt_window) / float(dt_baseline)
     var = (err_window / dt_baseline) ** 2
-    var += ((dt_window * err_baseline) / dt_baseline ** 2) ** 2
+    var += ((dt_window * err_baseline) / dt_baseline**2) ** 2
     return scale, float(np.sqrt(var))
 
 
@@ -30,15 +36,17 @@ def subtract_baseline_counts(
     live_time: float,
     baseline_counts: float,
     baseline_live_time: float,
+    isotopes=None,
 ) -> tuple[float, float]:
     """Return background-corrected rate and uncertainty."""
+
+    if isotopes is not None:
+        _validate_subtraction(isotopes)
 
     if live_time <= 0:
         raise ValueError("live_time must be positive for baseline correction")
     if baseline_live_time <= 0:
-        raise ValueError(
-            "baseline_live_time must be positive for baseline correction"
-        )
+        raise ValueError("baseline_live_time must be positive for baseline correction")
     if efficiency <= 0:
         raise ValueError("efficiency must be positive for baseline correction")
 
@@ -47,10 +55,8 @@ def subtract_baseline_counts(
     net = counts - scale * baseline_counts
     corrected_rate = net / live_time / efficiency
 
-    sigma_sq = counts / live_time ** 2 / efficiency ** 2
-    baseline_sigma_sq = (
-        baseline_counts * scale ** 2 / live_time ** 2 / efficiency ** 2
-    )
+    sigma_sq = counts / live_time**2 / efficiency**2
+    baseline_sigma_sq = baseline_counts * scale**2 / live_time**2 / efficiency**2
     corrected_sigma = np.sqrt(sigma_sq + baseline_sigma_sq)
     return corrected_rate, corrected_sigma
 
@@ -70,16 +76,12 @@ def subtract_baseline_rate(
     if live_time <= 0:
         raise ValueError("live_time must be positive for baseline correction")
     if baseline_live_time <= 0:
-        raise ValueError(
-            "baseline_live_time must be positive for baseline correction"
-        )
+        raise ValueError("baseline_live_time must be positive for baseline correction")
     if efficiency <= 0:
         raise ValueError("efficiency must be positive for baseline correction")
 
     baseline_rate = baseline_counts / (baseline_live_time * efficiency)
-    baseline_sigma = np.sqrt(baseline_counts) / (
-        baseline_live_time * efficiency
-    )
+    baseline_sigma = np.sqrt(baseline_counts) / (baseline_live_time * efficiency)
 
     _, sigma_rate = subtract_baseline_counts(
         counts,


### PR DESCRIPTION
## Summary
- restrict radon baseline subtraction to electronic noise
- validate optional isotope list in `subtract_baseline_counts`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac5f7e838832b858578b5f7f11500