### PR TITLE
Improve timezone handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,6 +634,9 @@ centroids. Time parsing utilities are available from `utils.time_utils`:
   always yields a UTC `pandas.Timestamp`.
 - `to_epoch_seconds(ts_or_str)` from `utils.time_utils` converts these inputs to
   Unix seconds.
+- `baseline_utils.baseline_period_before_data(end, start)` returns ``True`` if
+  the baseline interval ends before the data window begins.  Both inputs may be
+  naïve or timezone-aware and are compared in UTC to avoid subtle mismatches.
 
 - `find_adc_bin_peaks(adc_values, expected, window=50, prominence=0.0, width=None, method="prominence")`
   histogramises the raw ADC spectrum, searches for maxima near each expected

--- a/baseline_utils.py
+++ b/baseline_utils.py
@@ -46,11 +46,24 @@ def compute_dilution_factor(monitor_volume: float, sample_volume: float) -> floa
 
 
 def baseline_period_before_data(baseline_end, data_start):
-    """Return True if baseline interval ends before data interval starts."""
+    """Return ``True`` if the baseline interval ends before data starts.
 
-    end = parse_timestamp(pd.Timestamp(baseline_end))
-    start = parse_timestamp(pd.Timestamp(data_start))
-    return end < start
+    Parameters
+    ----------
+    baseline_end, data_start:
+        ``str``, numeric seconds or ``datetime`` objects.  Values may be
+        timezone-naive or timezone-aware and are interpreted in UTC.
+
+    Notes
+    -----
+    Inputs are converted to UTC using :func:`utils.time_utils.parse_timestamp`
+    and compared on their integer nanoseconds to avoid issues with mixed time
+    zone information.
+    """
+
+    end_ns = parse_timestamp(pd.Timestamp(baseline_end)).value
+    start_ns = parse_timestamp(pd.Timestamp(data_start)).value
+    return end_ns < start_ns
 
 
 def _to_datetime64(events: pd.DataFrame | pd.Series) -> np.ndarray:


### PR DESCRIPTION
## Summary
- avoid timezone comparison issues in baseline_period_before_data
- document the timezone-safe comparison helper

## Testing
- `pytest tests/test_baseline.py::test_baseline_guard -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68897479f074832b8be9b40a541f540a