### PR TITLE
feat: positive unit-area background with amplitude (S_bkg) + softplus areas

### DIFF
--- a/assertions_and_ci.py
+++ b/assertions_and_ci.py
@@ -27,15 +27,9 @@ def run_assertions(summary: Mapping[str, Any], constants: Mapping[str, Any], con
         aic = float(spec.get("aic", 0.0))
         assert aic == aic and aic < 1e12  # finite and not astronomical
 
-        # Non-negative continuum across the ROI
-        b0 = float(spec.get("b0", 0.0))
-        b1 = float(spec.get("b1", 0.0))
-        ewin = config.get("time_fit", {}).get("window_po210") or [5.2, 5.4]
-        elo = float(ewin[0])
-        ehi = float(ewin[1]) + 2.5  # conservative high end for the ROI
-        assert b0 >= 0.0
-        assert (b0 + b1 * elo) >= 0.0
-        assert (b0 + b1 * ehi) >= 0.0
+        # Non-negative background amplitude
+        B = float(spec.get("S_bkg", 0.0))
+        assert B >= 0.0
 
     assert constants["Po214"]["half_life_s"] < 1e3
     assert config["baseline"]["sample_volume_l"] > 0


### PR DESCRIPTION
## Summary
- ensure spectral component areas are positive via softplus reparameterization
- introduce a normalized log-linear background shape with explicit amplitude parameter `S_bkg`
- relax assertions to require only non-negative background amplitude

## Testing
- `pytest tests/test_fitting.py tests/test_plot_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896a0eea230832ba087f06594db4b4f