### PR TITLE
Add radon summary assertions

### DIFF
--- a/assertions_and_ci.py
+++ b/assertions_and_ci.py
@@ -4,6 +4,7 @@ from typing import Mapping, Any
 
 __all__ = ["run_assertions"]
 
+
 def run_assertions(summary: Mapping[str, Any], constants: Mapping[str, Any], config: Mapping[str, Any]) -> None:
     """Validate key runtime invariants.
 
@@ -16,6 +17,12 @@ def run_assertions(summary: Mapping[str, Any], constants: Mapping[str, Any], con
     config : mapping
         Loaded configuration dictionary.
     """
+
+    if "radon" in summary:
+        assert summary["radon"]["Rn_activity_Bq"] >= 0
+        assert summary["radon"]["stat_unc_Bq"] > 0
+
+    # Baseline results should always be non-negative
     assert summary["baseline"]["corrected_activity"]["Po214"]["value"] >= 0
     assert constants["Po214"]["half_life_s"] < 1e3
     assert config["baseline"]["sample_volume_l"] > 0

--- a/tests/test_assertions_and_ci.py
+++ b/tests/test_assertions_and_ci.py
@@ -3,7 +3,10 @@ from assertions_and_ci import run_assertions
 
 
 def test_run_assertions_ok():
-    summary = {"baseline": {"corrected_activity": {"Po214": {"value": 0.1}}}}
+    summary = {
+        "baseline": {"corrected_activity": {"Po214": {"value": 0.1}}},
+        "radon": {"Rn_activity_Bq": 10.0, "stat_unc_Bq": 1.0},
+    }
     constants = {"Po214": {"half_life_s": 0.000164}}
     config = {"baseline": {"sample_volume_l": 1.0}}
     run_assertions(summary, constants, config)
@@ -17,9 +20,31 @@ def test_run_assertions_negative_activity():
         run_assertions(summary, constants, config)
 
 
+def test_run_assertions_invalid_radon_activity():
+    summary = {
+        "baseline": {"corrected_activity": {"Po214": {"value": 0.1}}},
+        "radon": {"Rn_activity_Bq": -1.0, "stat_unc_Bq": 1.0},
+    }
+    constants = {"Po214": {"half_life_s": 0.000164}}
+    config = {"baseline": {"sample_volume_l": 1.0}}
+    with pytest.raises(AssertionError):
+        run_assertions(summary, constants, config)
+
+
 def test_run_assertions_invalid_half_life():
     summary = {"baseline": {"corrected_activity": {"Po214": {"value": 0.1}}}}
     constants = {"Po214": {"half_life_s": 2000.0}}
+    config = {"baseline": {"sample_volume_l": 1.0}}
+    with pytest.raises(AssertionError):
+        run_assertions(summary, constants, config)
+
+
+def test_run_assertions_invalid_radon_uncertainty():
+    summary = {
+        "baseline": {"corrected_activity": {"Po214": {"value": 0.1}}},
+        "radon": {"Rn_activity_Bq": 1.0, "stat_unc_Bq": 0.0},
+    }
+    constants = {"Po214": {"half_life_s": 0.000164}}
     config = {"baseline": {"sample_volume_l": 1.0}}
     with pytest.raises(AssertionError):
         run_assertions(summary, constants, config)


### PR DESCRIPTION
## Summary
- update `run_assertions` to validate radon activity
- expand tests for new radon checks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b4de8c6c0832bb6735e091d9caf3d