### PR TITLE
Add radon plotting utility module

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -131,11 +131,10 @@ from plot_utils import (
     plot_spectrum,
     plot_time_series,
     plot_equivalent_air,
-    plot_radon_activity,
-    plot_radon_trend,
     plot_radon_activity_full,
     plot_radon_trend_full,
 )
+from plot_utils.radon import plot_radon_activity, plot_radon_trend
 from systematics import scan_systematics, apply_linear_adc_shift
 from visualize import cov_heatmap, efficiency_bar
 from utils import (
@@ -2458,6 +2457,8 @@ def main(argv=None):
         except KeyError:
             rad_ts = None
         if rad_ts is not None:
+            from plot_utils.radon import plot_radon_activity, plot_radon_trend
+
             plot_radon_activity(rad_ts, out_dir)
             plot_radon_trend(rad_ts, out_dir)
 

--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from color_schemes import COLOR_SCHEMES
 from constants import PO214, PO218, PO210
 from .paths import get_targets
+from .radon import plot_radon_activity, plot_radon_trend
 
 # Half-life constants used for the time-series overlay [seconds]
 PO214_HALF_LIFE_S = PO214.half_life_s
@@ -673,36 +674,7 @@ def plot_radon_trend_full(times, activity, out_png, config=None):
     plt.close()
 
 
-def plot_radon_activity(ts_dict, outdir):
-    """Simple wrapper to plot radon activity time series."""
-    import matplotlib.pyplot as plt
-    outdir = Path(outdir)
-    t = ts_dict["time"]
-    y = ts_dict["activity"]
-    e = ts_dict["error"]
-    plt.errorbar(t, y, yerr=e, fmt="o")
-    plt.ylabel("Radon activity [Bq]")
-    plt.xlabel("Time (UTC)")
-    plt.tight_layout()
-    plt.savefig(outdir / "radon_activity.png", dpi=300)
-    plt.close()
 
-
-def plot_radon_trend(ts_dict, outdir):
-    """Simple wrapper to plot a radon activity trend."""
-    import numpy as np
-    import matplotlib.pyplot as plt
-    outdir = Path(outdir)
-    t = np.asarray(ts_dict["time"])
-    y = np.asarray(ts_dict["activity"])
-    coeff = np.polyfit(t, y, 1)
-    plt.plot(t, y, "o")
-    plt.plot(t, np.polyval(coeff, t))
-    plt.ylabel("Radon activity [Bq]")
-    plt.xlabel("Time (UTC)")
-    plt.tight_layout()
-    plt.savefig(outdir / "radon_trend.png", dpi=300)
-    plt.close()
 
 
 # -----------------------------------------------------

--- a/plot_utils/radon.py
+++ b/plot_utils/radon.py
@@ -1,0 +1,34 @@
+import matplotlib.pyplot as plt
+import numpy as np
+from pathlib import Path
+
+
+def _save(fig, outdir: Path, name: str):
+    for ext in ("png", "pdf"):
+        fig.savefig(outdir / f"{name}.{ext}", dpi=300)
+    plt.close(fig)
+
+
+def plot_radon_activity(ts_dict, outdir: Path):
+    t = np.asarray(ts_dict["time"])
+    a = np.asarray(ts_dict["activity"])
+    e = np.asarray(ts_dict["error"])
+    fig, ax = plt.subplots()
+    ax.errorbar(t, a, yerr=e, fmt="o")
+    ax.set_ylabel("Rn-222 activity [Bq]")
+    ax.set_xlabel("Time (UTC)")
+    _save(fig, outdir, "radon_activity")
+
+
+def plot_radon_trend(ts_dict, outdir: Path):
+    t = np.asarray(ts_dict["time"])
+    a = np.asarray(ts_dict["activity"])
+    coeff = np.polyfit(t, a, 1)
+    fig, ax = plt.subplots()
+    ax.plot(t, a, "o")
+    ax.plot(t, np.polyval(coeff, t), label=f"slope={coeff[0]:.2e} Bq/s")
+    ax.set_ylabel("Rn-222 activity [Bq]")
+    ax.set_xlabel("Time (UTC)")
+    ax.legend()
+    _save(fig, outdir, "radon_trend")
+


### PR DESCRIPTION
## Summary
- add `plot_utils.radon` module with helper plots
- import radon plotting helpers from new module
- call radon activity and trend plots after writing radon summary

## Testing
- `pytest tests/test_analyze_config_merge.py::test_analysis_start_time_applied -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c448bb880832b955317e49caa5135