### PR TITLE
feat(cli,config): add feature flags for background model and likelihood

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -799,6 +799,16 @@ def parse_args(argv=None):
         help="Reference start time of the analysis (ISO string or epoch). Overrides `analysis.analysis_start_time` in config.yaml",
     )
     p.add_argument(
+        "--background-model",
+        choices=["linear", "loglin_unit"],
+        help="Experimental (opt-in) background model. Defaults keep legacy behavior.",
+    )
+    p.add_argument(
+        "--likelihood",
+        choices=["current", "extended"],
+        help="Experimental (opt-in) likelihood. Defaults keep legacy behavior.",
+    )
+    p.add_argument(
         "--spike-start-time",
         help="Discard events after this ISO timestamp. Providing this option overrides `analysis.spike_start_time` in config.yaml",
     )
@@ -1142,6 +1152,14 @@ def main(argv=None):
             args.radon_interval[0],
             args.radon_interval[1],
         ]
+
+    if args.background_model is not None:
+        _log_override("analysis", "background_model", args.background_model)
+        cfg.setdefault("analysis", {})["background_model"] = args.background_model
+
+    if args.likelihood is not None:
+        _log_override("analysis", "likelihood", args.likelihood)
+        cfg.setdefault("analysis", {})["likelihood"] = args.likelihood
 
     if args.settle_s is not None:
         _log_override("analysis", "settle_s", float(args.settle_s))
@@ -2962,6 +2980,8 @@ def main(argv=None):
             "spike_periods": spike_periods_cfg,
             "run_periods": run_periods_cfg,
             "radon_interval": radon_interval_cfg,
+            "background_model": cfg.get("analysis", {}).get("background_model"),
+            "likelihood": cfg.get("analysis", {}).get("likelihood"),
             "ambient_concentration": cfg.get("analysis", {}).get(
                 "ambient_concentration"
             ),

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -3,6 +3,10 @@ analysis_isotope: radon
 allow_negative_baseline: false
 allow_negative_activity: false
 
+analysis:
+  background_model: linear
+  likelihood: current
+
 calibration:
   slope_MeV_per_ch: null
   intercept_MeV: null

--- a/feature_selectors.py
+++ b/feature_selectors.py
@@ -1,0 +1,76 @@
+"""Factory helpers for optional background and likelihood models.
+
+These helpers expose experimental feature-flagged behaviour without changing
+the default execution path.  Callers can supply an object ``opts`` providing
+``background_model`` and ``likelihood`` attributes to opt in to the new
+implementations.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping, Sequence
+
+import numpy as np
+
+from fitting import softplus
+
+
+def _existing_linear_bkg(E, params):
+    """Legacy linear background model returning counts/MeV."""
+
+    b0 = params.get("b0", 0.0)
+    b1 = params.get("b1", 0.0)
+    return b0 + b1 * np.asarray(E)
+
+
+def select_background_factory(opts: Any, Emin: float, Emax: float) -> Callable:
+    """Select a background factory based on ``opts.background_model``.
+
+    Parameters
+    ----------
+    opts : Any
+        Object providing a ``background_model`` attribute.
+    Emin, Emax : float
+        Energy bounds used when constructing the log-linear shape.
+    """
+
+    if getattr(opts, "background_model", "") == "loglin_unit":
+        from fitting import make_linear_bkg
+
+        shape = make_linear_bkg(Emin, Emax)
+
+        def bkg(E, params):
+            val = shape(E, params["beta0"], params["beta1"])
+            return softplus(params["S_bkg"]) * val
+
+        return bkg
+
+    return lambda E, params: _existing_linear_bkg(E, params)
+
+
+def select_neg_loglike(opts: Any) -> Callable:
+    """Return the negative log-likelihood function based on ``opts``."""
+
+    if getattr(opts, "likelihood", "") == "extended":
+        from likelihood_ext import neg_loglike_extended
+
+        return neg_loglike_extended
+
+    def neg_loglike_current(
+        E: Sequence[float],
+        intensity_fn: Callable[[Sequence[float], Mapping[str, float]], np.ndarray],
+        params: Mapping[str, float],
+        *,
+        area_keys: Sequence[str] | None = None,
+        clip: float = 1e-300,
+    ) -> float:
+        """Simple unextended unbinned negative log-likelihood."""
+
+        lam = np.clip(intensity_fn(E, params), clip, np.inf)
+        return float(-np.sum(np.log(lam)))
+
+    return neg_loglike_current
+
+
+__all__ = ["select_background_factory", "select_neg_loglike"]
+

--- a/io_utils.py
+++ b/io_utils.py
@@ -242,6 +242,14 @@ CONFIG_SCHEMA = {
                 },
                 "ambient_concentration": {"type": ["number", "null"]},
                 "settle_s": {"type": ["number", "null"], "minimum": 0},
+                "background_model": {
+                    "type": "string",
+                    "enum": ["linear", "loglin_unit"],
+                },
+                "likelihood": {
+                    "type": "string",
+                    "enum": ["current", "extended"],
+                },
             },
         },
         "columns": {


### PR DESCRIPTION
## Summary
- allow selecting between linear and loglin background models
- add switch for current vs extended likelihood
- provide factory helpers to gate experimental features

## Testing
- `pytest -q`
- `python analyze.py --help | head -n 40`


------
https://chatgpt.com/codex/tasks/task_e_68976d057358832bbf94765a35d63572