### PR TITLE
Lower calibration peak prominence default

### DIFF
--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -10,6 +10,7 @@ calibration:
   use_two_point: false
   sigma_E_init: null
   peak_widths: null
+  peak_prominence: 10
 
 spectral_fit:
   float_sigma_E: true


### PR DESCRIPTION
## Summary
- Default calibration peak search now uses a prominence threshold of 10 to ensure secondary anchor peaks are found reliably.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0ffa529ac832b9cdca948b64dd0f0