### PR TITLE
Add percentages to noise cut and load event logs

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1226,7 +1226,13 @@ def main(argv=None):
                 events_filtered["adc"] > noise_thr_val
             ].reset_index(drop=True)
             n_removed_noise = before - len(events_filtered)
-            logging.info(f"Noise cut removed {n_removed_noise} events")
+            if before > 0:
+                frac_removed_noise = n_removed_noise / before
+                logging.info(
+                    f"Noise cut removed {n_removed_noise} events ({frac_removed_noise:.1%})"
+                )
+            else:
+                logging.info(f"Noise cut removed {n_removed_noise} events")
 
     _ensure_events(events_filtered, "noise cut")
 

--- a/io_utils.py
+++ b/io_utils.py
@@ -481,7 +481,11 @@ def load_events(csv_path, *, start=None, end=None, column_map=None):
         end_dt = parse_timestamp(end)
         df = df[df["timestamp"] <= end_dt]
 
-    logger.info(f"Loaded {len(df)} events from {csv_path} ({discarded} discarded).")
+    frac_discarded = discarded / start_len if start_len > 0 else 0
+    logger.info(
+        f"Loaded {len(df)} events from {csv_path} "
+        f"({discarded} discarded, {frac_discarded:.1%})."
+    )
     return df
 
 


### PR DESCRIPTION
## Summary
- show percentage of events removed by the noise cut
- show percentage of discarded rows when loading events

## Testing
- `pytest tests/test_io_utils.py::test_load_events_drop_bad_rows -q`
- `pytest tests/test_io_utils.py::test_load_events_string_nan -q`


------
https://chatgpt.com/codex/tasks/task_e_688b2e632f44832bafea6d6ab4ca9d22