### PR TITLE
Enhance fixed slope calibration

### DIFF
--- a/tests/test_fixed_slope.py
+++ b/tests/test_fixed_slope.py
@@ -14,6 +14,8 @@ def test_fixed_slope_calibration():
             "peak_search_radius": 5,
             "peak_prominence": 0.0,
             "peak_width": 1,
+            "fit_window_adc": 20,
+            "use_emg": False,
             "init_sigma_adc": 5.0,
             "known_energies": {"Po214": 7.687},
         }
@@ -23,6 +25,8 @@ def test_fixed_slope_calibration():
     assert res["a"] == 0.00435
     assert res["c"] == pytest.approx(-0.14, abs=0.02)
     assert res["calibration_valid"] is True
+    # Expected sigma_E is slope * true sigma (~2 ADC)
+    assert res["sigma_E"] == pytest.approx(0.00435 * 2, rel=0.2)
 
 
 def test_float_slope_calibration():


### PR DESCRIPTION
## Summary
- Fit Po-214 (and optional Po-210) peaks with histogram-based Gaussian/EMG models when slope is fixed
- Derive intercept from fitted Po-214 centroid and convert peak width to energy `sigma_E`
- Test fixed-slope calibration for realistic intercept and resolution

## Testing
- `PYTHONPATH=. pytest tests/test_fixed_slope.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e0547f4f8832b9457a2e8b2d017c8