### PR TITLE
Add efficiency prior controls

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -109,9 +109,10 @@ time_fit:
   window_po210:
   - 5.25
   - 5.37
-  eff_po214: null
-  eff_po218: null
-  eff_po210: null
+  eff_po214: 1.0        # nominal × (±100 %)
+  eff_po218: 1.0
+  eff_po210: 1.0
+  eff_prior_sigma: 1.0  # 100 % relative σ
   hl_po214: null
   hl_po218: null
   bkg_po214:


### PR DESCRIPTION
## Summary
- provide nominal efficiency settings in config.yaml
- allow CLI flag to fix detection efficiencies
- incorporate efficiency prior logic in time-series analysis

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686af371f18c832bb5017a571f4cd285