### PR TITLE
Enable time series JSON dumping by default

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -169,6 +169,6 @@ plotting:
   plot_save_formats:
   - png
   - pdf
-  dump_time_series_json: false
+  dump_time_series_json: true
   plot_time_style: lines
   overlay_isotopes: true

--- a/examples/config_fixed_slope.json
+++ b/examples/config_fixed_slope.json
@@ -118,7 +118,7 @@
         "plot_time_normalise_rate": true,
         "time_bins_fallback": 1,
         "plot_save_formats": ["png", "pdf"],
-        "dump_time_series_json": false,
+        "dump_time_series_json": true,
         "plot_time_style": "lines",
         "overlay_isotopes": false
     }


### PR DESCRIPTION
## Summary
- default to dumping time-series data JSON for easier debugging

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a103167600832b88145e6d37035874