### PR TITLE
Fix F to 0 for spectral fit

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1785,6 +1785,11 @@ def main(argv=None):
                 "float_sigma_E is false but sigma_E_prior_source is nonzero"
             )
         priors_spec["sigma_E"] = (sigE_mean, sigma_E_prior)
+        # Fit_spectrum expects separate ``sigma0`` and ``F`` resolution terms.
+        # Initialise sigma0 from the calibration-derived resolution and
+        # constrain the energy-dependence slope ``F`` to zero.
+        priors_spec["sigma0"] = (sigE_mean, sigma_E_prior)
+        priors_spec["F"] = (0.0, 0.0)
 
         for peak, centroid_adc in adc_peaks.items():
             mu = apply_calibration(centroid_adc, a, c, quadratic_coeff=a2)

--- a/config.yaml
+++ b/config.yaml
@@ -94,6 +94,8 @@ spectral_fit:
   refit_aic_threshold: 2.0
   use_plot_bins_for_fit: false
   unbinned_likelihood: true
+  flags:
+    fix_F: true
   mu_bounds:
     Po210: null
     Po218:


### PR DESCRIPTION
## Summary
- freeze the energy-dependence slope in the spectral fit
- initialize resolution parameters with sigma0 from calibration and F=0

## Testing
- `pytest tests/test_fitting.py::test_fit_spectrum_fixed_resolution -q`

------
https://chatgpt.com/codex/tasks/task_e_688cd87f7c48832bb9e1e95fcf84f924