### PR TITLE
docs: fence noise cutoff YAML examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,17 +220,15 @@ value from the configuration file.
 Example snippet:
 
 ```yaml
-"calibration": {
-    "noise_cutoff": 400
-}
+calibration:
+  noise_cutoff: 400
 ```
 
 To disable the cut:
 
 ```yaml
-"calibration": {
-    "noise_cutoff": null
-}
+calibration:
+  noise_cutoff: null
 ```
 
 `slope_MeV_per_ch` may also be specified under `calibration` to fix the


### PR DESCRIPTION
## Summary
- fence `noise_cutoff` calibration examples in README with `yaml` code blocks
- show disabling the cut using YAML notation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688fe4bfdf88832b87d7b82fca7f2a91