### PR TITLE
Enhance spectral fitting stability

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -92,6 +92,7 @@ spectral_fit:
   peak_search_width_adc: 3
   peak_search_method: prominence
   peak_search_cwt_widths: null
+  refit_aic_threshold: 2.0
   use_plot_bins_for_fit: false
   unbinned_likelihood: true
   mu_bounds:

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -8,6 +8,7 @@ calibration:
 spectral_fit:
   peak_search_method: prominence
   peak_search_cwt_widths: null
+  refit_aic_threshold: 2.0
 time_fit:
   window_po214:
   - 7.55


### PR DESCRIPTION
## Summary
- enforce positive amplitudes and optional tau width cap in `fit_spectrum`
- compute AIC for spectrum fits
- automatically refit spectrum with fixed tau when covariance invalid
- expose `refit_aic_threshold` in default configs
- add regression tests for amplitude bounds and tail stability

## Testing
- `pip install -r requirements.txt`
- `pytest -k fitting -q`

------
https://chatgpt.com/codex/tasks/task_e_687c36fadf8c832b90bdc5c7a39ccc37