### PR TITLE
feat: support two-point intercept calibration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -54,6 +54,7 @@ calibration:
     Po214: 5
   slope_MeV_per_ch: 0.00427
   float_slope: false
+  use_two_point: true
   nominal_adc:
     Po210: 1246
     Po218: 1399

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -6,6 +6,7 @@ calibration:
   slope_MeV_per_ch: null
   intercept_MeV: null
   float_slope: false
+  use_two_point: false
   sigma_E_init: null
   peak_widths: null
 spectral_fit:


### PR DESCRIPTION
## Summary
- allow fixed-slope calibrations to average Po-210 and Po-214 peaks for the intercept
- expose new `calibration.use_two_point` option in default and example configs
- cover two-point intercept calibration with unit tests

## Testing
- `pytest`
- `PYTHONPATH=. pytest tests/test_fixed_slope.py`


------
https://chatgpt.com/codex/tasks/task_e_688fe7c37020832bb08126813e1cf623