### PR TITLE
Fix assertions test import

### DIFF
--- a/tests/test_assertions_and_ci.py
+++ b/tests/test_assertions_and_ci.py
@@ -1,4 +1,8 @@
+import sys
+from pathlib import Path
 import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from assertions_and_ci import run_assertions
 
 


### PR DESCRIPTION
## Summary
- ensure tests can import assertions by adding the repository root to `sys.path`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686da54914dc832bb80e8ad422e087e4