### PR TITLE
Allow spectral fit width and Fano factor to float

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -105,8 +105,8 @@ spectral_fit:
   use_plot_bins_for_fit: false
   unbinned_likelihood: true
   flags:
-    fix_sigma0: true
-    fix_F: true
+    fix_sigma0: false  # let the width refit
+    fix_F: false       # let the Fano factor float
   mu_bounds:
     Po210:
     - 5.28

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -15,11 +15,13 @@ spectral_fit:
   peak_search_method: prominence
   peak_search_cwt_widths: null
   refit_aic_threshold: 2.0
-
-  # new flags to silence covariance warnings
+  # Allow width and Fano factor to float
   flags:
-    fix_sigma0: true
-    fix_F: true
+    fix_sigma0: false  # let the width refit
+    fix_F: false       # let the Fano factor float
+  # Freeing those two parameters restores enough degrees-of-freedom for the
+  # optimiser to converge, so fit_valid becomes true again instead of dumping
+  # all-zero covariance.
 
   # your existing background priors
   bkg_mode: linear


### PR DESCRIPTION
## Summary
- Let spectral fit refit width (`sigma0`) and Fano factor by default, improving optimizer convergence
- Document reasoning in configuration defaults

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890a68f8e4c832bb12d46af88ba60b8