### PR TITLE
Enable fixed slope calibration by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ python analyze.py [--config config.yaml] --input merged_data.csv \
     [--output_dir results] [--job-id MYRUN] [--overwrite] \
     [--efficiency-json eff.json] [--systematics-json syst.json] \
     [--spike-count N --spike-count-err S] [--slope RATE] \
-    [--noise-cutoff N] \
+    [--noise-cutoff N] [--calibration-slope M] \
     [--analysis-start-time ISO --analysis-end-time ISO --spike-end-time ISO] \
     [--spike-period START END] [--run-period START END] \
     [--radon-interval START END] \
@@ -75,6 +75,7 @@ subtraction are performed directly by `analyze.py`. Configure them in
 `config.yaml` or override the values via command-line options:
 
 - `calibration.noise_cutoff` / `--noise-cutoff` for the pedestal cut
+- `calibration.slope_MeV_per_ch` / `--calibration-slope` to fix the ADC→MeV conversion
 - `burst_filter.burst_mode` / `--burst-mode` for burst vetoing
 - `analysis_*` timestamps and periods to clip or exclude data
 - `baseline.range` or `--baseline-range` to enable baseline subtraction
@@ -180,6 +181,7 @@ deviates by more than this amount.
 Po‑214 peak is used to determine the intercept so the two‑point fit is skipped.
 Alternatively `intercept_MeV` may be supplied along with the slope to bypass
 searching for the Po‑214 peak entirely.
+The command-line option `--calibration-slope` overrides this value from the CLI.
 
 `noise_cutoff` defines a pedestal noise threshold in ADC.  Events with raw
 ADC values at or below this threshold are removed before any fits.  The

--- a/analyze.py
+++ b/analyze.py
@@ -820,6 +820,14 @@ def parse_args(argv=None):
         ),
     )
     p.add_argument(
+        "--calibration-slope",
+        type=float,
+        help=(
+            "Fixed MeV per ADC conversion slope. Providing this option overrides "
+            "`calibration.slope_MeV_per_ch` in config.yaml"
+        ),
+    )
+    p.add_argument(
         "--calibration-method",
         choices=["two-point", "auto"],
         help=(
@@ -1169,6 +1177,14 @@ def main(argv=None):
             int(args.noise_cutoff),
         )
         cfg.setdefault("calibration", {})["noise_cutoff"] = int(args.noise_cutoff)
+
+    if args.calibration_slope is not None:
+        _log_override(
+            "calibration",
+            "slope_MeV_per_ch",
+            float(args.calibration_slope),
+        )
+        cfg.setdefault("calibration", {})["slope_MeV_per_ch"] = float(args.calibration_slope)
 
     if args.iso is not None:
         prev = cfg.get("analysis_isotope")

--- a/config.yaml
+++ b/config.yaml
@@ -48,6 +48,7 @@ calibration:
   peak_search_radius: 100
   peak_prominence: 5
   peak_width: 5
+  slope_MeV_per_ch: 0.00427
   nominal_adc:
     Po210: 1246
     Po218: 1399


### PR DESCRIPTION
## Summary
- default to a fixed ADC→MeV conversion by adding `slope_MeV_per_ch` in `config.yaml`
- add `--calibration-slope` CLI flag and propagate override in `analyze.py`
- document new option in usage and configuration notes

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d64009ef4832b97e1435b77d38f17