### PR TITLE
Remove unicode characters causing Windows console issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ To disable the cut:
 ```
 
 `slope_MeV_per_ch` may also be specified under `calibration` to fix the
-ADC→MeV conversion. When this slope is given the two‑point fit is skipped
+ADC->MeV conversion. When this slope is given the two-point fit is skipped
 and the provided value is used directly. If `intercept_MeV` is also
 supplied the calibration is fully fixed and Po‑214 is no longer searched.
 Set either value to `null` to retain the automatic calibration.
@@ -439,7 +439,7 @@ Example snippet:
 `plot_time_series` can also display uncertainty bands around the model
 curves.  Pass arrays of propagated errors via the optional
 `model_errors` argument.  When running `analyze.py` these arrays are
-derived from the fitted parameters (`corrected_sigma`) so shaded ±1σ
+derived from the fitted parameters (`corrected_sigma`) so shaded +/-1 sigma
 regions appear alongside the dashed model lines.
 
 `plot_time_series` takes its half-life values from the `time_fit` section.
@@ -643,7 +643,7 @@ python utils.py 0.5 --to bq --volume_liters 10
 
 `calibration.CalibrationResult` stores the energy calibration
 parameters.  Use `predict()` to convert ADC values to MeV and
-`uncertainty()` to propagate the 1‑σ error:
+`uncertainty()` to propagate the 1-sigma error:
 
 ```python
 from calibration import CalibrationResult

--- a/analyze.py
+++ b/analyze.py
@@ -28,7 +28,7 @@ This script performs the following steps:
      -> Subtract global t₀ so that model always starts at t=0.
      -> Fit unbinned decay (with efficiency, background, N₀, half‐life priors).
      -> Overlay fit curve on a time‐binned histogram (default 1 h bins), at 95% CL.
-  7. (Optional) Systematics scan around user‐specified σ shifts.
+  7. (Optional) Systematics scan around user-specified sigma shifts.
   8. Produce a single JSON summary with:
        • calibration parameters
        • spectral‐fit outputs
@@ -1544,7 +1544,7 @@ def main(argv=None):
 
         # Build priors for the unbinned spectrum fit:
         priors_spec = {}
