### PR TITLE
Update time fit defaults

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -347,18 +347,29 @@ def _ts_bin_centers_widths(times, cfg, t_start, t_end):
     return centers, widths
 
 
+def _get_half_life(cfg, iso):
+    """Return half-life in seconds for ``iso`` using ``cfg`` defaults."""
+    tf = cfg.get("time_fit", {})
+    val = tf.get(f"hl_{iso.lower()}")
+    if isinstance(val, list):
+        val = val[0] if val else None
+    if val is None:
+        const = cfg.get("nuclide_constants", {})
+        defaults = {
+            "Po214": const.get("Po214", PO214).half_life_s,
+            "Po218": const.get("Po218", PO218).half_life_s,
+            "Po210": const.get("Po210", PO210).half_life_s,
+        }
+        val = defaults[iso]
+    return float(val)
+
+
 def _model_uncertainty(centers, widths, fit_obj, iso, cfg, normalise):
     """Propagate fit parameter errors to the model curve."""
     if fit_obj is None:
         return None
     params = _fit_params(fit_obj)
-    default_const = cfg.get("nuclide_constants", {})
-    hl_default = {
-        "Po214": default_const.get("Po214", PO214).half_life_s,
-        "Po218": default_const.get("Po218", PO218).half_life_s,
-        "Po210": default_const.get("Po210", PO210).half_life_s,
-    }[iso]
-    hl = cfg.get("time_fit", {}).get(f"hl_{iso.lower()}", [hl_default])[0]
+    hl = _get_half_life(cfg, iso)
     eff_cfg = cfg.get("time_fit", {}).get(f"eff_{iso.lower()}")
     if isinstance(eff_cfg, list):
         eff = eff_cfg[0]
@@ -2174,9 +2185,7 @@ def main(argv=None):
             dE = fit.get("dE_corrected", fit.get("dE_Po214", 0.0))
             N0 = fit.get("N0_Po214", 0.0)
             dN0 = fit.get("dN0_Po214", 0.0)
