### PR TITLE
Refactor baseline subtraction output

### DIFF
--- a/tests/test_baseline_datetime.py
+++ b/tests/test_baseline_datetime.py
@@ -26,7 +26,7 @@ def test_subtract_baseline_datetime_column():
     df_bl = pd.DataFrame({"timestamp": ts_bl, "adc": np.tile([1,2,3,4,5],10)})
     df_full = pd.concat([df_an, df_bl], ignore_index=True)
     bins = np.arange(0, 7)
-    out, _ = baseline.subtract(
+    out_df, (hist, _) = baseline.subtract(
         df_an,
         df_full,
         bins=bins,
@@ -34,7 +34,7 @@ def test_subtract_baseline_datetime_column():
         t_base1=datetime(1970,1,2,0,0,40,tzinfo=timezone.utc),
         mode="all",
     )
-    integral = out["subtracted_adc_hist"].iloc[0].sum()
+    integral = hist.sum()
     assert integral == pytest.approx(0.0, rel=1e-6)
-    assert str(out["timestamp"].dtype) == "datetime64[ns, UTC]"
+    assert str(out_df["timestamp"].dtype) == "datetime64[ns, UTC]"
 

--- a/tests/test_baseline_subtract.py
+++ b/tests/test_baseline_subtract.py
@@ -17,7 +17,7 @@ def test_baseline_none():
         "adc": np.arange(10),
     })
     bins = np.arange(0, 11)
-    out = baseline_utils.subtract_baseline_dataframe(
+    out_df, hist = baseline_utils.subtract_baseline_dataframe(
         df,
         df,
         bins=bins,
@@ -25,9 +25,8 @@ def test_baseline_none():
         t_base1=pd.Timestamp(5, unit="s", tz="UTC"),
         mode="none",
     )
-    hist_before, _ = baseline.rate_histogram(df, bins)
-    hist_after, _ = baseline.rate_histogram(out, bins)
-    assert np.allclose(hist_before, hist_after)
+    counts_before, _ = np.histogram(df["adc"], bins=bins)
+    assert np.array_equal(counts_before, hist)
 
 
 def test_baseline_time_norm():
@@ -41,7 +40,7 @@ def test_baseline_time_norm():
     })
     df_full = pd.concat([df_an, df_bl], ignore_index=True)
     bins = np.arange(0, 7)
-    out = baseline_utils.subtract_baseline_dataframe(
+    out_df, hist = baseline_utils.subtract_baseline_dataframe(
         df_an,
         df_full,
         bins=bins,
@@ -49,7 +48,7 @@ def test_baseline_time_norm():
         t_base1=pd.Timestamp(140, unit="s", tz="UTC"),
         mode="all",
     )
-    integral = out["subtracted_adc_hist"].iloc[0].sum()
+    integral = hist.sum()
     assert integral == pytest.approx(0.0, rel=1e-6)
 
 
@@ -59,7 +58,7 @@ def test_baseline_none_datetime():
         "adc": np.arange(10),
     })
     bins = np.arange(0, 11)
-    out = baseline_utils.subtract_baseline_dataframe(
+    out_df, hist = baseline_utils.subtract_baseline_dataframe(
         df,
         df,
         bins=bins,
@@ -67,9 +66,8 @@ def test_baseline_none_datetime():
         t_base1=datetime.fromtimestamp(5, tz=timezone.utc),
         mode="none",
     )
-    hist_before, _ = baseline.rate_histogram(df, bins)
-    hist_after, _ = baseline.rate_histogram(out, bins)
-    assert np.allclose(hist_before, hist_after)
+    counts_before, _ = np.histogram(df["adc"], bins=bins)
+    assert np.array_equal(counts_before, hist)
 
 
 def test_baseline_time_norm_datetime():
@@ -83,7 +81,7 @@ def test_baseline_time_norm_datetime():
     })
     df_full = pd.concat([df_an, df_bl], ignore_index=True)
     bins = np.arange(0, 7)
-    out = baseline_utils.subtract_baseline_dataframe(
+    out_df, hist = baseline_utils.subtract_baseline_dataframe(
         df_an,
         df_full,
         bins=bins,
@@ -91,6 +89,6 @@ def test_baseline_time_norm_datetime():
         t_base1=datetime.fromtimestamp(140, tz=timezone.utc),
         mode="all",
     )
-    integral = out["subtracted_adc_hist"].iloc[0].sum()
+    integral = hist.sum()
     assert integral == pytest.approx(0.0, rel=1e-6)
 


### PR DESCRIPTION
## Summary
- avoid duplicating histograms in `apply_baseline_subtraction`
- return corrected histogram separately from `subtract`
- adjust baseline subtraction tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68897442aa94832b8953fff1195dcd30