### PR TITLE
Adaptive time fit improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,8 +311,9 @@ The CLI options `--plot-time-binning-mode` (deprecated alias
 `--time-bin-mode`) and `--plot-time-bin-width` override
 `plot_time_binning_mode` and `plot_time_bin_width_s` in the configuration
 to control the time-series histogram. Passing `--dump-time-series-json`
-(alias `--dump-ts-json`) writes the histogram counts to a `*_ts.json`
-file alongside the plot.
+(alias `--dump-ts-json`) writes a `*_ts.json` file alongside the plot
+containing the binned counts together with per-bin live time and
+detection efficiency.
 
 Additional convenience flags include `--spike-count` (with optional
 `--spike-count-err`) to override spike efficiency inputs, `--slope` to

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -19,3 +19,4 @@ time_fit:
   window_po210:
   - 5.25
   - 5.37
+  min_counts: 20

--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -378,7 +378,7 @@ def plot_time_series(
     if config.get("dump_time_series_json", False):
         import json
 
-        ts_summary = {"centers_s": centers.tolist()}
+        ts_summary = {"centers_s": centers.tolist(), "widths_s": bin_widths.tolist()}
         for iso in iso_list:
             emin, emax = iso_params[iso]["window"]
             ts_summary[f"counts_{iso}"] = np.histogram(
@@ -390,6 +390,8 @@ def plot_time_series(
                 ],
                 bins=edges,
             )[0].tolist()
+            ts_summary[f"live_time_{iso}_s"] = bin_widths.tolist()
+            ts_summary[f"eff_{iso}"] = [iso_params[iso]["eff"]] * len(bin_widths)
         base = Path(out_png).with_suffix("")
         json_path = base.with_name(base.name + "_ts.json")
         with open(json_path, "w") as jf:

--- a/tests/test_auto_window_expand.py
+++ b/tests/test_auto_window_expand.py
@@ -1,0 +1,15 @@
+import pandas as pd
+import numpy as np
+import analyze
+
+
+def test_auto_expand_window_recovers_counts():
+    df = pd.DataFrame({
+        "timestamp": pd.date_range("1970-01-01", periods=5, freq="s"),
+        "energy_MeV": np.full(5, 7.72),
+        "denergy_MeV": np.full(5, 0.01),
+    })
+    events, win = analyze.auto_expand_window(df, (7.71, 7.71), threshold=5, step=0.02)
+    assert len(events) == 5
+    assert win[0] < 7.71 and win[1] > 7.71
+

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -70,6 +70,9 @@ def test_plot_time_series_auto_fd(tmp_path):
         data = json.load(f)
 
     centers = data["centers_s"]
+    assert "widths_s" in data
+    assert "eff_Po214" in data
+    assert "live_time_Po214_s" in data
     arr = times - 1000.0
     q25, q75 = np.percentile(arr[(arr >= 0) & (arr <= 5)], [25, 75])
     iqr = q75 - q25


### PR DESCRIPTION
## Summary
- add auto_expand_window helper for flexible energy windows
- use auto expansion in analyze time fit loop
- apply likelihood ratio test for decay fits
- store per-bin live time and efficiency in ts JSON files
- document ts JSON enhancements
- test window expansion and updated plotting JSON

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884e5ec4f88832b869637b2767ff6d8