### PR TITLE
Adjust Po-210 tau prior

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -82,8 +82,8 @@ spectral_fit:
   b1_prior:
   - 0.0
   - 0.1
-  tau_Po210_prior_mean: 0.010
-  tau_Po210_prior_sigma: 0.005
+  tau_Po210_prior_mean: 0.025
+  tau_Po210_prior_sigma: 0.010
   tau_Po218_prior_mean: 0.015
   tau_Po218_prior_sigma: 0.007
   tau_Po214_prior_mean: 0.010


### PR DESCRIPTION
## Summary
- give Po-210 a longer low-energy tail by raising the tau prior mean to 0.025 MeV
- loosen the prior width on the Po-210 tail to 0.010 MeV

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fe7ce2fa8832b96fe8c6331b70244