### PR TITLE
Use linear background with tight slope prior

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -75,13 +75,13 @@ spectral_fit:
   fd_hist_bins: 400
   mu_sigma: 0.02
   amp_prior_scale: 5.0
-  bkg_mode: constant
+  bkg_mode: linear
   b0_prior:
   - 0.0
   - 5.0
   b1_prior:
-  - 0.0
-  - 0.1
+  - -0.2
+  - 0.2
   tau_Po210_prior_mean: 0.010
   tau_Po210_prior_sigma: 0.005
   tau_Po218_prior_mean: 0.015

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -12,6 +12,13 @@ spectral_fit:
   peak_search_method: prominence
   peak_search_cwt_widths: null
   refit_aic_threshold: 2.0
+  bkg_mode: linear
+  b0_prior:
+  - 0.0
+  - 5.0
+  b1_prior:
+  - -0.2
+  - 0.2
 time_fit:
   window_po214:
   - 7.55


### PR DESCRIPTION
## Summary
- switch spectral-fit background mode to `linear`
- restrict slope prior to ±0.2 counts/bin/MeV so continuum follows baseline without overshooting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fe7dbab40832bb672b3f5afe81876