### PR TITLE
feat(cli,config): add feature flags for background model and likelihood (opt-in)

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -722,6 +722,16 @@ def parse_args(argv=None):
         help="Analysis isotope mode (overrides analysis_isotope in config.yaml)",
     )
     p.add_argument(
+        "--background-model",
+        choices=["linear", "loglin_unit"],
+        help="Experimental (opt-in). Background model. Defaults keep legacy behavior.",
+    )
+    p.add_argument(
+        "--likelihood",
+        choices=["current", "extended"],
+        help="Experimental (opt-in). Likelihood function. Defaults keep legacy behavior.",
+    )
+    p.add_argument(
         "--allow-negative-baseline",
         action="store_true",
         help="Allow negative baseline-corrected rates",
@@ -1097,6 +1107,14 @@ def main(argv=None):
     if args.seed is not None:
         _log_override("pipeline", "random_seed", int(args.seed))
         cfg.setdefault("pipeline", {})["random_seed"] = int(args.seed)
+    if args.background_model is not None:
+        _log_override("analysis", "background_model", args.background_model)
+        cfg.setdefault("analysis", {})["background_model"] = args.background_model
+
+    if args.likelihood is not None:
+        _log_override("analysis", "likelihood", args.likelihood)
+        cfg.setdefault("analysis", {})["likelihood"] = args.likelihood
+
 
     if args.ambient_concentration is not None:
         _log_override(

--- a/config.yaml
+++ b/config.yaml
@@ -23,6 +23,8 @@ analysis:
   - '2024-01-05T06:00:00Z'
   - '2024-01-06T18:00:00Z'
   ambient_concentration: null
+  background_model: linear
+  likelihood: current
 columns:
   timestamp: timestamps
   adc: adc_channels

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -52,3 +52,7 @@ time_fit:
   bkg_po214:
     - 0.0
     - 0.2
+
+analysis:
+  background_model: linear
+  likelihood: current

--- a/io_utils.py
+++ b/io_utils.py
@@ -241,6 +241,8 @@ CONFIG_SCHEMA = {
                     "maxItems": 2,
                 },
                 "ambient_concentration": {"type": ["number", "null"]},
+                "background_model": {"type": "string", "enum": ["linear", "loglin_unit"]},
+                "likelihood": {"type": "string", "enum": ["current", "extended"]},
                 "settle_s": {"type": ["number", "null"], "minimum": 0},
             },
         },

--- a/model_selectors.py
+++ b/model_selectors.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping
+
+import numpy as np
+
+from fitting import softplus
+
+
+def select_background_factory(opts: Mapping[str, Any], Emin: float, Emax: float) -> Callable[[np.ndarray, Mapping[str, float]], np.ndarray]:
+    """Return a background function based on configuration options."""
+    model = getattr(opts, "background_model", "linear")
+    if model == "loglin_unit":
+        from fitting import make_linear_bkg  # lazy import
+
+        def bkg(E, params):
+            shape = make_linear_bkg(Emin, Emax)(E, params["beta0"], params["beta1"])
+            return softplus(params["S_bkg"]) * shape
+
+        return bkg
+
+    def existing_linear_bkg(E, params):
+        beta0 = params["beta0"]
+        beta1 = params["beta1"]
+        S = params.get("S_bkg", 0.0)
+        norm = beta0 * (Emax - Emin) + 0.5 * beta1 * (Emax**2 - Emin**2)
+        norm = max(norm, 1e-300)
+        return softplus(S) * (beta0 + beta1 * E) / norm
+
+    return existing_linear_bkg
+
+
+def select_neg_loglike(opts: Mapping[str, Any]):
+    """Return the negative log-likelihood function for spectral fits."""
+    if getattr(opts, "likelihood", "current") == "extended":
+        from likelihood_ext import neg_loglike_extended
+
+        return neg_loglike_extended
+
+    def existing_neg_loglike(E, intensity_fn, params, *, area_keys, clip=1e-300):
+        lam = np.clip(intensity_fn(E, params), clip, np.inf)
+        Nexp = float(sum(params[k] for k in area_keys))
+        return float(-(np.sum(np.log(lam)) - Nexp))
+
+    return existing_neg_loglike


### PR DESCRIPTION
## Summary
- expose experimental `background_model` and `likelihood` toggles in config and CLI
- add schema validation and defaults for new analysis options
- provide helper factories for selecting background and likelihood implementations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68976d057358832bbf94765a35d63572