### PR TITLE
Add radon activity plotting utilities

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -119,6 +119,7 @@ from plot_utils import (
     plot_equivalent_air,
     plot_radon_trend,
 )
+import plotting
 from systematics import scan_systematics, apply_linear_adc_shift
 from visualize import cov_heatmap, efficiency_bar
 from utils import (
@@ -2394,6 +2395,15 @@ def main(argv=None):
 
     copy_config(results_dir, cfg, exist_ok=args.overwrite)
     out_dir = write_summary(results_dir, summary)
+
+    if iso_mode == "radon":
+        rad_ts = summary.get("radon", {}).get("time_series")
+        if rad_ts is not None:
+            try:
+                plotting.plot_radon_activity(rad_ts, Path(out_dir))
+                plotting.plot_radon_trend(rad_ts, Path(out_dir))
+            except Exception as e:
+                print(f"WARNING: Could not create radon pipeline plots -> {e}")
 
     # Generate plots now that the output directory exists
     if spec_plot_data:

--- a/plotting.py
+++ b/plotting.py
@@ -1,0 +1,38 @@
+import matplotlib as _mpl
+_mpl.use("Agg")
+import matplotlib.pyplot as plt
+from pathlib import Path
+
+__all__ = ["plot_radon_activity", "plot_radon_trend"]
+
+
+def plot_radon_activity(ts, outdir):
+    """Plot radon activity with uncertainties.
+
+    Parameters
+    ----------
+    ts : object
+        Object with ``time``, ``activity`` and ``error`` attributes.
+    outdir : Path or str
+        Output directory where ``radon_activity.png`` will be saved.
+    """
+    outdir = Path(outdir)
+    fig, ax = plt.subplots()
+    ax.errorbar(ts.time, ts.activity, yerr=getattr(ts, "error", None), fmt="o")
+    ax.set_ylabel("Radon activity [Bq]")
+    ax.set_xlabel("Time (UTC)")
+    fig.tight_layout()
+    fig.savefig(outdir / "radon_activity.png", dpi=300)
+    plt.close(fig)
+
+
+def plot_radon_trend(ts, outdir):
+    """Plot radon activity trend without uncertainties."""
+    outdir = Path(outdir)
+    fig, ax = plt.subplots()
+    ax.plot(ts.time, ts.activity, "o-")
+    ax.set_ylabel("Radon activity [Bq]")
+    ax.set_xlabel("Time (UTC)")
+    fig.tight_layout()
+    fig.savefig(outdir / "radon_trend.png", dpi=300)
+    plt.close(fig)


### PR DESCRIPTION
## Summary
- implement lightweight plotting helpers for radon activity
- hook them into `analyze.py` when radon analysis mode is active

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686af7ae1e3c832b90c76428d4c96710