### PR TITLE
Expose version check helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ This project requires **Python 3.11** or newer.
 pip install -r requirements.txt
 ```
 
+Verify your NumPy and SciPy versions if desired:
+
+```python
+import RMTest
+RMTest.check_versions()
+```
+
 ## Usage
 
 ```bash

--- a/__init__.py
+++ b/__init__.py
@@ -6,13 +6,12 @@ from .efficiency import (
     calc_decay_efficiency,
     blue_combine,
 )
-from .version_check import check_versions as _check_versions
-
-_check_versions()
+from .version_check import check_versions
 
 __all__ = [
     "calc_spike_efficiency",
     "calc_assay_efficiency",
     "calc_decay_efficiency",
     "blue_combine",
+    "check_versions",
 ]


### PR DESCRIPTION
## Summary
- remove automatic version check on import
- make `check_versions` public
- document how to run version check manually

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887f0ddcf28832b8d1cf9772e938701