### PR TITLE
Narrow linear background slope prior

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -82,7 +82,7 @@ spectral_fit:
     - 5.0
   b1_prior:
     - 0.0
-    - 0.2
+    - 0.02
   tau_Po210_prior_mean: 0.025
   tau_Po210_prior_sigma: 0.010
   tau_Po218_prior_mean: 0.015

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -36,7 +36,7 @@ spectral_fit:
     - 5.0
   b1_prior:
     - 0.0
-    - 0.2
+    - 0.02
 
 time_fit:
   window_po214:


### PR DESCRIPTION
## Summary
- Tighten b1 prior for linear background to keep slope near zero

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0ffbd7dd0832bb32f8ed5f577df22