### PR TITLE
Implement radon joint estimator hook

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -72,6 +72,9 @@ class Summary(Mapping[str, Any]):
     baseline: dict = field(default_factory=dict)
     radon_results: dict = field(default_factory=dict)
     radon_combined: dict = field(default_factory=dict)
+    radon: dict = field(default_factory=dict)
+    po214: dict = field(default_factory=dict)
+    po218: dict = field(default_factory=dict)
     noise_cut: dict = field(default_factory=dict)
     burst_filter: dict = field(default_factory=dict)
     adc_drift_rate: float | None = None


### PR DESCRIPTION
## Summary
- extend `Summary` dataclass with radon fields
- allow `estimate_radon_activity` to work with decay rates
- call radon estimator after time-series fits and store result in summary

## Testing
- `pytest tests/test_radon_combined.py::test_radon_combined_hook -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aecf0955c832bb1bba13403565c9f