### PR TITLE
Fix zero count radon estimates

### DIFF
--- a/radon_joint_estimator.py
+++ b/radon_joint_estimator.py
@@ -100,6 +100,14 @@ def estimate_radon_activity(
     if f218 <= 0 or f214 <= 0:
         raise ValueError("fractions must be positive")
 
+    if N214 is not None and N218 is not None and N214 + N218 == 0:
+        return {
+            "isotope_mode": "radon",
+            "Rn_activity_Bq": 0.0,
+            "stat_unc_Bq": float("inf"),
+            "components": {},
+        }
+
     consts = load_nuclide_overrides(nuclide_constants)
     lam_rn = _decay_constant(consts.get("Rn222", RN222).half_life_s)
     lam_218 = _decay_constant(consts.get("Po218", PO218).half_life_s)

--- a/tests/test_radon_joint_estimator.py
+++ b/tests/test_radon_joint_estimator.py
@@ -37,3 +37,9 @@ def test_radon_joint_estimator_combination():
     sigma = result["stat_unc_Bq"]
     assert abs(est - A_true) <= sigma
 
+
+def test_radon_joint_estimator_zero_counts():
+    result = estimate_radon_activity(0, 1.0, 1.0, 0, 1.0, 1.0)
+    assert result["Rn_activity_Bq"] == 0.0
+    assert math.isinf(result["stat_unc_Bq"])
+


### PR DESCRIPTION
## Summary
- avoid NaN uncertainties if both Po-218 and Po-214 counts are zero
- test estimator on zero-count input

## Testing
- `pytest tests/test_radon_joint_estimator.py::test_radon_joint_estimator_zero_counts -q`
- `pytest -q` *(fails: test_analyze_config_merge.py, test_calibration_method_cli.py, test_cli_negative_baseline.py)*

------
https://chatgpt.com/codex/tasks/task_e_686db467ba78832b8023b903189766f9