### PR TITLE
Add radon plotting module

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -131,11 +131,10 @@ from plot_utils import (
     plot_spectrum,
     plot_time_series,
     plot_equivalent_air,
-    plot_radon_activity,
-    plot_radon_trend,
     plot_radon_activity_full,
     plot_radon_trend_full,
 )
+from plot_utils.radon import plot_radon_activity, plot_radon_trend
 from systematics import scan_systematics, apply_linear_adc_shift
 from visualize import cov_heatmap, efficiency_bar
 from utils import (

--- a/plot_utils/radon.py
+++ b/plot_utils/radon.py
@@ -1,0 +1,33 @@
+import matplotlib.pyplot as plt
+import numpy as np
+from pathlib import Path
+
+
+def _save(fig, outdir: Path, name: str) -> None:
+    for ext in ("png", "pdf"):
+        fig.savefig(outdir / f"{name}.{ext}", dpi=300)
+    plt.close(fig)
+
+
+def plot_radon_activity(ts_dict, outdir: Path) -> None:
+    t = np.asarray(ts_dict["time"])
+    a = np.asarray(ts_dict["activity"])
+    e = np.asarray(ts_dict["error"])
+    fig, ax = plt.subplots()
+    ax.errorbar(t, a, yerr=e, fmt="o")
+    ax.set_ylabel("Rn-222 activity [Bq]")
+    ax.set_xlabel("Time (UTC)")
+    _save(fig, outdir, "radon_activity")
+
+
+def plot_radon_trend(ts_dict, outdir: Path) -> None:
+    t = np.asarray(ts_dict["time"])
+    a = np.asarray(ts_dict["activity"])
+    coeff = np.polyfit(t, a, 1)
+    fig, ax = plt.subplots()
+    ax.plot(t, a, "o")
+    ax.plot(t, np.polyval(coeff, t), label=f"slope={coeff[0]:.2e} Bq/s")
+    ax.set_ylabel("Rn-222 activity [Bq]")
+    ax.set_xlabel("Time (UTC)")
+    ax.legend()
+    _save(fig, outdir, "radon_trend")


### PR DESCRIPTION
## Summary
- add `plot_utils.radon` with helpers for radon activity/trend plots
- import radon plotting utilities in `analyze.py`
- call new plotting helpers when radon analysis is selected

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b4de06150832b9138e558ffc1eff4