### PR TITLE
feat: positive unit-area background with amplitude (S_bkg) + softplus areas

### DIFF
--- a/assertions_and_ci.py
+++ b/assertions_and_ci.py
@@ -27,15 +27,8 @@ def run_assertions(summary: Mapping[str, Any], constants: Mapping[str, Any], con
         aic = float(spec.get("aic", 0.0))
         assert aic == aic and aic < 1e12  # finite and not astronomical
 
-        # Non-negative continuum across the ROI
-        b0 = float(spec.get("b0", 0.0))
-        b1 = float(spec.get("b1", 0.0))
-        ewin = config.get("time_fit", {}).get("window_po210") or [5.2, 5.4]
-        elo = float(ewin[0])
-        ehi = float(ewin[1]) + 2.5  # conservative high end for the ROI
-        assert b0 >= 0.0
-        assert (b0 + b1 * elo) >= 0.0
-        assert (b0 + b1 * ehi) >= 0.0
+        # Non-negative background amplitude
+        assert float(spec.get("S_bkg", 0.0)) >= 0.0
 
     assert constants["Po214"]["half_life_s"] < 1e3
     assert config["baseline"]["sample_volume_l"] > 0

--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from pathlib import Path
 from color_schemes import COLOR_SCHEMES
 from constants import PO214, PO218, PO210
+from fitting import _make_linear_bkg
 from .paths import get_targets
 
 # Half-life constants used for the time-series overlay [seconds]
@@ -466,14 +467,13 @@ def plot_spectrum(
 
     if fit_vals:
         sigma_E = fit_vals.get("sigma_E", 1.0)
-        b0 = fit_vals.get("b0", 0.0)
-        b1 = fit_vals.get("b1", 0.0)
-        S_bkg = fit_vals.get("S_bkg", 0.0)
-        bkg_cent = b0 + b1 * centers
-        bkg_norm = b0 * (edges[-1] - edges[0]) + 0.5 * b1 * (edges[-1] ** 2 - edges[0] ** 2)
+        beta0 = fit_vals.get("b0", 0.0)
+        beta1 = fit_vals.get("b1", 0.0)
+        B = fit_vals.get("S_bkg", 0.0)
+        bkg_shape = _make_linear_bkg(edges[0], edges[-1])
+        bkg_cent = bkg_shape(centers, beta0, beta1)
         y_cent = np.zeros_like(centers)
-        if bkg_norm > 0:
-            y_cent += S_bkg * bkg_cent / bkg_norm
+        y_cent += B * bkg_cent
         for pk in ("Po210", "Po218", "Po214"):
             mu_key = f"mu_{pk}"
             amp_key = f"S_{pk}"

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -131,12 +131,12 @@ def test_plot_spectrum_irregular_edges_residuals(tmp_path, monkeypatch):
     hist, _ = np.histogram(energies, bins=edges)
     width = np.diff(edges)
     centers = edges[:-1] + width / 2.0
-    norm = fit_vals["b0"] * (edges[-1] - edges[0]) + 0.5 * fit_vals["b1"] * (
-        edges[-1] ** 2 - edges[0] ** 2
-    )
-    model_counts = (
-        fit_vals["S_bkg"] * (fit_vals["b0"] + fit_vals["b1"] * centers) / norm * width
-    )
+    from fitting import _make_linear_bkg
+
+    bkg_shape = _make_linear_bkg(edges[0], edges[-1])
+    model_counts = fit_vals["S_bkg"] * bkg_shape(
+        centers, fit_vals["b0"], fit_vals["b1"]
+    ) * width
     expected = hist - model_counts
 
     assert len(captured) >= 2


### PR DESCRIPTION
## Summary
- add stable softplus and unit-area log-linear background shape
- map all spectral areas via softplus and introduce S_bkg amplitude
- relax ROI background assertions and update plotting to new background model

## Testing
- `pytest tests/test_fitting.py tests/test_plot_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896a0eea230832ba087f06594db4b4f