### PR TITLE
Lower time-fit min_counts threshold

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -139,7 +139,7 @@ time_fit:
   bkg_po218:
     - 0.0
     - 0.0
-  min_counts: 200
+  min_counts: 20
   sig_n0_po214: 1.0
   sig_n0_po218: 1.0
   background_guess: 0.0

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -46,4 +46,4 @@ time_fit:
   bkg_po214:
     - 0.0
     - 0.2
-  min_counts: 200
+  min_counts: 20


### PR DESCRIPTION
## Summary
- Reduce time-fit `min_counts` default to 20 to accept runs with fewer counts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890c017df78832b9251d1660e829876