### PR TITLE
Allow negative BLUE weights by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,6 +719,11 @@ Here `activity_bq` is the spike activity expressed in decays per second (Bq).
 The helper `blue_combine.py` exposes a small wrapper so the combination
 can be used independently via ``from blue_combine import BLUE``.
 
+When measurements are strongly correlated the optimal BLUE weights can
+be slightly negative.  Negative weights are allowed by default and
+emit a warning.  Pass ``allow_negative=False`` to ``blue_combine`` if
+such weights should instead raise an exception.
+
 The option `--efficiency-json PATH` may be supplied on the command line to
 load the efficiency section from a separate file instead of embedding it
 directly in the main configuration.  Similarly `--systematics-json PATH`

--- a/blue_combine.py
+++ b/blue_combine.py
@@ -12,9 +12,15 @@ def blue_combine(
     errors: Sequence[float],
     corr: Optional[np.ndarray] = None,
     *,
-    allow_negative: bool = False,
+    allow_negative: bool = True,
 ):
-    """Passthrough to :func:`efficiency.blue_combine` with kwarg support."""
+    """Passthrough to :func:`efficiency.blue_combine` with kwarg support.
+
+    Parameters
+    ----------
+    allow_negative : bool, optional
+        Permit negative BLUE weights (default: ``True``).
+    """
     return _efficiency_blue_combine(
         values,
         errors,
@@ -31,8 +37,14 @@ class Measurements:
     corr: Optional[np.ndarray] = None
 
 
-def BLUE(measurements: Measurements, *, allow_negative: bool = False):
-    """Return BLUE combination of the given measurements."""
+def BLUE(measurements: Measurements, *, allow_negative: bool = True):
+    """Return BLUE combination of the given measurements.
+
+    Parameters
+    ----------
+    allow_negative : bool, optional
+        Permit negative BLUE weights (default: ``True``).
+    """
     return blue_combine(
         measurements.values,
         measurements.errors,

--- a/efficiency.py
+++ b/efficiency.py
@@ -91,7 +91,7 @@ def blue_combine(
     errors: Sequence[float],
     corr: Optional[np.ndarray] = None,
     *,
-    allow_negative: bool = False,
+    allow_negative: bool = True,
 ) -> Tuple[float, float, np.ndarray]:
     """Combine estimates using the BLUE method.
 
@@ -116,9 +116,9 @@ def blue_combine(
 
     Notes
     -----
-    If ``allow_negative`` is ``False`` and any resulting weight is
-    negative, a :class:`ValueError` is raised.  Otherwise a
-    ``UserWarning`` is emitted.
+    When BLUE weights become negative and ``allow_negative`` is ``False``
+    a :class:`ValueError` is raised.  With ``allow_negative`` set to
+    ``True`` (the default) a ``UserWarning`` is emitted instead.
     """
     vals = np.asarray(values, dtype=float)
     errs = np.asarray(errors, dtype=float)

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -77,12 +77,13 @@ def test_blue_combine_negative_weights_warning():
     assert np.any(weights < 0)
 
 
-def test_blue_combine_negative_weights_error():
+def test_blue_combine_negative_weights_default_warning():
     vals = np.array([1.0, 2.0])
     errs = np.array([0.1, 0.2])
     corr = np.array([[1.0, 0.99], [0.99, 1.0]])
-    with pytest.raises(ValueError):
-        blue_combine(vals, errs, corr)
+    with pytest.warns(UserWarning):
+        _, _, weights = blue_combine(vals, errs, corr)
+    assert np.any(weights < 0)
 
 
 def test_blue_combine_singular_matrix_error():


### PR DESCRIPTION
## Summary
- allow slightly negative BLUE weights without raising
- update docs and tests for new behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688813988030832b8bc26eac7d928b6b