### PR TITLE
Enable floating two-point calibration defaults

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -53,7 +53,7 @@ calibration:
     Po218: 5
     Po214: 5
   slope_MeV_per_ch: 0.00427
-  float_slope: false
+  float_slope: true
   use_two_point: true
   nominal_adc:
     Po210: 1246

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -4,10 +4,11 @@ allow_negative_baseline: false
 allow_negative_activity: false
 
 calibration:
+  method: two-point
   slope_MeV_per_ch: null
   intercept_MeV: null
-  float_slope: false
-  use_two_point: false
+  float_slope: true
+  use_two_point: true
   sigma_E_init: null
   peak_widths: null
 

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -11,6 +11,7 @@ calibration:
   use_two_point: true
   sigma_E_init: null
   peak_widths: null
+  peak_prominence: 10
 
 spectral_fit:
   float_sigma_E: true


### PR DESCRIPTION
## Summary
- Default to two-point calibration with floating slope
- Allow example configuration to float slope during two-point calibration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0ff8921b4832b8e6b23aaae029948