### PR TITLE
feat(cli,config): add feature flags for background model and likelihood (opt-in)

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -702,6 +702,16 @@ def parse_args(argv=None):
         help="Timezone for naive input timestamps (default: UTC)",
     )
     p.add_argument(
+        "--background-model",
+        choices=["linear", "loglin_unit"],
+        help="Experimental (opt-in) background model (default: linear)",
+    )
+    p.add_argument(
+        "--likelihood",
+        choices=["current", "extended"],
+        help="Experimental (opt-in) likelihood (default: current)",
+    )
+    p.add_argument(
         "--baseline_range",
         nargs=2,
         metavar=("TSTART", "TEND"),
@@ -1146,6 +1156,12 @@ def main(argv=None):
     if args.settle_s is not None:
         _log_override("analysis", "settle_s", float(args.settle_s))
         cfg.setdefault("analysis", {})["settle_s"] = float(args.settle_s)
+    if args.background_model is not None:
+        _log_override("analysis", "background_model", args.background_model)
+        cfg.setdefault("analysis", {})["background_model"] = args.background_model
+    if args.likelihood is not None:
+        _log_override("analysis", "likelihood", args.likelihood)
+        cfg.setdefault("analysis", {})["likelihood"] = args.likelihood
 
     if args.hl_po214 is not None:
         tf = cfg.setdefault("time_fit", {})

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -52,3 +52,7 @@ time_fit:
   bkg_po214:
     - 0.0
     - 0.2
+
+analysis:
+  background_model: linear
+  likelihood: current

--- a/feature_selectors.py
+++ b/feature_selectors.py
@@ -1,0 +1,66 @@
+"""Helper selectors for experimental features."""
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping
+
+import numpy as np
+
+
+__all__ = ["select_background_factory", "select_neg_loglike"]
+
+
+def existing_linear_bkg(E: np.ndarray | float, params: Mapping[str, float]) -> np.ndarray | float:
+    """Simple linear background ``b0 + b1 * E``."""
+    b0 = float(params.get("b0", 0.0))
+    b1 = float(params.get("b1", 0.0))
+    E = np.asarray(E, dtype=float)
+    return b0 + b1 * E
+
+
+def select_background_factory(opts: Any, Emin: float, Emax: float) -> Callable[[np.ndarray, Mapping[str, float]], np.ndarray]:
+    """Return a background intensity function based on ``opts.background_model``.
+
+    Parameters
+    ----------
+    opts:
+        Object with attribute ``background_model``.
+    Emin, Emax:
+        Energy bounds for the log-linear shape.
+    """
+    model = getattr(opts, "background_model", "linear")
+    if model == "loglin_unit":
+        from fitting import make_linear_bkg, softplus
+
+        shape_fn = make_linear_bkg(Emin, Emax)
+
+        def bkg(E, params):
+            beta0 = params.get("beta0", params.get("b0", 0.0))
+            beta1 = params.get("beta1", params.get("b1", 0.0))
+            shape = shape_fn(E, beta0, beta1)
+            return softplus(params["S_bkg"]) * shape
+
+        return bkg
+    else:
+        return lambda E, params: existing_linear_bkg(E, params)
+
+
+def existing_neg_loglike(
+    E: np.ndarray,
+    intensity_fn: Callable[[np.ndarray, Mapping[str, float]], np.ndarray],
+    params: Mapping[str, float],
+    *,
+    area_keys,
+    clip: float = 1e-300,
+) -> float:
+    """Status-quo negative log-likelihood ignoring expected counts."""
+    lam = np.clip(intensity_fn(E, params), clip, np.inf)
+    return float(-np.sum(np.log(lam)))
+
+
+def select_neg_loglike(opts: Any) -> Callable:
+    """Select the negative log-likelihood implementation."""
+    if getattr(opts, "likelihood", "current") == "extended":
+        from likelihood_ext import neg_loglike_extended
+
+        return neg_loglike_extended
+    return existing_neg_loglike

--- a/io_utils.py
+++ b/io_utils.py
@@ -240,6 +240,14 @@ CONFIG_SCHEMA = {
                     "minItems": 2,
                     "maxItems": 2,
                 },
+                "background_model": {
+                    "type": "string",
+                    "enum": ["linear", "loglin_unit"],
+                },
+                "likelihood": {
+                    "type": "string",
+                    "enum": ["current", "extended"],
+                },
                 "ambient_concentration": {"type": ["number", "null"]},
                 "settle_s": {"type": ["number", "null"], "minimum": 0},
             },


### PR DESCRIPTION
## Summary
- allow configuring background model via config/CLI
- add opt-in extended likelihood flag
- provide helper selectors for experimental features

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68976d057358832bbf94765a35d63572