### PR TITLE
Add radon plotting utilities

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -131,8 +131,6 @@ from plot_utils import (
     plot_spectrum,
     plot_time_series,
     plot_equivalent_air,
-    plot_radon_activity,
-    plot_radon_trend,
     plot_radon_activity_full,
     plot_radon_trend_full,
 )
@@ -2453,12 +2451,13 @@ def main(argv=None):
 
     if iso_mode == "radon":
         try:
-            rad_ts = summary["radon"]["time_series"]
+            radon = summary["radon"]
         except KeyError:
-            rad_ts = None
-        if rad_ts is not None:
-            plot_radon_activity(rad_ts, out_dir)
-            plot_radon_trend(rad_ts, out_dir)
+            radon = None
+        if radon is not None:
+            from plot_utils.radon import plot_radon_activity, plot_radon_trend
+            plot_radon_activity(radon["time_series"], out_dir)
+            plot_radon_trend(radon["time_series"], out_dir)
 
     # Generate plots now that the output directory exists
     if spec_plot_data:

--- a/plot_utils/radon.py
+++ b/plot_utils/radon.py
@@ -1,0 +1,37 @@
+import matplotlib.pyplot as plt
+import numpy as np
+from pathlib import Path
+
+
+def _save(fig, outdir: Path, name: str):
+    """Save figure to ``outdir`` as PNG and PDF, then close it."""
+    for ext in ("png", "pdf"):
+        fig.savefig(outdir / f"{name}.{ext}", dpi=300)
+    plt.close(fig)
+
+
+def plot_radon_activity(ts_dict, outdir: Path):
+    """Plot radon activity with uncertainties."""
+    t = np.asarray(ts_dict["time"])
+    a = np.asarray(ts_dict["activity"])
+    e = np.asarray(ts_dict["error"])
+    fig, ax = plt.subplots()
+    ax.errorbar(t, a, yerr=e, fmt="o")
+    ax.set_ylabel("Rn-222 activity [Bq]")
+    ax.set_xlabel("Time (UTC)")
+    _save(fig, outdir, "radon_activity")
+
+
+def plot_radon_trend(ts_dict, outdir: Path):
+    """Plot radon activity trend without uncertainties."""
+    t = np.asarray(ts_dict["time"])
+    a = np.asarray(ts_dict["activity"])
+    coeff = np.polyfit(t, a, 1)
+    fig, ax = plt.subplots()
+    ax.plot(t, a, "o")
+    ax.plot(t, np.polyval(coeff, t), label=f"slope={coeff[0]:.2e} Bq/s")
+    ax.set_ylabel("Rn-222 activity [Bq]")
+    ax.set_xlabel("Time (UTC)")
+    ax.legend()
+    _save(fig, outdir, "radon_trend")
+


### PR DESCRIPTION
## Summary
- add new `plot_utils.radon` module with simple plotting helpers
- update `analyze.py` to import radon plot helpers from the new module
- drop unused imports in `analyze.py`

## Testing
- `pytest tests/test_plot_utils.py::test_plot_radon_activity_output -q`

------
https://chatgpt.com/codex/tasks/task_e_686b4de06150832b9138e558ffc1eff4