### PR TITLE
Simplify resolution control settings

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1976,7 +1976,6 @@ def main(argv=None):
         # Flags controlling the spectral fit
         spec_flags = cfg["spectral_fit"].get("flags", {}).copy()
         if not cfg["spectral_fit"].get("float_sigma_E", True):
-            spec_flags["fix_sigma0"] = True
             spec_flags.setdefault("fix_F", True)
 
         if "fix_sigma_E" in spec_flags:

--- a/config.yaml
+++ b/config.yaml
@@ -96,7 +96,7 @@ spectral_fit:
     Po210: true
     Po218: true
     Po214: true
-  float_sigma_E: true
+  float_sigma_E: false
   peak_search_prominence: 30
   peak_search_width_adc: 3
   peak_search_method: prominence
@@ -105,10 +105,6 @@ spectral_fit:
   use_plot_bins_for_fit: false
   unbinned_likelihood: true
   flags:
-    fix_sigma0: true  # fix the width
-    sigma0_prior:
-      - 0.13
-      - 0.02
     fix_F: true       # fix the Fano factor
     F_prior:
       - 0.0

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -12,7 +12,7 @@ calibration:
   peak_widths: null
 
 spectral_fit:
-  float_sigma_E: true
+  float_sigma_E: false
   peak_search_method: prominence
   peak_search_cwt_widths: null
   refit_aic_threshold: 2.0
@@ -20,10 +20,6 @@ spectral_fit:
   # Flags controlling resolution parameters; letting both float keeps the
   # optimiser well-constrained
   flags:
-    fix_sigma0: true  # fix the width
-    sigma0_prior:
-      - 0.13
-      - 0.02
     fix_F: true       # fix the Fano factor
     F_prior:
       - 0.0


### PR DESCRIPTION
## Summary
- disable floating energy-resolution width by default
- remove hard sigma0 fix and associated prior from spectral-fit flags
- avoid forcing sigma0 fixed when float_sigma_E is false

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0ffddd72c832b93321756a053b85e