### PR TITLE
Implement flat efficiency prior handling

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -109,10 +109,9 @@ time_fit:
   window_po210:
   - 5.25
   - 5.37
-  eff_po214: 1.0        # nominal × (±100 %)
-  eff_po218: 1.0
-  eff_po210: 1.0
-  eff_prior_sigma: 1.0  # 100 % relative σ
+  eff_po214: null
+  eff_po218: null
+  eff_po210: null
   hl_po214: null
   hl_po218: null
   bkg_po214:


### PR DESCRIPTION
## Summary
- treat `null` efficiency entries as free parameters with a flat prior
- update config defaults accordingly
- install a helper `_eff_prior` in `analyze.py`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b39f10630832b811bc80a3b3ba573