### PR TITLE
Add radon summary CI test

### DIFF
--- a/tests/test_radon_summary.py
+++ b/tests/test_radon_summary.py
@@ -1,0 +1,7 @@
+import json, pathlib, math
+
+def test_radon_block_present():
+    summ = json.load(open(pathlib.Path("results/summary.json")))
+    assert "radon" in summ, "Radon block missing in summary"
+    assert math.isfinite(summ["radon"]["Rn_activity_Bq"])
+    assert math.isfinite(summ["radon"]["stat_unc_Bq"])


### PR DESCRIPTION
## Summary
- add new test for radon block in summary

## Testing
- `bash scripts/setup_tests.sh`
- `pytest -q` *(fails: test_analyze_config_merge.py, test_calibration_method_cli.py, test_cli_negative_baseline.py)*

------
https://chatgpt.com/codex/tasks/task_e_686db3f08604832ba60715543ecb2f9e