### PR TITLE
Add wavelet peak detection option

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,12 @@ fit.  Important keys include:
 - `expected_peaks` – approximate ADC centroids used to locate the
   Po‑210, Po‑218 and Po‑214 peaks before fitting. The default is
   `{"Po210": 1250, "Po218": 1400, "Po214": 1800}`.
+- `peak_search_method` – algorithm used for the initial centroid search.
+  `"prominence"` applies `find_peaks` with the `peak_search_prominence` and
+  `peak_search_width_adc` thresholds. `"cwt"` uses
+  `find_peaks_cwt` with widths from `peak_search_cwt_widths`.
+- `peak_search_cwt_widths` – list of widths for wavelet peak detection
+  when `peak_search_method` is `"cwt"`.
 - `unbinned_likelihood` – when `true` use an extended unbinned likelihood
   instead of the default χ² fit to histogrammed data.
 - `emg_left` evaluations are wrapped in `np.errstate` and passed through
@@ -621,9 +627,10 @@ centroids. Time parsing utilities are available from `utils.time_utils`:
 - `to_epoch_seconds(ts_or_str)` from `utils.time_utils` converts these inputs to
   Unix seconds.
 
-- `find_adc_bin_peaks(adc_values, expected, window=50, prominence=0.0, width=None)`
+- `find_adc_bin_peaks(adc_values, expected, window=50, prominence=0.0, width=None, method="prominence")`
   histogramises the raw ADC spectrum, searches for maxima near each expected
-  centroid and returns a `{peak: adc_centroid}` mapping in ADC units.
+  centroid and returns a `{peak: adc_centroid}` mapping in ADC units.  Set
+  `method="cwt"` to use wavelet-based peak detection via `find_peaks_cwt`.
 
 You can invoke these from the command line:
 

--- a/analyze.py
+++ b/analyze.py
@@ -1538,6 +1538,8 @@ def main(argv=None):
             window=cfg["spectral_fit"].get("peak_search_width_adc", 50),
             prominence=cfg["spectral_fit"].get("peak_search_prominence", 0),
             width=cfg["spectral_fit"].get("peak_search_width_adc", None),
+            method=cfg["spectral_fit"].get("peak_search_method", "prominence"),
+            cwt_widths=cfg["spectral_fit"].get("peak_search_cwt_widths"),
         )
 
         # Build priors for the unbinned spectrum fit:

--- a/config.yaml
+++ b/config.yaml
@@ -90,6 +90,8 @@ spectral_fit:
   sigma_E_prior_source: 0.15
   peak_search_prominence: 30
   peak_search_width_adc: 3
+  peak_search_method: prominence
+  peak_search_cwt_widths: null
   use_plot_bins_for_fit: false
   unbinned_likelihood: true
   mu_bounds:

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -5,6 +5,9 @@ allow_negative_activity: false
 calibration:
   slope_MeV_per_ch: null
   intercept_MeV: null
+spectral_fit:
+  peak_search_method: prominence
+  peak_search_cwt_widths: null
 time_fit:
   window_po214:
   - 7.55

--- a/examples/config_fixed_slope.json
+++ b/examples/config_fixed_slope.json
@@ -72,6 +72,8 @@
         "sigma_E_prior_source": 0.15,
         "peak_search_prominence": 30,
         "peak_search_width_adc": 3,
+        "peak_search_method": "prominence",
+        "peak_search_cwt_widths": null,
         "use_plot_bins_for_fit": false,
         "unbinned_likelihood": false,
         "mu_bounds": {

--- a/tests/test_expected_peaks_default.py
+++ b/tests/test_expected_peaks_default.py
@@ -24,6 +24,7 @@ def test_expected_peaks_default(tmp_path, monkeypatch):
             "amp_prior_scale": 1.0,
             "b0_prior": [0.0, 1.0],
             "b1_prior": [0.0, 1.0],
+            "peak_search_method": "cwt",
         },
         "time_fit": {"do_time_fit": False},
         "systematics": {"enable": False},
@@ -75,6 +76,7 @@ def test_expected_peaks_default(tmp_path, monkeypatch):
 
     def fake_find_adc_bin_peaks(adc_values, expected, **kwargs):
         captured["expected"] = expected
+        captured["method"] = kwargs.get("method")
         return {k: float(v) for k, v in expected.items()}
 
     monkeypatch.setattr(analyze, "find_adc_bin_peaks", fake_find_adc_bin_peaks)
@@ -93,4 +95,5 @@ def test_expected_peaks_default(tmp_path, monkeypatch):
     analyze.main()
 
     assert captured.get("expected") == DEFAULT_ADC_CENTROIDS
+    assert captured.get("method") == "cwt"
 


### PR DESCRIPTION
## Summary
- allow `find_adc_bin_peaks` to use wavelet-based `find_peaks_cwt`
- document new `method` parameter in README
- make detection method configurable with `peak_search_method`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875b85b237c832ba2b59ecaf3057129