### PR TITLE
Narrow linear background slope prior

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -76,13 +76,13 @@ spectral_fit:
   fd_hist_bins: 400
   mu_sigma: 0.02
   amp_prior_scale: 5.0
-  bkg_mode: auto
+  bkg_mode: linear
   b0_prior:
     - 0.0
     - 5.0
   b1_prior:
-    - 0.0
-    - 0.2
+    - -0.02
+    - 0.02
   tau_Po210_prior_mean: 0.025
   tau_Po210_prior_sigma: 0.010
   tau_Po218_prior_mean: 0.015

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -30,13 +30,13 @@ spectral_fit:
       - 0.01
 
   # your existing background priors
-  bkg_mode: auto
+  bkg_mode: linear
   b0_prior:
     - 0.0
     - 5.0
   b1_prior:
-    - 0.0
-    - 0.2
+    - -0.02
+    - 0.02
 
 time_fit:
   window_po214:


### PR DESCRIPTION
## Summary
- use linear continuum by default
- narrow linear background slope prior to [-0.02, 0.02]

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0ffbd7dd0832bb32f8ed5f577df22