### PR TITLE
Add two-point intercept calibration option

### DIFF
--- a/calibration.py
+++ b/calibration.py
@@ -169,6 +169,53 @@ def two_point_calibration(adc_centroids, energies):
     return float(a), float(c)
 
 
+def intercept_fit_two_point(adc_values, cfg):
+    """Fit intercept using fixed slope and Po-210/Po-214 centroids.
+
+    This helper first fits the three radon peaks using :func:`calibrate_run`
+    to obtain precise ADC centroids.  With a user-supplied fixed slope
+    ``a``, the intercept is solved from the Po-210 and Po-214 centroids via
+    ``c = mean(E_i - a * ADC_i)``.  The slope uncertainty is set to zero and
+    the intercept variance is propagated from the centroid errors.
+    """
+
+    cal_cfg = cfg.get("calibration", {})
+    a = cal_cfg["slope_MeV_per_ch"]
+
+    # Reuse calibrate_run to determine centroid locations and widths
+    result = calibrate_run(adc_values, cfg)
+    peaks = result.peaks or {}
+
+    energies = {**DEFAULT_KNOWN_ENERGIES, **cal_cfg.get("known_energies", {})}
+    adc210 = peaks["Po210"]["centroid_adc"]
+    adc214 = peaks["Po214"]["centroid_adc"]
+
+    c210 = energies["Po210"] - a * adc210
+    c214 = energies["Po214"] - a * adc214
+    c = 0.5 * (c210 + c214)
+
+    # Centroid uncertainties -> intercept variance
+    mu_err_210 = float(np.sqrt(peaks["Po210"]["covariance"][1][1]))
+    mu_err_214 = float(np.sqrt(peaks["Po214"]["covariance"][1][1]))
+    var_c = (a ** 2 / 4.0) * (mu_err_210**2 + mu_err_214**2)
+
+    # Propagate sigma_E from Po-214 peak width
+    sigma_adc = peaks["Po214"]["sigma_adc"]
+    var_sigma_adc = peaks["Po214"]["covariance"][2][2]
+    sigma_E = abs(a) * sigma_adc
+    dsigma_E = abs(a) * np.sqrt(var_sigma_adc)
+
+    cov = np.array([[var_c, 0.0], [0.0, 0.0]])
+
+    return CalibrationResult(
+        coeffs=[float(c), float(a)],
+        cov=cov,
+        sigma_E=float(sigma_E),
+        sigma_E_error=float(dsigma_E),
+        peaks=peaks,
+    )
+
+
 def fixed_slope_calibration(adc_values, cfg):
     """Return calibration constants when the slope is fixed.
 
@@ -653,6 +700,8 @@ def derive_calibration_constants(adc_values, config):
     float_slope = cal_cfg.get("float_slope", False)
 
     if slope is not None and not float_slope:
+        if cal_cfg.get("use_two_point", False):
+            return intercept_fit_two_point(adc_values, config)
         return fixed_slope_calibration(adc_values, config)
 
     cfg = config if slope is None or not float_slope else deepcopy(config)
@@ -725,6 +774,7 @@ def derive_calibration_constants_auto(
 __all__ = [
     "CalibrationResult",
     "two_point_calibration",
+    "intercept_fit_two_point",
     "fixed_slope_calibration",
     "apply_calibration",
     "calibrate_run",

--- a/config.yaml
+++ b/config.yaml
@@ -54,6 +54,7 @@ calibration:
     Po214: 5
   slope_MeV_per_ch: 0.00427
   float_slope: false
+  use_two_point: true
   nominal_adc:
     Po210: 1246
     Po218: 1399

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -6,6 +6,7 @@ calibration:
   slope_MeV_per_ch: null
   intercept_MeV: null
   float_slope: false
+  use_two_point: false
   sigma_E_init: null
   peak_widths: null
 spectral_fit:

--- a/tests/test_fixed_slope.py
+++ b/tests/test_fixed_slope.py
@@ -5,23 +5,36 @@ from calibration import derive_calibration_constants
 
 def test_fixed_slope_calibration():
     rng = np.random.default_rng(0)
-    adc = rng.normal(1800, 2, 1000)
+    adc = np.concatenate(
+        [
+            rng.normal(1246, 2, 500),
+            rng.normal(1399, 2, 500),
+            rng.normal(1800, 2, 500),
+        ]
+    )
 
     cfg = {
         "calibration": {
             "slope_MeV_per_ch": 0.00435,
-            "nominal_adc": {"Po214": 1800},
+            "float_slope": False,
+            "use_two_point": True,
+            "nominal_adc": {"Po210": 1246, "Po218": 1399, "Po214": 1800},
             "peak_search_radius": 5,
             "peak_prominence": 0.0,
             "peak_width": 1,
             "init_sigma_adc": 5.0,
-            "known_energies": {"Po214": 7.687},
+            "fit_window_adc": 20,
+            "use_emg": False,
+            "known_energies": {"Po210": 5.304, "Po214": 7.687},
         }
     }
 
     res = derive_calibration_constants(adc, cfg)
     assert res.coeffs[1] == 0.00435
-    assert res.coeffs[0] == pytest.approx(-0.14, abs=0.02)
+    expected_c = 0.5 * (
+        (5.304 - 0.00435 * 1246) + (7.687 - 0.00435 * 1800)
+    )
+    assert res.coeffs[0] == pytest.approx(expected_c, abs=0.02)
     assert res.sigma_E == pytest.approx(0.00435 * 2, rel=0.2)
 
 


### PR DESCRIPTION
## Summary
- support fixed-slope calibration using Po-210 and Po-214 anchors
- expose new `use_two_point` setting in default and example configs
- cover two-point intercept behaviour with unit test

## Testing
- `pytest`
- `PYTHONPATH=. pytest tests/test_fixed_slope.py`


------
https://chatgpt.com/codex/tasks/task_e_688fe7c37020832bb08126813e1cf623