### PR TITLE
Handle fixed resolution parameters without covariance warnings

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -104,6 +104,7 @@ spectral_fit:
   use_plot_bins_for_fit: false
   unbinned_likelihood: true
   flags:
+    fix_sigma0: true
     fix_F: true
   mu_bounds:
     Po210:

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -12,6 +12,9 @@ spectral_fit:
   peak_search_method: prominence
   peak_search_cwt_widths: null
   refit_aic_threshold: 2.0
+  flags:
+    fix_sigma0: true
+    fix_F: true
 time_fit:
   window_po214:
   - 7.55


### PR DESCRIPTION
## Summary
- add `fix_sigma0` and `fix_F` flags to spectral fit defaults
- avoid including fixed resolution parameters in spectral-fit optimisation
- return fixed sigma0 and F values without triggering covariance warnings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fe7eb200c832b8a32d85fe634cbf2