### PR TITLE
Add radon CI summary test

### DIFF
--- a/results/summary.json
+++ b/results/summary.json
@@ -1,0 +1,6 @@
+{
+  "radon": {
+    "Rn_activity_Bq": 0.0,
+    "stat_unc_Bq": 0.1
+  }
+}

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,10 @@
+import json
+import pytest
+import pathlib
+import math
+
+summary = json.load(open(pathlib.Path("results/summary.json")))
+
+def test_radon_present():
+    assert "radon" in summary and summary["radon"]["Rn_activity_Bq"] >= 0
+    assert math.isfinite(summary["radon"]["stat_unc_Bq"])


### PR DESCRIPTION
## Summary
- create a simple radon summary JSON fixture
- add `tests/test_summary.py` to check for radon information

## Testing
- `pytest -k test_summary -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b42d6b2b0832bb26fe4ba996c970b