### PR TITLE
refactor calibration imports to prevent circular import

### DIFF
--- a/calibrate.py
+++ b/calibrate.py
@@ -1,10 +1,14 @@
 import numpy as np
-from calibration import calibrate_run, CalibrationResult
 from constants import DEFAULT_KNOWN_ENERGIES
 
 
 def intercept_fit_two_point(adc_values, cfg):
     """Return calibration with fixed slope using Po-210 and Po-214 anchors."""
+    try:
+        from .calibration import CalibrationResult, calibrate_run
+    except ImportError:  # pragma: no cover - fallback for root imports
+        from calibration import CalibrationResult, calibrate_run
+
     a = cfg["calibration"]["slope_MeV_per_ch"]
     # Use full calibration routine to locate peaks for both isotopes
     cal_res = calibrate_run(adc_values, cfg)

--- a/calibration.py
+++ b/calibration.py
@@ -655,7 +655,10 @@ def derive_calibration_constants(adc_values, config):
 
     if slope is not None and not float_slope:
         if cal_cfg.get("use_two_point", False):
-            from calibrate import intercept_fit_two_point as _if2p
+            try:
+                from .calibrate import intercept_fit_two_point as _if2p
+            except ImportError:  # pragma: no cover - fallback for root imports
+                from calibrate import intercept_fit_two_point as _if2p
             return _if2p(adc_values, config)
         return fixed_slope_calibration(adc_values, config)
 
@@ -734,7 +737,10 @@ def intercept_fit_two_point(*args, **kwargs):
         DeprecationWarning,
         stacklevel=2,
     )
-    from calibrate import intercept_fit_two_point as _if2p
+    try:
+        from .calibrate import intercept_fit_two_point as _if2p
+    except ImportError:  # pragma: no cover - fallback for root imports
+        from calibrate import intercept_fit_two_point as _if2p
     return _if2p(*args, **kwargs)
 
 __all__ = [


### PR DESCRIPTION
## Summary
- localize calibration imports within `intercept_fit_two_point`
- defer `intercept_fit_two_point` imports in `calibration` to call sites

## Testing
- `python - <<'PY'
import importlib,sys;sys.path.insert(0,'/workspace');import rmtest.calibrate,rmtest.calibration
PY`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689096ff46ec832ba8d757649c582be3