### PR TITLE
Auto derive min counts

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -2121,11 +2121,20 @@ def main(argv=None):
             iso_events = df_analysis[iso_mask].copy()
             iso_events["weight"] = probs[iso_mask]
 
-            thr = int(cfg.get("time_fit", {}).get("min_counts", 20))
-            if len(iso_events) < thr:
-                iso_events, (lo, hi) = auto_expand_window(df_analysis, (lo, hi), thr)
-                if len(iso_events) >= thr:
-                    logger.info("expanded %s window to [%.2f, %.2f] MeV", iso, lo, hi)
+            # Derive minimum counts automatically if not provided
+            thr_cfg = cfg.get("time_fit", {}).get("min_counts")
+            if thr_cfg is not None:
+                thr = int(thr_cfg)
+                if len(iso_events) < thr:
+                    iso_events, (lo, hi) = auto_expand_window(
+                        df_analysis, (lo, hi), thr
+                    )
+                    if len(iso_events) >= thr:
+                        logger.info(
+                            "expanded %s window to [%.2f, %.2f] MeV", iso, lo, hi
+                        )
+            else:
+                thr = len(iso_events)
 
             if iso_events.empty:
                 logger.warning(

--- a/config.yaml
+++ b/config.yaml
@@ -139,7 +139,6 @@ time_fit:
   bkg_po218:
     - 0.0
     - 0.0
-  min_counts: 20
   sig_n0_po214: 1.0
   sig_n0_po218: 1.0
   background_guess: 0.0

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -46,4 +46,3 @@ time_fit:
   bkg_po214:
     - 0.0
     - 0.2
-  min_counts: 20

--- a/fitting.py
+++ b/fitting.py
@@ -728,7 +728,6 @@ def fit_time_series(times_dict, t_start, t_end, config, weights=None, strict=Fal
         weights_dict = {iso: np.asarray(weights.get(iso), dtype=float) if weights.get(iso) is not None else None for iso in iso_list}
 
     # Early exit when statistics are insufficient
-    min_counts = int(config.get("min_counts", 0))
     total_counts = 0.0
     for iso in iso_list:
         w_arr = weights_dict.get(iso)
@@ -736,6 +735,14 @@ def fit_time_series(times_dict, t_start, t_end, config, weights=None, strict=Fal
             total_counts += len(times_dict.get(iso, []))
         else:
             total_counts += float(np.sum(w_arr))
+
+    cfg_min_counts = config.get("min_counts")
+    if cfg_min_counts is not None and int(cfg_min_counts) > 0:
+        min_counts = int(cfg_min_counts)
+    else:
+        # Require at least one event by default; otherwise use the observed count
+        min_counts = max(1, int(total_counts))
+
     if total_counts < min_counts:
         logger.info(
             "fit_time_series: skipping fit, only %.0f events (< %d)",


### PR DESCRIPTION
## Summary
- derive minimum event counts from observed data when not configured
- drop `min_counts` from default and example configs

## Testing
- `pytest tests/test_fitting.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6890c530649c832bb097fed497551108