### PR TITLE
Fix Po-214 time fit runaway

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -126,14 +126,12 @@ time_fit:
   window_po210:
   - 5.25
   - 5.37
-  eff_po214: null
+  eff_po214: 0.25               # ZnS(Ag) typical; change if you measured it
   eff_po218: null
   eff_po210: null
   hl_po214: null
   hl_po218: null
-  bkg_po214:
-  - 0.0
-  - 0.0
+  bkg_po214: [0.0, 0.2]         # allow a flat residual background
   bkg_po218:
   - 0.0
   - 0.0
@@ -141,6 +139,7 @@ time_fit:
   sig_n0_po218: 1.0
   background_guess: 0.0
   n0_guess_fraction: 0.1
+  min_counts: 200               # skip fit if too few events
   flags:
     fix_background_b: false
     fix_N0_Po218: false

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -22,4 +22,6 @@ time_fit:
   window_po210:
   - 5.25
   - 5.37
+  eff_po214: 0.25               # ZnS(Ag) typical; change if you measured it
+  bkg_po214: [0.0, 0.2]         # allow a flat residual background
   min_counts: 20

--- a/fitting.py
+++ b/fitting.py
@@ -688,6 +688,11 @@ def fit_time_series(times_dict, t_start, t_end, config, weights=None, strict=Fal
     """
     iso_list = list(config["isotopes"].keys())
 
+    n_events = sum(len(np.asarray(times_dict.get(iso, []))) for iso in iso_list)
+    min_counts = config.get("min_counts")
+    if min_counts is not None and n_events < min_counts:
+        return FitResult({"fit_valid": False}, None, 0, {}, counts=int(n_events))
+
     # Normalize weights mapping
     if weights is None:
         weights_dict = {iso: None for iso in iso_list}


### PR DESCRIPTION
## Summary
- Configure typical Po-214 efficiency and allow a small residual background
- Guard time-series fitting by skipping when total events are below `min_counts`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fe7f810ac832bbf4ee738de86d19d