-        # σ_E prior
+        # sigma_E prior
         priors_spec["sigma_E"] = (
             sigE_mean,
             cfg["spectral_fit"].get("sigma_E_prior_source", sigE_sigma),
@@ -1710,7 +1710,7 @@ def main(argv=None):
             eff_val, sigma = _eff_prior(eff_cfg_val)
             priors_time["eff"] = (eff_val, sigma)
 
-        # Half-life prior (user must supply [T₁/₂, σ(T₁/₂)] in seconds)
+        # Half-life prior (user must supply [T1/2, sigma(T1/2)] in seconds)
         hl_key = f"hl_{iso.lower()}"
         hl_val = cfg["time_fit"].get(hl_key)
         if hl_val is not None:

--- a/calibration.py
+++ b/calibration.py
@@ -301,7 +301,7 @@ def calibrate_run(adc_values, config, hist_bins=None):
 
     # 4) For each chosen peak, perform a local fit with EMG or Gaussian:
     peak_fits = {}
-    window = config["calibration"]["fit_window_adc"]  # e.g. ±50 ADC channels
+    window = config["calibration"]["fit_window_adc"]  # e.g. +/-50 ADC channels
     use_emg = config["calibration"]["use_emg"]  # True/False
     for iso, idx_center in chosen_idx.items():
         x0 = centers[idx_center]
@@ -435,7 +435,7 @@ def calibrate_run(adc_values, config, hist_bins=None):
         if diff > tol:
             raise RuntimeError(
                 f"{iso} peak at {peak_fits[iso]['centroid_mev']:.3f} MeV "
-                f"outside ±{tol} MeV of expected {energies[iso]}"
+                f"outside +/-{tol} MeV of expected {energies[iso]}"
             )
 
     # 7) Propagate centroid uncertainties to calibration coefficients
@@ -483,7 +483,7 @@ def calibrate_run(adc_values, config, hist_bins=None):
         cov_a_a2 = 0.0
         cov_a2_c = 0.0
 
-    # 8) Convert σADC -> σE (MeV) using local derivative at the Po-214 peak.
+    # 8) Convert sigma_ADC -> sigma_E (MeV) using local derivative at the Po-214 peak.
     slope_local = 2 * a2 * adc214 + a
     sigma_adc214 = peak_fits["Po214"]["sigma_adc"]
     sigma_E = abs(slope_local) * sigma_adc214

--- a/constants.py
+++ b/constants.py
@@ -17,7 +17,7 @@ DEFAULT_NOISE_CUTOFF = 400
 # Iteration cap for ``scipy.optimize.curve_fit``
 CURVE_FIT_MAX_EVALS = 10000
 
-# Clip exponents to ``±EXP_OVERFLOW_DOUBLE`` to avoid floating-point overflow
+# Clip exponents to ``+/-EXP_OVERFLOW_DOUBLE`` to avoid floating-point overflow
 # when evaluating functions with large tails (e.g. EMG).
 def safe_exp(x: np.ndarray) -> np.ndarray:
     """Return ``exp(x)`` with the input clipped to ``[-EXP_OVERFLOW_DOUBLE, EXP_OVERFLOW_DOUBLE]``."""

--- a/fitting.py
+++ b/fitting.py
@@ -225,7 +225,7 @@ def fit_spectrum(
     flags : dict, optional
         Flags such as ``{"fix_sigma0": True}`` to fix parameters. Fixed
         parameters are implemented by constraining the optimizer to a tiny
-        interval (``±1e-12``) around the provided mean value.
+        interval (``+/-1e-12``) around the provided mean value.
     bins : int or sequence, optional
         Number of bins or bin edges to use when histogramming the input
         energies.  Ignored if ``bin_edges`` is provided.  If both ``bins``
@@ -238,7 +238,7 @@ def fit_spectrum(
         defined by ``bin_edges``.
     bounds : dict, optional
         Mapping of parameter name to ``(lower, upper)`` tuples overriding the
-        default ±5σ range derived from the priors.  ``None`` values disable a
+        default +/-5 sigma range derived from the priors.  ``None`` values disable a
         limit on that side.
     unbinned : bool, optional
         When ``True`` use an extended unbinned likelihood fit instead of the

--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -111,7 +111,7 @@ def plot_time_series(
     model_errors : dict[str, array-like], optional
         Mapping of isotope name to 1D arrays of uncertainties for the
         model curve. When provided, ``fill_between`` is used to draw
-        ±1σ bands around the corresponding model.
+        +/-1 sigma bands around the corresponding model.
     """
 
     if fit_results is None:
@@ -247,7 +247,7 @@ def plot_time_series(
             n_bins = 1
 
     # ------------------------------------------------------------------
-    # Build equally-spaced edges so Δt is identical for each bin
+    # Build equally-spaced edges so delta t is identical for each bin
     # ------------------------------------------------------------------
     if bin_mode not in ("fd", "auto"):
         edges = np.arange(0, (n_bins + 1) * dt, dt, dtype=float)

--- a/radon_activity.py
+++ b/radon_activity.py
@@ -324,7 +324,7 @@ def print_activity_breakdown(rows: list[dict[str, object]]) -> None:
                 "Raw (Bq)",
                 "Baseline (Bq)",
                 "Corrected (Bq)",
-                "σ (Bq)",
+                "Err (Bq)",
             ]
         )
         for row in rows:
@@ -339,7 +339,7 @@ def print_activity_breakdown(rows: list[dict[str, object]]) -> None:
             )
         print(table.draw())
     except Exception:
-        headings = ["Isotope", "Raw (Bq)", "Baseline (Bq)", "Corrected (Bq)", "σ (Bq)"]
+        headings = ["Isotope", "Raw (Bq)", "Baseline (Bq)", "Corrected (Bq)", "Err (Bq)"]
         str_rows = [
             [
                 str(row.get("iso", "")),
@@ -355,16 +355,16 @@ def print_activity_breakdown(rows: list[dict[str, object]]) -> None:
             for i, val in enumerate(r):
                 widths[i] = max(widths[i], len(val))
 
-        top = "┌" + "┬".join("─" * w for w in widths) + "┐"
+        top = "+" + "+".join("-" * w for w in widths) + "+"
         print(top)
-        header = "│" + "│".join(h.ljust(widths[i]) for i, h in enumerate(headings)) + "│"
+        header = "|" + "|".join(h.ljust(widths[i]) for i, h in enumerate(headings)) + "|"
         print(header)
-        middle = "├" + "┼".join("─" * w for w in widths) + "┤"
+        middle = "+" + "+".join("-" * w for w in widths) + "+"
         print(middle)
         for r in str_rows:
-            line = "│" + "│".join(r[i].ljust(widths[i]) for i in range(len(widths))) + "│"
+            line = "|" + "|".join(r[i].ljust(widths[i]) for i in range(len(widths))) + "|"
             print(line)
-        bottom = "└" + "┴".join("─" * w for w in widths) + "┘"
+        bottom = "+" + "+".join("-" * w for w in widths) + "+"
         print(bottom)
 
     # Compute total radon activity from the corrected rates
@@ -379,4 +379,4 @@ def print_activity_breakdown(rows: list[dict[str, object]]) -> None:
             err214 = float(cast(float, row.get("err_corrected", 0.0)))
 
     total, sigma = compute_radon_activity(rate218, err218, 1.0, rate214, err214, 1.0)
-    print(f"Total radon: {total:.3f} ± {sigma:.3f} Bq")
+    print(f"Total radon: {total:.3f} +/- {sigma:.3f} Bq")

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -90,7 +90,7 @@ def find_adc_bin_peaks(
     expected : dict
         Mapping of peak name -> expected ADC centroid.
     window : int, optional
-        Search window around each expected centroid (± window).
+        Search window around each expected centroid (+/- window).
     prominence : float, optional
         Minimum prominence passed to :func:`scipy.signal.find_peaks`.
         Ignored when ``method`` is ``"cwt"``.


### PR DESCRIPTION
## Summary
- sanitize messages and comments to avoid Unicode symbols that may break on Windows
- replace table drawing characters in `radon_activity` with simple ASCII
- update docs accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877b01e79fc832b8629fe711f0b5ce6