### PR TITLE
Reduce calibration peak prominence threshold

### DIFF
--- a/calibration.py
+++ b/calibration.py
@@ -709,7 +709,7 @@ def derive_calibration_constants_auto(
 
     config = {
         "calibration": {
-            "peak_prominence": 10,
+            "peak_prominence": 5,
             "peak_width": 3,
             "nominal_adc": nominal_adc,
             # parameter renamed to ``peak_search_radius`` to match config.json

--- a/examples/config_fixed_slope.json
+++ b/examples/config_fixed_slope.json
@@ -34,7 +34,7 @@
         "noise_cutoff": 400,
         "hist_bins": 2000,
         "peak_search_radius": 100,
-        "peak_prominence": 10,
+        "peak_prominence": 5,
         "peak_width": 3,
         "nominal_adc": {"Po210": 1250, "Po218": 1405, "Po214": 1800},
         "fit_window_adc": 40,


### PR DESCRIPTION
## Summary
- Lower default peak prominence in calibration auto-calibration to 5 to better detect anchor peaks
- Align fixed-slope example config with new threshold

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0ffa529ac832b9cdca948b64dd0f0