### PR TITLE
Allow negative BLUE weights by default

### DIFF
--- a/blue_combine.py
+++ b/blue_combine.py
@@ -12,7 +12,7 @@ def blue_combine(
     errors: Sequence[float],
     corr: Optional[np.ndarray] = None,
     *,
-    allow_negative: bool = False,
+    allow_negative: bool = True,
 ):
     """Passthrough to :func:`efficiency.blue_combine` with kwarg support."""
     return _efficiency_blue_combine(
@@ -31,7 +31,7 @@ class Measurements:
     corr: Optional[np.ndarray] = None
 
 
-def BLUE(measurements: Measurements, *, allow_negative: bool = False):
+def BLUE(measurements: Measurements, *, allow_negative: bool = True):
     """Return BLUE combination of the given measurements."""
     return blue_combine(
         measurements.values,

--- a/efficiency.py
+++ b/efficiency.py
@@ -91,7 +91,7 @@ def blue_combine(
     errors: Sequence[float],
     corr: Optional[np.ndarray] = None,
     *,
-    allow_negative: bool = False,
+    allow_negative: bool = True,
 ) -> Tuple[float, float, np.ndarray]:
     """Combine estimates using the BLUE method.
 
@@ -116,9 +116,9 @@ def blue_combine(
 
     Notes
     -----
-    If ``allow_negative`` is ``False`` and any resulting weight is
-    negative, a :class:`ValueError` is raised.  Otherwise a
-    ``UserWarning`` is emitted.
+    By default negative weights are allowed but result in a
+    ``UserWarning``.  Pass ``allow_negative=False`` to raise a
+    :class:`ValueError` instead.
     """
     vals = np.asarray(values, dtype=float)
     errs = np.asarray(errors, dtype=float)

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -73,7 +73,7 @@ def test_blue_combine_negative_weights_warning():
     errs = np.array([0.1, 0.2])
     corr = np.array([[1.0, 0.99], [0.99, 1.0]])
     with pytest.warns(UserWarning):
-        _, _, weights = blue_combine(vals, errs, corr, allow_negative=True)
+        _, _, weights = blue_combine(vals, errs, corr)
     assert np.any(weights < 0)
 
 
@@ -82,7 +82,7 @@ def test_blue_combine_negative_weights_error():
     errs = np.array([0.1, 0.2])
     corr = np.array([[1.0, 0.99], [0.99, 1.0]])
     with pytest.raises(ValueError):
-        blue_combine(vals, errs, corr)
+        blue_combine(vals, errs, corr, allow_negative=False)
 
 
 def test_blue_combine_singular_matrix_error():


### PR DESCRIPTION
## Summary
- relax default check for BLUE weights in `efficiency.blue_combine`
- update wrapper module and adjust tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688813988030832b8bc26eac7d928b6b