### PR TITLE
Guard Po-214 time fit against low-count spikes

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -2298,6 +2298,7 @@ def main(argv=None):
             ),
             "background_guess": cfg["time_fit"].get("background_guess", 0.0),
             "n0_guess_fraction": cfg["time_fit"].get("n0_guess_fraction", 0.1),
+            "min_counts": cfg["time_fit"].get("min_counts", 0),
         }
 
         # Run time-series fit

--- a/config.yaml
+++ b/config.yaml
@@ -126,17 +126,18 @@ time_fit:
   window_po210:
   - 5.25
   - 5.37
-  eff_po214: null
+  eff_po214: 0.25
   eff_po218: null
   eff_po210: null
   hl_po214: null
   hl_po218: null
   bkg_po214:
   - 0.0
-  - 0.0
+  - 0.2
   bkg_po218:
   - 0.0
   - 0.0
+  min_counts: 200
   sig_n0_po214: 1.0
   sig_n0_po218: 1.0
   background_guess: 0.0

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -22,4 +22,8 @@ time_fit:
   window_po210:
   - 5.25
   - 5.37
-  min_counts: 20
+  eff_po214: 0.25
+  bkg_po214:
+  - 0.0
+  - 0.2
+  min_counts: 200

--- a/fitting.py
+++ b/fitting.py
@@ -694,6 +694,19 @@ def fit_time_series(times_dict, t_start, t_end, config, weights=None, strict=Fal
     else:
         weights_dict = {iso: np.asarray(weights.get(iso), dtype=float) if weights.get(iso) is not None else None for iso in iso_list}
 
+    # Optional guard for low statistics
+    min_counts = int(config.get("min_counts", 0))
+    total_counts = 0
+    for iso in iso_list:
+        arr = times_dict.get(iso, [])
+        w_arr = weights_dict.get(iso)
+        if w_arr is None:
+            total_counts += len(arr)
+        else:
+            total_counts += float(np.sum(w_arr))
+    if total_counts < min_counts:
+        return FitResult({"fit_valid": False}, np.zeros((0, 0)), 0, counts=int(total_counts))
+
     # 1) Build maps: lam_map, eff_map, fix_b_map, fix_n0_map
     lam_map, eff_map = {}, {}
     fix_b_map, fix_n0_map = {}, {}

--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -170,6 +170,12 @@ def plot_time_series(
             return float(val[0]) if val else float(default)
         return float(default) if val is None else float(val)
 
+    def _eff_param(name, default=1.0):
+        val = _cfg_get(config, name, [default])
+        if isinstance(val, list):
+            return float(val[0]) if val else float(default)
+        return float(val)
+
     po214_hl = float(hl_po214) if hl_po214 is not None else _hl_param("hl_po214", default214)
     po218_hl = float(hl_po218) if hl_po218 is not None else _hl_param("hl_po218", default218)
 
@@ -182,7 +188,7 @@ def plot_time_series(
         "Po210": {
             # Energy window for Po-210 events (optional)
             "window": _cfg_get(config, "window_po210"),
-            "eff": float(_cfg_get(config, "eff_po210", [1.0])[0]),
+            "eff": _eff_param("eff_po210"),
             "half_life": _hl_param(
                 "hl_po210",
                 default_const.get("Po210", PO210).half_life_s,
@@ -191,13 +197,13 @@ def plot_time_series(
         "Po218": {
             # Energy window for Po-218 events
             "window": _cfg_get(config, "window_po218"),
-            "eff": float(_cfg_get(config, "eff_po218", [1.0])[0]),
+            "eff": _eff_param("eff_po218"),
             "half_life": po218_hl,
         },
         "Po214": {
             # Energy window for Po-214 events
             "window": _cfg_get(config, "window_po214"),
-            "eff": float(_cfg_get(config, "eff_po214", [1.0])[0]),
+            "eff": _eff_param("eff_po214"),
             "half_life": po214_hl,
         },
     }

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -38,6 +38,20 @@ def test_fit_time_series_po214_only():
     assert abs(E_fit - E_true) / E_true < 1.0
 
 
+def test_fit_time_series_respects_min_counts():
+    times = np.linspace(0, 1, 10)
+    times_dict = {"Po214": times}
+    cfg = {
+        "isotopes": {"Po214": {"half_life_s": 1.0, "efficiency": 1.0}},
+        "fit_background": True,
+        "fit_initial": True,
+        "min_counts": 20,
+    }
+    res = fit_time_series(times_dict, 0.0, 1.0, cfg)
+    assert res.params.get("fit_valid") is False
+    assert res.counts == len(times)
+
+
 def test_fit_time_series_time_window_config():
     """Changing the energy window should alter the events passed to fit_time_series."""
     # Two groups of events at different energies


### PR DESCRIPTION
## Summary
- set default Po-214 efficiency and background range, require at least 200 events
- skip Po-214 time fit when counts below threshold and allow scalar efficiencies in plotting
- test min-count guard for time-series fitter

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fe7f810ac832bbf4ee738de86d19d