### PR TITLE
Fix radon activity edge case

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -2479,11 +2479,12 @@ def main(argv=None):
 
     copy_config(results_dir, cfg, exist_ok=args.overwrite)
     out_dir = Path(write_summary(results_dir, summary))
+    out_dir.mkdir(parents=True, exist_ok=True)
 
     if iso_mode == "radon" and "radon" in summary:
         rad_ts = summary["radon"]["time_series"]
-        plot_radon_activity(rad_ts, out_dir)
-        plot_radon_trend(rad_ts, out_dir)
+        plot_radon_activity(rad_ts, out_dir, Path(out_dir) / "radon_activity.png")
+        plot_radon_trend(rad_ts, out_dir, Path(out_dir) / "radon_trend.png")
 
     # Generate plots now that the output directory exists
     if spec_plot_data:

--- a/plot_utils/radon.py
+++ b/plot_utils/radon.py
@@ -9,7 +9,7 @@ def _save(fig, outdir: Path, name: str) -> None:
     plt.close(fig)
 
 
-def plot_radon_activity(ts_dict, outdir: Path) -> None:
+def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None) -> None:
     t = np.asarray(ts_dict["time"])
     a = np.asarray(ts_dict["activity"])
     e = np.asarray(ts_dict["error"])
@@ -17,10 +17,14 @@ def plot_radon_activity(ts_dict, outdir: Path) -> None:
     ax.errorbar(t, a, yerr=e, fmt="o")
     ax.set_ylabel("Rn-222 activity [Bq]")
     ax.set_xlabel("Time (UTC)")
-    _save(fig, outdir, "radon_activity")
+    if out_png is not None:
+        fig.savefig(out_png, dpi=300)
+        plt.close(fig)
+    else:
+        _save(fig, outdir, "radon_activity")
 
 
-def plot_radon_trend(ts_dict, outdir: Path) -> None:
+def plot_radon_trend(ts_dict, outdir: Path, out_png: str | Path | None = None) -> None:
     t = np.asarray(ts_dict["time"])
     a = np.asarray(ts_dict["activity"])
     if t.size < 2:
@@ -33,4 +37,8 @@ def plot_radon_trend(ts_dict, outdir: Path) -> None:
     ax.set_ylabel("Rn-222 activity [Bq]")
     ax.set_xlabel("Time (UTC)")
     ax.legend()
-    _save(fig, outdir, "radon_trend")
+    if out_png is not None:
+        fig.savefig(out_png, dpi=300)
+        plt.close(fig)
+    else:
+        _save(fig, outdir, "radon_trend")

--- a/radon_joint_estimator.py
+++ b/radon_joint_estimator.py
@@ -100,6 +100,17 @@ def estimate_radon_activity(
     if f218 <= 0 or f214 <= 0:
         raise ValueError("fractions must be positive")
 
+    # Handle the special case when both counts are zero.  This avoids
+    # propagating NaNs further down in the calculation and signals that the
+    # activity is unconstrained.
+    if (N218 or 0) + (N214 or 0) == 0:
+        return {
+            "isotope_mode": analysis_isotope.lower(),
+            "Rn_activity_Bq": 0.0,
+            "stat_unc_Bq": float("inf"),
+            "components": {},
+        }
+
     consts = load_nuclide_overrides(nuclide_constants)
     lam_rn = _decay_constant(consts.get("Rn222", RN222).half_life_s)
     lam_218 = _decay_constant(consts.get("Po218", PO218).half_life_s)


### PR DESCRIPTION
## Summary
- avoid NaNs when both Po-218 and Po-214 counts are zero
- create output directory before plotting radon activity
- allow `plot_radon_activity` and `plot_radon_trend` to take an explicit output path

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686db467ba78832b8023b903189766f9