### PR TITLE
Update sigma_E_prior_source default

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,9 @@ fit.  Important keys include:
   Set for example `{"Po218": [5.9, 6.2]}` to keep the Po‑218 fit from
   drifting into the Po‑210 region.  Centroid guesses found during peak
   search are clamped to this range before the fit starts.
+- `sigma_E_prior_source` – one-sigma width of the prior on the common
+  energy resolution parameter. When omitted the uncertainty from the
+  calibration step is used.
 
 - `expected_peaks` – approximate ADC centroids used to locate the
   Po‑210, Po‑218 and Po‑214 peaks before fitting. The default is

--- a/config.yaml
+++ b/config.yaml
@@ -87,7 +87,6 @@ spectral_fit:
     Po218: false
     Po214: false
   float_sigma_E: false
-  sigma_E_prior_source: 0.15
   peak_search_prominence: 30
   peak_search_width_adc: 3
   peak_search_method: prominence

--- a/examples/config_fixed_slope.json
+++ b/examples/config_fixed_slope.json
@@ -69,7 +69,6 @@
             "Po214": false
         },
         "float_sigma_E": true,
-        "sigma_E_prior_source": 0.15,
         "peak_search_prominence": 30,
         "peak_search_width_adc": 3,
         "peak_search_method": "prominence",


### PR DESCRIPTION
## Summary
- use the calibration error as the implicit default for `sigma_E_prior_source`
- remove this entry from the fixed-slope example
- document the new behaviour in the README

## Testing
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_688b23c9b784832bb551ad9c1051edba