### PR TITLE
Add validation for calc_activity

### DIFF
--- a/baseline.py
+++ b/baseline.py
@@ -1,8 +1,32 @@
 from baseline_utils import rate_histogram, subtract
 
 
-def calc_activity(counts, live_time_s):
-    return counts / live_time_s  # Bq
+def calc_activity(counts: float, live_time_s: float) -> float:
+    """Compute activity from event counts and exposure time.
+
+    Parameters
+    ----------
+    counts : float
+        Number of detected counts.
+    live_time_s : float
+        Exposure time in seconds.
+
+    Returns
+    -------
+    float
+        Activity in Bq.
+
+    Raises
+    ------
+    ValueError
+        If ``live_time_s`` is non-positive or ``counts`` is negative.
+    """
+
+    if live_time_s <= 0:
+        raise ValueError("live_time_s must be positive")
+    if counts < 0:
+        raise ValueError("counts cannot be negative")
+    return float(counts) / float(live_time_s)
 
 # Backwards compatibility
 subtract_baseline = subtract

--- a/tests/test_calc_activity.py
+++ b/tests/test_calc_activity.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import baseline
+
+
+def test_calc_activity_basic():
+    assert baseline.calc_activity(50, 10.0) == pytest.approx(5.0)
+
+
+def test_calc_activity_zero_live_time():
+    with pytest.raises(ValueError):
+        baseline.calc_activity(1, 0)
+
+
+def test_calc_activity_negative_live_time():
+    with pytest.raises(ValueError):
+        baseline.calc_activity(1, -1.0)
+
+
+def test_calc_activity_negative_counts():
+    with pytest.raises(ValueError):
+        baseline.calc_activity(-5, 10.0)


### PR DESCRIPTION
## Summary
- add checks for positive live time and non-negative counts in `calc_activity`
- document `calc_activity`
- add unit tests for these conditions

## Testing
- `pytest tests/test_calc_activity.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688813881860832b8b8fda3402fe0266