### PR TITLE
Fix isotope override logic and radon plotting

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -894,7 +894,7 @@ def main(argv=None):
         )
         cfg.setdefault("calibration", {})["noise_cutoff"] = int(args.noise_cutoff)
 
-    if args.iso is not None:
+    if args.iso:
         prev = cfg.get("analysis_isotope")
         if prev is not None and prev != args.iso:
             logging.info(
@@ -1882,7 +1882,7 @@ def main(argv=None):
             params=p,
         )
 
-    iso_mode = (args.iso or cfg.get("analysis_isotope", "radon")).lower()
+    iso_mode = cfg.get("analysis_isotope", "radon").lower()
 
     if iso_mode == "radon":
         have_218 = (
@@ -2482,8 +2482,16 @@ def main(argv=None):
 
     if iso_mode == "radon" and "radon" in summary:
         rad_ts = summary["radon"]["time_series"]
-        plot_radon_activity(rad_ts, out_dir)
-        plot_radon_trend(rad_ts, out_dir)
+        plot_radon_activity(
+            rad_ts,
+            out_dir,
+            Path(out_dir) / "radon_activity.png",
+        )
+        plot_radon_trend(
+            rad_ts,
+            out_dir,
+            Path(out_dir) / "radon_trend.png",
+        )
 
     # Generate plots now that the output directory exists
     if spec_plot_data:

--- a/plot_utils/radon.py
+++ b/plot_utils/radon.py
@@ -9,7 +9,9 @@ def _save(fig, outdir: Path, name: str) -> None:
     plt.close(fig)
 
 
-def plot_radon_activity(ts_dict, outdir: Path) -> None:
+def plot_radon_activity(ts_dict, outdir: Path, out_png: Path | None = None) -> None:
+    """Plot radon activity versus time."""
+
     t = np.asarray(ts_dict["time"])
     a = np.asarray(ts_dict["activity"])
     e = np.asarray(ts_dict["error"])
@@ -17,10 +19,20 @@ def plot_radon_activity(ts_dict, outdir: Path) -> None:
     ax.errorbar(t, a, yerr=e, fmt="o")
     ax.set_ylabel("Rn-222 activity [Bq]")
     ax.set_xlabel("Time (UTC)")
-    _save(fig, outdir, "radon_activity")
+
+    outdir = Path(outdir)
+    if out_png is None:
+        _save(fig, outdir, "radon_activity")
+    else:
+        out_png = Path(out_png)
+        out_png.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(out_png, dpi=300)
+        plt.close(fig)
 
 
-def plot_radon_trend(ts_dict, outdir: Path) -> None:
+def plot_radon_trend(ts_dict, outdir: Path, out_png: Path | None = None) -> None:
+    """Plot a radon activity trend."""
+
     t = np.asarray(ts_dict["time"])
     a = np.asarray(ts_dict["activity"])
     if t.size < 2:
@@ -33,4 +45,12 @@ def plot_radon_trend(ts_dict, outdir: Path) -> None:
     ax.set_ylabel("Rn-222 activity [Bq]")
     ax.set_xlabel("Time (UTC)")
     ax.legend()
-    _save(fig, outdir, "radon_trend")
+
+    outdir = Path(outdir)
+    if out_png is None:
+        _save(fig, outdir, "radon_trend")
+    else:
+        out_png = Path(out_png)
+        out_png.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(out_png, dpi=300)
+        plt.close(fig)


### PR DESCRIPTION
## Summary
- make CLI `--iso` override YAML config once at start
- use config exclusively for isotope mode
- ensure radon plots create output directories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686db4b6289c832ba5b415b7f342e549