### PR TITLE
Simplify resolution parameter handling

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -96,7 +96,7 @@ spectral_fit:
     Po210: true
     Po218: true
     Po214: true
-  float_sigma_E: true
+  float_sigma_E: false
   peak_search_prominence: 30
   peak_search_width_adc: 3
   peak_search_method: prominence
@@ -105,10 +105,7 @@ spectral_fit:
   use_plot_bins_for_fit: false
   unbinned_likelihood: true
   flags:
-    fix_sigma0: true  # fix the width
-    sigma0_prior:
-      - 0.13
-      - 0.02
+    fix_sigma0: false  # allow the width to vary
     fix_F: true       # fix the Fano factor
     F_prior:
       - 0.0

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -12,7 +12,7 @@ calibration:
   peak_widths: null
 
 spectral_fit:
-  float_sigma_E: true
+  float_sigma_E: false
   peak_search_method: prominence
   peak_search_cwt_widths: null
   refit_aic_threshold: 2.0
@@ -20,10 +20,7 @@ spectral_fit:
   # Flags controlling resolution parameters; letting both float keeps the
   # optimiser well-constrained
   flags:
-    fix_sigma0: true  # fix the width
-    sigma0_prior:
-      - 0.13
-      - 0.02
+    fix_sigma0: false  # allow the width to vary
     fix_F: true       # fix the Fano factor
     F_prior:
       - 0.0


### PR DESCRIPTION
## Summary
- avoid conflicting resolution controls by disabling float_sigma_E and allowing sigma0 to vary
- drop strong sigma0 prior from default and example configs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0ffddd72c832b93321756a053b85e