### PR TITLE
Fix default sigma0 and F flags

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -105,8 +105,8 @@ spectral_fit:
   use_plot_bins_for_fit: false
   unbinned_likelihood: true
   flags:
-    fix_sigma0: false  # let the width refit
-    fix_F: false       # let the Fano factor float
+    fix_sigma0: true  # fix the width
+    fix_F: true       # fix the Fano factor
   mu_bounds:
     Po210:
     - 5.28

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -20,8 +20,8 @@ spectral_fit:
   # Flags controlling resolution parameters; letting both float keeps the
   # optimiser well-constrained
   flags:
-    fix_sigma0: false  # let the width refit
-    fix_F: false       # let the Fano factor float
+    fix_sigma0: true  # fix the width
+    fix_F: true       # fix the Fano factor
 
   # your existing background priors
   bkg_mode: linear


### PR DESCRIPTION
## Summary
- Keep sigma0 and F fixed during spectral fitting by default

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890c3626c34832bacf4ef584b009d05