### PR TITLE
Fix calibration slope value

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -48,7 +48,7 @@ calibration:
   peak_search_radius: 100
   peak_prominence: 5
   peak_width: 5
-  slope_MeV_per_ch: 0.00427
+  slope_MeV_per_ch: 0.00435
   nominal_adc:
     Po210: 1246
     Po218: 1399


### PR DESCRIPTION
## Summary
- correct ADC-to-MeV conversion slope to 0.00435 MeV/channel

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d6cec1324832b86e6ea016456233e