### PR TITLE
Scale model line to counts per bin

### DIFF
--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -465,40 +465,25 @@ def plot_spectrum(
         ax_main.set_xlim(lo, hi)
 
     if fit_vals:
-        x = np.linspace(edges[0], edges[-1], 1000)
         sigma_E = fit_vals.get("sigma_E", 1.0)
-        y = fit_vals.get("b0", 0.0) + fit_vals.get("b1", 0.0) * x
+        y_cent = fit_vals.get("b0", 0.0) + fit_vals.get("b1", 0.0) * centers
         for pk in ("Po210", "Po218", "Po214"):
             mu_key = f"mu_{pk}"
             amp_key = f"S_{pk}"
             if mu_key in fit_vals and amp_key in fit_vals:
                 mu = fit_vals[mu_key]
                 amp = fit_vals[amp_key]
-                y += (
+                y_cent += (
                     amp
                     / (sigma_E * np.sqrt(2 * np.pi))
-                    * np.exp(-0.5 * ((x - mu) / sigma_E) ** 2)
+                    * np.exp(-0.5 * ((centers - mu) / sigma_E) ** 2)
                 )
-        palette_name = str(config.get("palette", "default")) if config else "default"
-        palette = COLOR_SCHEMES.get(palette_name, COLOR_SCHEMES["default"])
+
         fit_color = palette.get("fit", "#ff0000")
-        avg_width = float(np.mean(width))
-        ax_main.plot(x, y * avg_width, color=fit_color, lw=2, label="Fit")
+        model_counts = y_cent * width
+        ax_main.plot(centers, model_counts, color=fit_color, lw=2, label="Fit")
 
         if show_res:
-            y_cent = fit_vals.get("b0", 0.0) + fit_vals.get("b1", 0.0) * centers
-            for pk in ("Po210", "Po218", "Po214"):
-                mu_key = f"mu_{pk}"
-                amp_key = f"S_{pk}"
-                if mu_key in fit_vals and amp_key in fit_vals:
-                    mu = fit_vals[mu_key]
-                    amp = fit_vals[amp_key]
-                    y_cent += (
-                        amp
-                        / (sigma_E * np.sqrt(2 * np.pi))
-                        * np.exp(-0.5 * ((centers - mu) / sigma_E) ** 2)
-                    )
-            model_counts = y_cent * width
             residuals = hist - model_counts
             ax_res.bar(
                 centers,


### PR DESCRIPTION
## Summary
- scale spectrum model overlay by bin width so red curve shows counts per bin
- add regression test confirming model scaling

## Testing
- `pytest tests/test_plot_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_689552539248832ba04c251fadbde424