### PR TITLE
Add radon activity counts hook

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1841,35 +1841,65 @@ def main(argv=None):
         fit214 = SimpleNamespace(
             rate=p.get("E_corrected", p.get("E_Po214")),
             err=p.get("dE_corrected", p.get("dE_Po214")),
+            counts=getattr(fit214_obj, "counts", None),
+            params=p,
         )
     if fit218_obj:
         p = _fit_params(fit218_obj)
         fit218 = SimpleNamespace(
             rate=p.get("E_corrected", p.get("E_Po218")),
             err=p.get("dE_corrected", p.get("dE_Po218")),
+            counts=getattr(fit218_obj, "counts", None),
+            params=p,
         )
 
-    iso_mode = cfg.get("analysis_isotope", "radon").lower()
+    iso_mode = (args.iso or cfg.get("analysis_isotope", "radon")).lower()
 
     if iso_mode == "radon":
-        if (fit214 and fit214.rate is not None) or (fit218 and fit218.rate is not None):
+        have_218 = (
+            fit218
+            and fit218.counts is not None
+            and ("eff" in fit218.params or "eff_Po218" in fit218.params)
+        )
+        have_214 = (
+            fit214
+            and fit214.counts is not None
+            and ("eff" in fit214.params or "eff_Po214" in fit214.params)
+        )
+        if have_218 or have_214:
+            N218 = fit218.counts if have_218 else None
+            N214 = fit214.counts if have_214 else None
+            eps218 = (
+                fit218.params.get("eff", fit218.params.get("eff_Po218", 1.0))
+                if fit218
+                else 1.0
+            )
+            eps214 = (
+                fit214.params.get("eff", fit214.params.get("eff_Po214", 1.0))
+                if fit214
+                else 1.0
+            )
+            radon_estimate_info = estimate_radon_activity(
+                N218=N218,
+                epsilon218=eps218,
+                f218=1.0,
+                N214=N214,
+                epsilon214=eps214,
+                f214=1.0,
+            )
+        elif (fit214 and fit214.rate is not None) or (fit218 and fit218.rate is not None):
             radon_estimate_info = estimate_radon_activity(
                 rate214=fit214.rate if fit214 else None,
                 err214=fit214.err if fit214 else None,
                 rate218=fit218.rate if fit218 else None,
                 err218=fit218.err if fit218 else None,
             )
-    elif iso_mode in {"po214", "po218"}:
-        chosen = fit214 if iso_mode == "po214" else fit218
-        if chosen and chosen.rate is not None:
-            info = {
-                "activity_Bq": chosen.rate,
-                "stat_unc_Bq": chosen.err,
-            }
-            if iso_mode == "po214":
-                po214_estimate_info = info
-            else:
-                po218_estimate_info = info
+    elif iso_mode == "po218":
+        if fit218:
+            po218_estimate_info = {"activity_Bq": fit218.rate, "stat_unc_Bq": fit218.err}
+    elif iso_mode == "po214":
+        if fit214:
+            po214_estimate_info = {"activity_Bq": fit214.rate, "stat_unc_Bq": fit214.err}
     else:
         raise ValueError(f"Unknown analysis isotope {iso_mode}")
 

--- a/tests/test_radon_hook_counts.py
+++ b/tests/test_radon_hook_counts.py
@@ -1,0 +1,81 @@
+import sys
+from pathlib import Path
+import json
+import pandas as pd
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+import radon_joint_estimator
+from dataclasses import asdict
+from calibration import CalibrationResult
+from fitting import FitResult, FitParams
+
+
+def test_radon_hook_counts(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "baseline": {"monitor_volume_l": 10.0, "sample_volume_l": 5.0},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": True, "window_po214": [7, 9], "hl_po214": [1.0, 0.0], "eff_po214": [1.0, 0.0], "flags": {}},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+
+    cfg_path = tmp_path / "cfg.json"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame({
+        "fUniqueID": [1],
+        "fBits": [0],
+        "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")],
+        "adc": [8],
+        "fchannel": [1],
+    })
+    data_path = tmp_path / "d.csv"
+    df.to_csv(data_path, index=False)
+
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({"eff": 1.0}), np.zeros((1, 1)), 0, counts=10))
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+
+    monkeypatch.setattr(radon_joint_estimator, "estimate_radon_activity", lambda *a, **k: {"Rn_activity_Bq": 5.0, "stat_unc_Bq": 0.5, "isotope_mode": "radon"})
+
+    captured = {}
+
+    def fake_write(out_dir, summary, timestamp=None):
+        captured["summary"] = asdict(summary)
+        d = Path(out_dir) / (timestamp or "x")
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+    args = [
+        "analyze.py",
+        "--config", str(cfg_path),
+        "--input", str(data_path),
+        "--output_dir", str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+
+    analyze.main()
+
+    summary = captured.get("summary", {})
+    assert summary["radon"]["Rn_activity_Bq"] == pytest.approx(5.0)
+    assert summary["radon"]["stat_unc_Bq"] == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- support event counts in `FitResult`
- estimate radon activity from counts when available
- test new radon counts hook

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b3a0c18e0832b810a00eaaea4db21