### PR TITLE
Respect --allow-negative-activity flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,9 +681,10 @@ The Po‑214 activity alone is plotted in `radon_activity_po214.png`. When
 ambient concentration data are available, `equivalent_air_po214.png`
 shows the equivalent air volume derived from this Po‑214 activity.
 
-If the combined activity of Po‑214 and Po‑218 is negative it is clamped to
-zero by default and the pipeline aborts.  Pass `--allow-negative-activity`
-to continue processing with a total radon value of `0 Bq`.
+If the combined activity of Po‑214 and Po‑218 is negative the pipeline
+aborts by default after clamping the result to zero.  Passing
+`--allow-negative-activity` preserves the negative value and processing
+continues.
 
 ### Radon vs Po214 Mode
 

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -204,15 +204,13 @@ def test_compute_total_radon_negative_activity_default_raises():
 
 
 def test_compute_total_radon_negative_activity_allowed(caplog):
-    with caplog.at_level(logging.WARNING):
-        conc, dconc, tot, dtot = compute_total_radon(
-            -1.0, 0.5, 10.0, 1.0, allow_negative_activity=True
-        )
-    assert conc == pytest.approx(0.0)
+    conc, dconc, tot, dtot = compute_total_radon(
+        -1.0, 0.5, 10.0, 1.0, allow_negative_activity=True
+    )
+    assert conc == pytest.approx(-0.1)
     assert dconc == pytest.approx(0.05)
-    assert tot == pytest.approx(0.0)
+    assert tot == pytest.approx(-0.1)
     assert dtot == pytest.approx(0.05)
-    assert "Clamped negative activity" in caplog.text
 
 
 def test_radon_activity_curve():


### PR DESCRIPTION
## Summary
- preserve negative activity values when `--allow-negative-activity` is passed
- document new behaviour
- update unit tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68897487ab30832b98e304cceb01bd81