### PR TITLE
Scale spectrum model by bin width

### DIFF
--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -465,40 +465,59 @@ def plot_spectrum(
         ax_main.set_xlim(lo, hi)
 
     if fit_vals:
-        x = np.linspace(edges[0], edges[-1], 1000)
         sigma_E = fit_vals.get("sigma_E", 1.0)
-        y = fit_vals.get("b0", 0.0) + fit_vals.get("b1", 0.0) * x
+
+        # --- 1) Linear background normalization -----------------------------
+        b0    = fit_vals.get("b0",    0.0)
+        b1    = fit_vals.get("b1",    0.0)
+        S_bkg = fit_vals.get("S_bkg", 0.0)
+
+        # bin centers are already defined above as `centers`
+        # compute background value at each center:
+        bkg_cent = b0 + b1 * centers
+
+        # integrate (b0 + b1·x) dx from x = edges[0] to edges[-1]:
+        lo_edge = edges[0]
+        hi_edge = edges[-1]
+        bkg_norm = b0 * (hi_edge - lo_edge) + 0.5 * b1 * (hi_edge**2 - lo_edge**2)
+
+        # start model array (counts/s)
+        y = np.zeros_like(centers)
+        if bkg_norm > 0:
+            # scale to total background counts S_bkg
+            y += S_bkg * (bkg_cent / bkg_norm)
+
+        # --- 2) Add Gaussian peaks -------------------------------------------
         for pk in ("Po210", "Po218", "Po214"):
-            mu_key = f"mu_{pk}"
+            mu_key  = f"mu_{pk}"
             amp_key = f"S_{pk}"
             if mu_key in fit_vals and amp_key in fit_vals:
-                mu = fit_vals[mu_key]
+                mu  = fit_vals[mu_key]
                 amp = fit_vals[amp_key]
-                y += (
+                y  += (
                     amp
                     / (sigma_E * np.sqrt(2 * np.pi))
-                    * np.exp(-0.5 * ((x - mu) / sigma_E) ** 2)
+                    * np.exp(-0.5 * ((centers - mu) / sigma_E) ** 2)
                 )
-        palette_name = str(config.get("palette", "default")) if config else "default"
-        palette = COLOR_SCHEMES.get(palette_name, COLOR_SCHEMES["default"])
-        fit_color = palette.get("fit", "#ff0000")
-        avg_width = float(np.mean(width))
-        ax_main.plot(x, y * avg_width, color=fit_color, lw=2, label="Fit")
 
+        # --- 3) Convert rates (counts/s) to counts per bin -------------------
+        model_counts = y * width
+
+        # --- 4) Plot the combined model over the histogram -------------------
+        palette_name = str(config.get("palette", "default")) if config else "default"
+        palette      = COLOR_SCHEMES.get(palette_name, COLOR_SCHEMES["default"])
+        fit_color    = palette.get("fit", "#ff0000")
+        ax_main.plot(
+            centers,
+            model_counts,
+            color=fit_color,
+            lw=2,
+            ls="--",
+            label="Fit",
+        )
+
+        # --- 5) Residuals panel (if enabled) ---------------------------------
         if show_res:
-            y_cent = fit_vals.get("b0", 0.0) + fit_vals.get("b1", 0.0) * centers
-            for pk in ("Po210", "Po218", "Po214"):
-                mu_key = f"mu_{pk}"
-                amp_key = f"S_{pk}"
-                if mu_key in fit_vals and amp_key in fit_vals:
-                    mu = fit_vals[mu_key]
-                    amp = fit_vals[amp_key]
-                    y_cent += (
-                        amp
-                        / (sigma_E * np.sqrt(2 * np.pi))
-                        * np.exp(-0.5 * ((centers - mu) / sigma_E) ** 2)
-                    )
-            model_counts = y_cent * width
             residuals = hist - model_counts
             ax_res.bar(
                 centers,


### PR DESCRIPTION
## Summary
- normalize linear background to total counts and convert fit model to counts per bin
- adjust irregular-bin spectrum test to include background integral when validating captured model

## Testing
- `pytest tests/test_plot_utils.py::test_plot_spectrum_irregular_edges_residuals tests/test_plot_utils.py::test_plot_time_series_custom_half_life`
- `pytest tests/test_fitting.py::test_spectrum_tail_amplitude_stability` *(fails: assert (20.93 / 375) < 0.03)*

------
https://chatgpt.com/codex/tasks/task_e_689552539248832ba04c251fadbde424