### PR TITLE
Enable floating sigma and correct Po214 efficiency

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -78,11 +78,11 @@ spectral_fit:
   amp_prior_scale: 5.0
   bkg_mode: linear
   b0_prior:
-  - 0.0
-  - 5.0
+    - 0.0
+    - 5.0
   b1_prior:
-  - -0.2
-  - 0.2
+    - -0.2
+    - 0.2
   tau_Po210_prior_mean: 0.025
   tau_Po210_prior_sigma: 0.010
   tau_Po218_prior_mean: 0.015
@@ -96,7 +96,7 @@ spectral_fit:
     Po210: true
     Po218: true
     Po214: true
-  float_sigma_E: false
+  float_sigma_E: true
   peak_search_prominence: 30
   peak_search_width_adc: 3
   peak_search_method: prominence
@@ -120,25 +120,25 @@ spectral_fit:
 time_fit:
   do_time_fit: true
   window_po214:
-  - 7.55
-  - 7.80
+    - 7.55
+    - 7.80
   window_po218:
-  - 5.90
-  - 6.10
+    - 5.90
+    - 6.10
   window_po210:
-  - 5.25
-  - 5.37
-  eff_po214: 0.25
+    - 5.25
+    - 5.37
+  eff_po214: 0.99
   eff_po218: null
   eff_po210: null
   hl_po214: null
   hl_po218: null
   bkg_po214:
-  - 0.0
-  - 0.2
+    - 0.0
+    - 0.2
   bkg_po218:
-  - 0.0
-  - 0.0
+    - 0.0
+    - 0.0
   min_counts: 200
   sig_n0_po214: 1.0
   sig_n0_po218: 1.0

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -12,6 +12,7 @@ calibration:
   peak_widths: null
 
 spectral_fit:
+  float_sigma_E: true
   peak_search_method: prominence
   peak_search_cwt_widths: null
   refit_aic_threshold: 2.0
@@ -40,7 +41,7 @@ time_fit:
   window_po210:
     - 5.25
     - 5.37
-  eff_po214: 0.25
+  eff_po214: 0.99
   bkg_po214:
     - 0.0
     - 0.2


### PR DESCRIPTION
## Summary
- Allow the spectral fit to float the global energy resolution by enabling `float_sigma_E`
- Restore Po214 detection efficiency to 0.99 in default and example configurations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890a6a39b60832ba51dff01487acda5