### PR TITLE
Calibrate Po-214 peak for fixed slope

### DIFF
--- a/tests/test_fixed_slope.py
+++ b/tests/test_fixed_slope.py
@@ -20,9 +20,9 @@ def test_fixed_slope_calibration():
     }
 
     res = derive_calibration_constants(adc, cfg)
-    assert res["a"] == 0.00435
-    assert res["c"] == pytest.approx(-0.14, abs=0.02)
-    assert res["calibration_valid"] is True
+    assert res.coeffs[1] == 0.00435
+    assert res.coeffs[0] == pytest.approx(-0.14, abs=0.02)
+    assert res.sigma_E == pytest.approx(0.00435 * 2, rel=0.2)
 
 
 def test_float_slope_calibration():


### PR DESCRIPTION
## Summary
- Fit the Po-214 peak when slope is fixed and propagate peak width to energy resolution
- Return a `CalibrationResult` with sigma_E for fixed-slope calibrations
- Update tests to expect the new CalibrationResult structure

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e041375d4832b9fa415bce789bcae