### PR TITLE
Enable EMG tail for Po-210 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,9 @@ fit.  Important keys include:
   `use_emg` enables that tail.  Use a strictly positive prior mean (e.g.
   ``0.005``) to prevent numerical overflow when the tail constant
   approaches zero.
+- `use_emg` – mapping of isotopes to boolean flags selecting an
+  exponentially modified Gaussian tail.  If omitted Po‑210 defaults to
+  `true` while Po‑218 and Po‑214 default to `false`.
 - `mu_bounds` – optional lower/upper limits for each peak centroid.
   Set for example `{"Po218": [5.9, 6.2]}` to keep the Po‑218 fit from
   drifting into the Po‑210 region.  Centroid guesses found during peak

--- a/config.yaml
+++ b/config.yaml
@@ -83,9 +83,9 @@ spectral_fit:
   tau_Po214_prior_sigma: 0.002
   spectral_peak_tolerance_mev: 0.3
   use_emg:
-    Po210: false
-    Po218: true
-    Po214: true
+    Po210: true
+    Po218: false
+    Po214: false
   float_sigma_E: true
   sigma_E_prior_source: 0.15
   peak_search_prominence: 30

--- a/examples/config_fixed_slope.json
+++ b/examples/config_fixed_slope.json
@@ -64,9 +64,9 @@
         "tau_Po214_prior_sigma": 0.002,
         "spectral_peak_tolerance_mev": 0.3,
         "use_emg": {
-            "Po210": false,
-            "Po218": true,
-            "Po214": true
+            "Po210": true,
+            "Po218": false,
+            "Po214": false
         },
         "float_sigma_E": true,
         "sigma_E_prior_source": 0.15,

--- a/io_utils.py
+++ b/io_utils.py
@@ -368,6 +368,20 @@ def load_config(config_path):
 
     if "analysis_isotope" not in cfg:
         cfg["analysis_isotope"] = "radon"
+
+    # Fill in default EMG usage for spectral fits when not explicitly provided
+    spec = cfg.setdefault("spectral_fit", {})
+    default_emg = {"Po210": True, "Po218": False, "Po214": False}
+    emg_cfg = spec.get("use_emg")
+    if emg_cfg is None:
+        spec["use_emg"] = default_emg.copy()
+    elif isinstance(emg_cfg, Mapping):
+        merged = default_emg.copy()
+        merged.update(emg_cfg)
+        spec["use_emg"] = merged
+    else:
+        val = bool(emg_cfg)
+        spec["use_emg"] = {iso: val for iso in default_emg}
     # CONFIG_SCHEMA validation already checks required keys
 
     return cfg


### PR DESCRIPTION
## Summary
- default `spectral_fit.use_emg` to enable Po-210 tails only
- update sample configs for new defaults
- document EMG usage defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ad855590c832b98c2a072a20367df