### PR TITLE
Allow sigma E float and restore Po214 efficiency

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -96,7 +96,7 @@ spectral_fit:
     Po210: true
     Po218: true
     Po214: true
-  float_sigma_E: false
+  float_sigma_E: true
   peak_search_prominence: 30
   peak_search_width_adc: 3
   peak_search_method: prominence
@@ -128,7 +128,7 @@ time_fit:
   window_po210:
   - 5.25
   - 5.37
-  eff_po214: 0.25
+  eff_po214: 0.99
   eff_po218: null
   eff_po210: null
   hl_po214: null

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -1,3 +1,4 @@
+
 allow_fallback: false
 analysis_isotope: radon
 allow_negative_baseline: false
@@ -40,7 +41,7 @@ time_fit:
   window_po210:
     - 5.25
     - 5.37
-  eff_po214: 0.25
+  eff_po214: 0.99
   bkg_po214:
     - 0.0
     - 0.2


### PR DESCRIPTION
## Summary
- allow spectral-fit sigma to float to track refitted resolution
- reset Po-214 time-fit efficiency to realistic 0.99

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890a6a39b60832ba51dff01487acda5