### PR TITLE
Align resolution controls

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -96,7 +96,7 @@ spectral_fit:
     Po210: true
     Po218: true
     Po214: true
-  float_sigma_E: true
+  float_sigma_E: false
   peak_search_prominence: 30
   peak_search_width_adc: 3
   peak_search_method: prominence
@@ -105,10 +105,10 @@ spectral_fit:
   use_plot_bins_for_fit: false
   unbinned_likelihood: true
   flags:
-    fix_sigma0: true  # fix the width
+    fix_sigma0: false  # allow the width to float
     sigma0_prior:
       - 0.13
-      - 0.02
+      - 0.05
     fix_F: true       # fix the Fano factor
     F_prior:
       - 0.0

--- a/config_defaults.yaml
+++ b/config_defaults.yaml
@@ -12,18 +12,18 @@ calibration:
   peak_widths: null
 
 spectral_fit:
-  float_sigma_E: true
+  float_sigma_E: false
   peak_search_method: prominence
   peak_search_cwt_widths: null
   refit_aic_threshold: 2.0
 
-  # Flags controlling resolution parameters; letting both float keeps the
-  # optimiser well-constrained
+  # Flags controlling resolution parameters. With the energy slope fixed,
+  # allow the width to float with a looser prior.
   flags:
-    fix_sigma0: true  # fix the width
+    fix_sigma0: false  # allow the width to float
     sigma0_prior:
       - 0.13
-      - 0.02
+      - 0.05
     fix_F: true       # fix the Fano factor
     F_prior:
       - 0.0


### PR DESCRIPTION
## Summary
- avoid conflicting resolution settings by disabling `float_sigma_E` and allowing `sigma0` to float with a looser prior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0ffddd72c832b93321756a053b85e