### PR TITLE
feat: positive unit-area background with amplitude (S_bkg) + softplus areas

### DIFF
--- a/assertions_and_ci.py
+++ b/assertions_and_ci.py
@@ -27,15 +27,8 @@ def run_assertions(summary: Mapping[str, Any], constants: Mapping[str, Any], con
         aic = float(spec.get("aic", 0.0))
         assert aic == aic and aic < 1e12  # finite and not astronomical
 
-        # Non-negative continuum across the ROI
-        b0 = float(spec.get("b0", 0.0))
-        b1 = float(spec.get("b1", 0.0))
-        ewin = config.get("time_fit", {}).get("window_po210") or [5.2, 5.4]
-        elo = float(ewin[0])
-        ehi = float(ewin[1]) + 2.5  # conservative high end for the ROI
-        assert b0 >= 0.0
-        assert (b0 + b1 * elo) >= 0.0
-        assert (b0 + b1 * ehi) >= 0.0
+        S_bkg = float(spec.get("S_bkg", 0.0))
+        assert S_bkg >= 0.0
 
     assert constants["Po214"]["half_life_s"] < 1e3
     assert config["baseline"]["sample_volume_l"] > 0

--- a/fitting.py
+++ b/fitting.py
@@ -19,6 +19,42 @@ from constants import _TAU_MIN, CURVE_FIT_MAX_EVALS, safe_exp as _safe_exp
 __all__ = ["fit_time_series", "fit_decay", "fit_spectrum"]
 
 
+def _softplus(x):
+    x = np.asarray(x)
+    return np.log1p(np.exp(-np.abs(x))) + np.maximum(x, 0.0)
+
+
+def _softplus_inv(y):
+    y = np.asarray(y)
+    out = np.empty_like(y, dtype=float)
+    mask_big = y > 20
+    mask_pos = (y > 0) & ~mask_big
+    out[mask_big] = y[mask_big]
+    out[mask_pos] = np.log(np.expm1(y[mask_pos]))
+    out[~(mask_big | mask_pos)] = -20.0
+    return out
+
+
+def _sigmoid(x):
+    return 1.0 / (1.0 + np.exp(-x))
+
+
+def _make_linear_bkg(E_lo, E_hi, Eref=None, n_grid=512):
+    if Eref is None:
+        Eref = 0.5 * (E_lo + E_hi)
+    grid = np.linspace(E_lo, E_hi, int(n_grid))
+
+    def shape(E, beta0, beta1):
+        t_grid = beta0 + beta1 * (grid - Eref)
+        t_max = np.max(t_grid)
+        g = np.exp(t_grid - t_max)
+        Z = np.trapz(g, grid)
+        t_eval = beta0 + beta1 * (np.asarray(E) - Eref)
+        return np.exp(t_eval - t_max) / Z
+
+    return shape
+
+
 class FitParams(TypedDict, total=False):
     """Typed mapping of fit parameter names to values."""
 
@@ -303,6 +339,8 @@ def fit_spectrum(
     E_lo = float(edges[0])
     E_hi = float(edges[-1])
 
+    bkg_shape = _make_linear_bkg(E_lo, E_hi)
+
     # Augment priors with a background amplitude if not provided
     priors = dict(priors)
     if "S_bkg" not in priors:
@@ -375,11 +413,12 @@ def fit_spectrum(
     sigma0_mean = sigma0_val
     for name in param_order:
         mean, sig = p(name, 1.0)
+        if name.startswith("S_"):
+            mean = float(_softplus_inv(mean))
         # Enforce a strictly positive initial tau to avoid singular EMG tails
         if name.startswith("tau_"):
             mean = max(mean, _TAU_MIN)
         if flags.get(f"fix_{name}", False) or sig == 0:
-            # curve_fit requires lower < upper; use a tiny width around fixed values
             lo = mean - eps
             hi = mean + eps
         else:
@@ -388,6 +427,11 @@ def fit_spectrum(
             hi = mean + delta
         if bounds and name in bounds:
             user_lo, user_hi = bounds[name]
+            if name.startswith("S_"):
+                if user_lo is not None:
+                    user_lo = float(_softplus_inv(user_lo))
+                if user_hi is not None:
+                    user_hi = float(_softplus_inv(user_hi))
             if user_lo is not None:
                 lo = max(lo, user_lo)
             if user_hi is not None:
@@ -397,10 +441,6 @@ def fit_spectrum(
             if max_tau_ratio is not None:
                 hi = min(hi, max_tau_ratio * sigma0_mean)
         if name in ("sigma0", "F"):
-            lo = max(lo, 0.0)
-        if name == "b0":
-            lo = max(lo, 0.0)
-        if name.startswith("S_"):
             lo = max(lo, 0.0)
         if hi <= lo:
             hi = lo + eps
@@ -423,7 +463,7 @@ def fit_spectrum(
         y = np.zeros_like(x)
         for iso in iso_list:
             mu = params[param_index[f"mu_{iso}"]]
-            S = params[param_index[f"S_{iso}"]]
+            S = _softplus(params[param_index[f"S_{iso}"]])
             if use_emg[iso]:
                 tau = params[param_index[f"tau_{iso}"]]
                 sigma = np.sqrt(sigma0 ** 2 + F_current * x)
@@ -434,14 +474,11 @@ def fit_spectrum(
             else:
                 sigma = np.sqrt(sigma0 ** 2 + F_current * x)
                 y += S * gaussian(x, mu, sigma)
-        b0 = params[param_index["b0"]]
-        b1 = params[param_index["b1"]]
-        S_bkg = params[param_index["S_bkg"]]
-        bkg = b0 + b1 * x
-        bkg_norm = b0 * (E_hi - E_lo) + 0.5 * b1 * (E_hi**2 - E_lo**2)
-        if bkg_norm > 0:
-            y += S_bkg * bkg / bkg_norm
-        return y
+        beta0 = params[param_index["b0"]]
+        beta1 = params[param_index["b1"]]
+        B = _softplus(params[param_index["S_bkg"]])
+        y += B * bkg_shape(x, beta0, beta1)
+        return np.clip(y, 1e-300, np.inf)
 
     def _model_binned(x, *params):
         y = _model_density(x, *params)
@@ -476,33 +513,17 @@ def fit_spectrum(
             )
     else:
         def _nll(*params):
-            # Per-event rate must be positive and finite
             rate = _model_density(e, *params)
-            if np.any(rate <= 0) or not np.isfinite(rate).all():
+            if not np.isfinite(rate).all():
                 return 1e50
 
-            # Sum of signal yields (non-negative by construction)
             S_sum = 0.0
             for iso in iso_list:
-                S_sum += params[param_index[f"S_{iso}"]]
+                S_sum += _softplus(params[param_index[f"S_{iso}"]])
 
-            # Background parameters
-            b0 = params[param_index["b0"]]
-            b1 = params[param_index["b1"]]
-            S_bkg = params[param_index["S_bkg"]]
+            B = _softplus(params[param_index["S_bkg"]])
+            expected = S_sum + B
 
-            # Enforce a non-negative background shape over the fit interval
-            if (b0 + b1 * E_lo) <= 0 or (b0 + b1 * E_hi) <= 0:
-                return 1e50
-
-            # Analytic integral of background shape for normalisation
-            bkg_norm = b0 * (E_hi - E_lo) + 0.5 * b1 * (E_hi**2 - E_lo**2)
-            if bkg_norm <= 0:
-                return 1e50
-
-            expected = S_sum + S_bkg
-
-            # Guard against pathological negative expectations
             if expected <= 0 or not np.isfinite(expected):
                 return 1e50
 
@@ -524,16 +545,24 @@ def fit_spectrum(
         if not m.valid:
             out["fit_valid"] = False
             for pname in param_order:
-                out[pname] = float(m.values[pname])
+                raw = float(m.values[pname])
                 err = float(m.errors[pname]) if pname in m.errors else np.nan
-                out["d" + pname] = err
+                if pname.startswith("S_"):
+                    out[pname] = float(_softplus(raw))
+                    out["d" + pname] = float(_sigmoid(raw) * err)
+                else:
+                    out[pname] = raw
+                    out["d" + pname] = err
             cov = np.zeros((len(param_order), len(param_order)))
             k = len(param_order)
             out["aic"] = float(2 * m.fval + 2 * k)
             return FitResult(out, cov, int(ndf), param_index, counts=int(n_events))
 
         m.hesse()
-        cov = np.array(m.covariance)
+        if m.covariance is None:
+            cov = np.zeros((len(param_order), len(param_order)))
+        else:
+            cov = np.array(m.covariance)
         perr = np.sqrt(np.clip(np.diag(cov), 0, None))
         try:
             eigvals = np.linalg.eigvals(cov)
@@ -560,8 +589,14 @@ def fit_spectrum(
                 pass
         out["fit_valid"] = fit_valid
         for i, pname in enumerate(param_order):
-            out[pname] = float(m.values[pname])
-            out["d" + pname] = float(perr[i] if i < len(perr) else np.nan)
+            raw = float(m.values[pname])
+            err = float(perr[i] if i < len(perr) else np.nan)
+            if pname.startswith("S_"):
+                out[pname] = float(_softplus(raw))
+                out["d" + pname] = float(_sigmoid(raw) * err)
+            else:
+                out[pname] = raw
+                out["d" + pname] = err
         if fix_sigma0:
             out["sigma0"] = sigma0_val
             out["dsigma0"] = 0.0
@@ -598,8 +633,14 @@ def fit_spectrum(
             pass
     out = {}
     for i, name in enumerate(param_order):
-        out[name] = float(popt[i])
-        out["d" + name] = float(perr[i])
+        raw = float(popt[i])
+        err = float(perr[i])
+        if name.startswith("S_"):
+            out[name] = float(_softplus(raw))
+            out["d" + name] = float(_sigmoid(raw) * err)
+        else:
+            out[name] = raw
+            out["d" + name] = err
 
     if fix_sigma0:
         out["sigma0"] = sigma0_val


### PR DESCRIPTION
## Summary
- ensure spectrum areas are strictly non-negative via a stable softplus transform
- model background with a normalized log-linear shape and separate S_bkg amplitude
- relax assertions to only require non-negative background amplitude

## Testing
- `pytest tests/test_fitting.py tests/test_plot_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896a0eea230832ba087f06594db4b4f