-            default_const = cfg.get("nuclide_constants", {})
-            default_hl = default_const.get("Po214", PO214).half_life_s
-            hl = cfg.get("time_fit", {}).get("hl_po214", [default_hl])[0]
+            hl = _get_half_life(cfg, "Po214")
             cov = _cov_lookup(fit_result, "E_Po214", "N0_Po214")
             delta214, err_delta214 = radon_delta(
                 t_start_rel,
@@ -2197,9 +2206,7 @@ def main(argv=None):
             dE = fit.get("dE_corrected", fit.get("dE_Po218", 0.0))
             N0 = fit.get("N0_Po218", 0.0)
             dN0 = fit.get("dN0_Po218", 0.0)
-            default_const = cfg.get("nuclide_constants", {})
-            default_hl = default_const.get("Po218", PO218).half_life_s
-            hl = cfg.get("time_fit", {}).get("hl_po218", [default_hl])[0]
+            hl = _get_half_life(cfg, "Po218")
             cov = _cov_lookup(fit_result, "E_Po218", "N0_Po218")
             delta218, err_delta218 = radon_delta(
                 t_start_rel,
@@ -2416,9 +2423,7 @@ def main(argv=None):
             dE = fit.get("dE_corrected", fit.get("dE_Po214", 0.0))
             N0 = fit.get("N0_Po214", 0.0)
             dN0 = fit.get("dN0_Po214", 0.0)
-            default_const = cfg.get("nuclide_constants", {})
-            default_hl = default_const.get("Po214", PO214).half_life_s
-            hl = cfg.get("time_fit", {}).get("hl_po214", [default_hl])[0]
+            hl = _get_half_life(cfg, "Po214")
             cov = _cov_lookup(fit_result, "E_Po214", "N0_Po214")
             A214, dA214 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl, cov)
             plot_radon_activity(
@@ -2437,9 +2442,7 @@ def main(argv=None):
             dE = fit.get("dE_corrected", fit.get("dE_Po218", 0.0))
             N0 = fit.get("N0_Po218", 0.0)
             dN0 = fit.get("dN0_Po218", 0.0)
-            default_const = cfg.get("nuclide_constants", {})
-            default_hl = default_const.get("Po218", PO218).half_life_s
-            hl = cfg.get("time_fit", {}).get("hl_po218", [default_hl])[0]
+            hl = _get_half_life(cfg, "Po218")
             cov = _cov_lookup(fit_result, "E_Po218", "N0_Po218")
             A218, dA218 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl, cov)
 
@@ -2493,9 +2496,7 @@ def main(argv=None):
                 dE214 = fit.get("dE_corrected", fit.get("dE_Po214", 0.0))
                 N0214 = fit.get("N0_Po214", 0.0)
                 dN0214 = fit.get("dN0_Po214", 0.0)
-                default_const = cfg.get("nuclide_constants", {})
-                default_hl = default_const.get("Po214", PO214).half_life_s
-                hl214 = cfg.get("time_fit", {}).get("hl_po214", [default_hl])[0]
+                hl214 = _get_half_life(cfg, "Po214")
                 cov214 = _cov_lookup(fit_result, "E_Po214", "N0_Po214")
                 A214_tr, _ = radon_activity_curve(
                     rel_trend, E214, dE214, N0214, dN0214, hl214, cov214
@@ -2508,9 +2509,7 @@ def main(argv=None):
                 dE218 = fit.get("dE_corrected", fit.get("dE_Po218", 0.0))
                 N0218 = fit.get("N0_Po218", 0.0)
                 dN0218 = fit.get("dN0_Po218", 0.0)
-                default_const = cfg.get("nuclide_constants", {})
-                default_hl = default_const.get("Po218", PO218).half_life_s
-                hl218 = cfg.get("time_fit", {}).get("hl_po218", [default_hl])[0]
+                hl218 = _get_half_life(cfg, "Po218")
                 cov218 = _cov_lookup(fit_result, "E_Po218", "N0_Po218")
                 A218_tr, _ = radon_activity_curve(
                     rel_trend, E218, dE218, N0218, dN0218, hl218, cov218

--- a/config.yaml
+++ b/config.yaml
@@ -101,23 +101,19 @@ spectral_fit:
 time_fit:
   do_time_fit: true
   window_po214:
-  - 7.4
-  - 7.9
+  - 7.55
+  - 7.80
   window_po218:
-  - 5.8
-  - 6.3
+  - 5.90
+  - 6.10
   window_po210:
-  - 5.2
-  - 5.4
+  - 5.25
+  - 5.37
   eff_po214: null
   eff_po218: null
   eff_po210: null
-  hl_po214:
-  - 328320
-  - 0.0
-  hl_po218:
-  - 328320
-  - 0.0
+  hl_po214: null
+  hl_po218: null
   bkg_po214:
   - 0.0
   - 0.0

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -7,11 +7,11 @@ calibration:
   intercept_MeV: null
 time_fit:
   window_po214:
-  - 7.607
-  - 7.767
+  - 7.55
+  - 7.80
   window_po218:
-  - 5.922
-  - 6.082
+  - 5.90
+  - 6.10
   window_po210:
-  - 5.224
-  - 5.384
+  - 5.25
+  - 5.37

--- a/constants.py
+++ b/constants.py
@@ -115,7 +115,7 @@ def load_nuclide_overrides(cfg: dict | None) -> dict[str, NuclideConst]:
             if isinstance(val, list):
                 if val:
                     hl = val[0]
-            else:
+            elif val is not None:
                 hl = val
         qv = override.get("Q_value_MeV", const.Q_value_MeV)
         result[name] = NuclideConst(half_life_s=float(hl), Q_value_MeV=qv)

--- a/io_utils.py
+++ b/io_utils.py
@@ -123,22 +123,40 @@ CONFIG_SCHEMA = {
             "properties": {
                 "do_time_fit": {"type": "boolean"},
                 "hl_po214": {
-                    "type": "array",
-                    "items": {"type": "number"},
-                    "minItems": 1,
-                    "maxItems": 2,
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {"type": "number", "minimum": 0},
+                            "minItems": 1,
+                            "maxItems": 2,
+                        },
+                        {"type": "number", "minimum": 0},
+                        {"type": "null"},
+                    ]
                 },
                 "hl_po218": {
-                    "type": "array",
-                    "items": {"type": "number"},
-                    "minItems": 1,
-                    "maxItems": 2,
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {"type": "number", "minimum": 0},
+                            "minItems": 1,
+                            "maxItems": 2,
+                        },
+                        {"type": "number", "minimum": 0},
+                        {"type": "null"},
+                    ]
                 },
                 "hl_po210": {
-                    "type": "array",
-                    "items": {"type": "number"},
-                    "minItems": 1,
-                    "maxItems": 2,
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {"type": "number", "minimum": 0},
+                            "minItems": 1,
+                            "maxItems": 2,
+                        },
+                        {"type": "number", "minimum": 0},
+                        {"type": "null"},
+                    ]
                 },
             },
             "required": ["do_time_fit"],

--- a/tests/test_window_po218_default.py
+++ b/tests/test_window_po218_default.py
@@ -21,4 +21,4 @@ def test_window_po218_default(tmp_path):
         json.dump(cfg, f)
 
     loaded = load_config(cfg_path)
-    assert loaded["time_fit"]["window_po218"] == [5.922, 6.082]
+    assert loaded["time_fit"]["window_po218"] == [5.90, 6.10]


### PR DESCRIPTION
## Summary
- tweak default energy windows for time series fitting
- allow nullable half-life overrides in config
- ignore `None` half-life overrides when loading nuclide constants
- helper in `analyze.py` to fetch half-life from config or defaults
- update unit tests for new defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac92afefc832bacdad2106fa20f6a