### PR TITLE
Fix spectral fit nuisance parameters

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -105,8 +105,8 @@ spectral_fit:
   use_plot_bins_for_fit: false
   unbinned_likelihood: true
   flags:
-    fix_sigma0: false  # let the width refit
-    fix_F: false       # let the Fano factor float
+    fix_sigma0: true
+    fix_F: true
   mu_bounds:
     Po210:
     - 5.28

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -17,11 +17,12 @@ spectral_fit:
   peak_search_cwt_widths: null
   refit_aic_threshold: 2.0
 
-  # Flags controlling resolution parameters; letting both float keeps the
-  # optimiser well-constrained
+  # Flags controlling resolution parameters.  The width and Fano factor are
+  # treated as nuisance parameters and fixed by default.  Allow them to float
+  # only when performing a dedicated spectral likelihood fit.
   flags:
-    fix_sigma0: false  # let the width refit
-    fix_F: false       # let the Fano factor float
+    fix_sigma0: true
+    fix_F: true
 
   # your existing background priors
   bkg_mode: linear


### PR DESCRIPTION
## Summary
- fix spectral width (sigma0) and Fano factor by default in spectral fit configuration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890c3626c34832bacf4ef584b009d05