### PR TITLE
docs: clarify sigma E init separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ peak energies must be to their known values.  The default of `0.5` MeV
 causes calibration to fail when any Po‑210, Po‑218 or Po‑214 centroid
 deviates by more than this amount.
 
+
 sigma_E_init — optional initial guess for the peak energy resolution (MeV).
 When present it is converted to an ADC width with the fixed calibration slope
 and used only as the starting σ for the Po‑214 peak fit; it never replaces the


### PR DESCRIPTION
## Summary
- add spacing between sanity tolerance description and `sigma_E_init` section for clarity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688fe4c2f140832b9c6afbef001a50f8