### PR TITLE
Fix BLUE weights summary assignment

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -2468,6 +2468,7 @@ def main(argv=None):
         raise ValueError(f"Unknown analysis_isotope {iso_mode!r}")
 
     if weights is not None:
+        summary.efficiency = summary.efficiency or {}
         summary.efficiency["blue_weights"] = list(weights)
 
     results_dir = Path(args.output_dir) / (args.job_id or now_str)


### PR DESCRIPTION
## Summary
- guard BLUE weight insertion against missing summary.efficiency dict

## Testing
- `pytest -q tests/test_blue_weights.py::test_blue_weights_summary tests/test_blue.py::test_blue_weights_normalization`


------
https://chatgpt.com/codex/tasks/task_e_686db47f43ec832bb3275586c93c9713