### PR TITLE
Allow spectral fit width and Fano factor to float

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -96,7 +96,7 @@ spectral_fit:
     Po210: true
     Po218: true
     Po214: true
-  float_sigma_E: false
+  float_sigma_E: true
   peak_search_prominence: 30
   peak_search_width_adc: 3
   peak_search_method: prominence
@@ -105,8 +105,8 @@ spectral_fit:
   use_plot_bins_for_fit: false
   unbinned_likelihood: true
   flags:
-    fix_sigma0: true
-    fix_F: true
+    fix_sigma0: false  # let the width refit
+    fix_F: false       # let the Fano factor float
   mu_bounds:
     Po210:
     - 5.28

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -16,10 +16,11 @@ spectral_fit:
   peak_search_cwt_widths: null
   refit_aic_threshold: 2.0
 
-  # new flags to silence covariance warnings
+  # Flags controlling resolution parameters; letting both float keeps the
+  # optimiser well-constrained
   flags:
-    fix_sigma0: true
-    fix_F: true
+    fix_sigma0: false  # let the width refit
+    fix_F: false       # let the Fano factor float
 
   # your existing background priors
   bkg_mode: linear


### PR DESCRIPTION
## Summary
- let spectral fit refit resolution width and Fano factor by default
- enable floating sigma_E in example config

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890a68f8e4c832bb12d46af88ba60b8