### PR TITLE
feat: add clear runtime checks for opt-in background/likelihood flags

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -669,7 +669,12 @@ def _model_uncertainty(centers, widths, fit_obj, iso, cfg, normalise):
 
 def parse_args(argv=None):
     """Parse command line arguments."""
-    p = argparse.ArgumentParser(description="Full Radon Monitor Analysis Pipeline")
+    p = argparse.ArgumentParser(
+        description="Full Radon Monitor Analysis Pipeline",
+        epilog=(
+            "See README for background_model and likelihood options."
+        ),
+    )
     default_cfg = Path(__file__).resolve().with_name("config.yaml")
     p.add_argument(
         "--config",

--- a/fitting.py
+++ b/fitting.py
@@ -361,6 +361,19 @@ def fit_spectrum(
 
     # Augment priors with a background amplitude if not provided
     priors = dict(priors)
+    background_model = flags.get("background_model") if flags else None
+    if background_model == "loglin_unit":
+        present = set(priors)
+        if "b0" in present:
+            present.add("beta0")
+        if "b1" in present:
+            present.add("beta1")
+        missing = [k for k in ("S_bkg", "beta0", "beta1") if k not in present]
+        if missing:
+            raise ValueError(
+                "background_model=loglin_unit requires params {S_bkg, beta0, beta1}; got: "
+                f"{sorted(priors)}"
+            )
     if "S_bkg" not in priors:
         b0_mu = priors.get("b0", (0.0, 1.0))[0]
         b1_mu = priors.get("b1", (0.0, 1.0))[0]

--- a/likelihood_ext.py
+++ b/likelihood_ext.py
@@ -43,6 +43,12 @@ def neg_loglike_extended(E, intensity_fn, params, *, area_keys, clip=1e-300):
     >>> neg_loglike_extended(E, reference_intensity, params, area_keys=("area",))
     1.5...
     """
+    missing = [k for k in area_keys if k not in params]
+    if missing:
+        raise ValueError(
+            "likelihood=extended requires params "
+            f"{list(area_keys)}; got: {sorted(params)}"
+        )
     E = np.asarray(E, dtype=float)
     lam = np.clip(intensity_fn(E, params), clip, np.inf)
     Nexp = float(sum(_softplus(params[k]) for k in area_keys))


### PR DESCRIPTION
## Summary
- validate params for opt-in log-linear background model
- guard extended likelihood against missing area keys
- mention background and likelihood options in CLI help

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68976d37835c832b8bcf03dd47de1afe