### PR TITLE
Narrow Po214 time-fit energy window

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -120,8 +120,8 @@ spectral_fit:
 time_fit:
   do_time_fit: true
   window_po214:
-    - 7.55
-    - 7.80
+    - 7.65
+    - 7.73
   window_po218:
     - 5.90
     - 6.10

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -34,8 +34,8 @@ spectral_fit:
 
 time_fit:
   window_po214:
-    - 7.55
-    - 7.80
+    - 7.65
+    - 7.73
   window_po218:
     - 5.90
     - 6.10

--- a/examples/config_fixed_slope.json
+++ b/examples/config_fixed_slope.json
@@ -83,7 +83,7 @@
     },
     "time_fit": {
         "do_time_fit": true,
-        "window_po214": [7.55, 7.80],
+        "window_po214": [7.65, 7.73],
         "window_po218": [5.90, 6.10],
         "window_po210": [5.25, 5.37],
         "eff_po214": [0.40, 0.0],

--- a/tests/data/mini_run/config.json
+++ b/tests/data/mini_run/config.json
@@ -15,7 +15,7 @@
   "spectral_fit": {"do_spectral_fit": false, "expected_peaks": {"Po210": 0}},
   "time_fit": {
     "do_time_fit": true,
-    "window_po214": [7.55, 7.80],
+    "window_po214": [7.65, 7.73],
     "hl_po214": null,
     "eff_po214": [1.0, 0.0],
     "flags": {}


### PR DESCRIPTION
## Summary
- tighten `time_fit.window_po214` to 7.65–7.73 MeV
- sync example and mini-run configs with the narrower Po214 window

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890bff358b0832bbee72e0dda856b15