### PR TITLE
feat: support two-point intercept for fixed slope

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,9 @@ calibration:
 slope_MeV_per_ch — fixes the linear calibration slope.
 
 • If float_slope is false (default) the slope is locked; only the Po‑214
-peak is fitted and its centroid gives the intercept.
+peak is fitted and its centroid gives the intercept unless `use_two_point`
+is true, in which case the Po‑210 and Po‑214 centroids determine the
+intercept.
 • If float_slope is true the value acts as a starting guess; a two‑point
 fit (Po‑210 & Po‑214) refines both slope and intercept.
 • You may also supply intercept_MeV together with the slope to bypass the
@@ -245,8 +247,9 @@ To disable the cut:
 
 `slope_MeV_per_ch` may also be specified under `calibration` to fix the
 ADC->MeV conversion. When this slope is given the two-point fit is skipped
-and the provided value is used directly. If `intercept_MeV` is also
-supplied the calibration is fully fixed and Po‑214 is no longer searched.
+unless `use_two_point` is set, in which case the intercept is solved from
+the Po‑210 and Po‑214 peaks. If `intercept_MeV` is also supplied the
+calibration is fully fixed and Po‑214 is no longer searched.
 Set either value to `null` to retain the automatic calibration.
 
 When the cut is applied the analysis logs how many events were removed. This

--- a/config.yaml
+++ b/config.yaml
@@ -54,6 +54,7 @@ calibration:
     Po214: 5
   slope_MeV_per_ch: 0.00427
   float_slope: false
+  use_two_point: true
   nominal_adc:
     Po210: 1246
     Po218: 1399

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -6,6 +6,7 @@ calibration:
   slope_MeV_per_ch: null
   intercept_MeV: null
   float_slope: false
+  use_two_point: false
   sigma_E_init: null
   peak_widths: null
 spectral_fit:

--- a/tests/test_fixed_slope.py
+++ b/tests/test_fixed_slope.py
@@ -58,3 +58,31 @@ def test_float_slope_calibration():
 
     res = derive_calibration_constants(adc, cfg)
     assert res.coeffs[1] == pytest.approx(0.00427, rel=0.05)
+
+
+def test_fixed_slope_two_point():
+    rng = np.random.default_rng(2)
+    adc = np.concatenate([
+        rng.normal(1200, 2, 200),
+        rng.normal(1800, 2, 200),
+    ])
+
+    cfg = {
+        "calibration": {
+            "slope_MeV_per_ch": 0.00435,
+            "use_two_point": True,
+            "float_slope": False,
+            "nominal_adc": {"Po210": 1200, "Po214": 1800},
+            "peak_search_radius": 5,
+            "peak_prominence": 0.0,
+            "peak_width": 1,
+            "known_energies": {"Po210": 5.304, "Po214": 7.687},
+        }
+    }
+
+    res = derive_calibration_constants(adc, cfg)
+    expected = (
+        (5.304 - 0.00435 * 1200) + (7.687 - 0.00435 * 1800)
+    ) / 2.0
+    assert res.coeffs[0] == pytest.approx(expected, abs=0.02)
+    assert res.coeffs[1] == 0.00435


### PR DESCRIPTION
## Summary
- allow fixed-slope calibration to average Po-210 and Po-214 for intercept
- expose new `use_two_point` option in configs and docs
- test two-point intercept calculation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fe7c37020832bb08126813e1cf623