### PR TITLE
Fix parameter order in radon_activity_curve docstring

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -243,11 +243,11 @@ def radon_activity_curve(
         Initial activity parameter.
     dN0 : float
         Uncertainty on ``N0``.
+    half_life_s : float
+        Half-life used for the decay model.
     cov_en0 : float, optional
         Covariance between ``E`` and ``N0``. Default is ``0.0`` and disables
         the cross term in the uncertainty propagation.
-    half_life_s : float
-        Half-life used for the decay model.
 
     Returns
     -------


### PR DESCRIPTION
## Summary
- correct docstring argument order to match `radon_activity_curve` signature

## Testing
- `pytest tests/test_radon_activity.py::test_radon_activity_curve -q`


------
https://chatgpt.com/codex/tasks/task_e_6887f0e9fe20832b9f017fe72534e1c6