### PR TITLE
Update run_assertions to handle radon summary

### DIFF
--- a/assertions_and_ci.py
+++ b/assertions_and_ci.py
@@ -16,6 +16,8 @@ def run_assertions(summary: Mapping[str, Any], constants: Mapping[str, Any], con
     config : mapping
         Loaded configuration dictionary.
     """
-    assert summary["baseline"]["corrected_activity"]["Po214"]["value"] >= 0
+    if "radon" in summary:
+        assert summary["radon"]["Rn_activity_Bq"] >= 0
+        assert summary["radon"]["stat_unc_Bq"] > 0
     assert constants["Po214"]["half_life_s"] < 1e3
     assert config["baseline"]["sample_volume_l"] > 0

--- a/tests/test_assertions_and_ci.py
+++ b/tests/test_assertions_and_ci.py
@@ -3,14 +3,14 @@ from assertions_and_ci import run_assertions
 
 
 def test_run_assertions_ok():
-    summary = {"baseline": {"corrected_activity": {"Po214": {"value": 0.1}}}}
+    summary = {"radon": {"Rn_activity_Bq": 1.0, "stat_unc_Bq": 0.1}}
     constants = {"Po214": {"half_life_s": 0.000164}}
     config = {"baseline": {"sample_volume_l": 1.0}}
     run_assertions(summary, constants, config)
 
 
 def test_run_assertions_negative_activity():
-    summary = {"baseline": {"corrected_activity": {"Po214": {"value": -1.0}}}}
+    summary = {"radon": {"Rn_activity_Bq": -1.0, "stat_unc_Bq": 0.1}}
     constants = {"Po214": {"half_life_s": 0.000164}}
     config = {"baseline": {"sample_volume_l": 1.0}}
     with pytest.raises(AssertionError):
@@ -18,7 +18,7 @@ def test_run_assertions_negative_activity():
 
 
 def test_run_assertions_invalid_half_life():
-    summary = {"baseline": {"corrected_activity": {"Po214": {"value": 0.1}}}}
+    summary = {"radon": {"Rn_activity_Bq": 1.0, "stat_unc_Bq": 0.1}}
     constants = {"Po214": {"half_life_s": 2000.0}}
     config = {"baseline": {"sample_volume_l": 1.0}}
     with pytest.raises(AssertionError):
@@ -26,7 +26,7 @@ def test_run_assertions_invalid_half_life():
 
 
 def test_run_assertions_invalid_sample_volume():
-    summary = {"baseline": {"corrected_activity": {"Po214": {"value": 0.1}}}}
+    summary = {"radon": {"Rn_activity_Bq": 1.0, "stat_unc_Bq": 0.1}}
     constants = {"Po214": {"half_life_s": 0.000164}}
     config = {"baseline": {"sample_volume_l": 0.0}}
     with pytest.raises(AssertionError):


### PR DESCRIPTION
## Summary
- update runtime assertion logic for new radon summary keys
- adjust unit tests for updated expectations

## Testing
- `python -m pytest tests/test_assertions_and_ci.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686b4de8c6c0832bb6735e091d9caf3d