### PR TITLE
Fix secondary axis offset in radon activity plots

### DIFF
--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -564,7 +564,10 @@ def plot_radon_activity_full(times, activity, errors, out_png, config=None):
             return f"{int(x)} s ({h:g} h)"
         return f"{int(x)} s"
 
+    # Use integer tick positions and suppress Matplotlib's auto offset text
+    secax.xaxis.set_major_locator(mticker.MaxNLocator(integer=True))
     secax.xaxis.set_major_formatter(mticker.FuncFormatter(_sec_formatter))
+    secax.xaxis.get_offset_text().set_visible(False)
     secax.set_xlabel("Elapsed Time (s)")
     plt.gcf().autofmt_xdate()
     plt.tight_layout()

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -750,7 +750,8 @@ def test_extract_time_series_none_window():
 
 
 def test_plot_radon_activity_axis_labels(tmp_path, monkeypatch):
-    times = [0.0, 1.0, 2.0]
+    # Use large epoch-second values to exercise secondary-axis formatting
+    times = [10892370.0, 10896370.0, 10898370.0]
     activity = [1.0, 2.0, 3.0]
     errors = [0.1, 0.2, 0.3]
     out_png = tmp_path / "radon_lbl.png"
@@ -778,7 +779,10 @@ def test_plot_radon_activity_axis_labels(tmp_path, monkeypatch):
     ax = plt.gca()
     assert ax.get_xlabel() == "Time (UTC)"
     assert "axis" in captured
-    assert captured["axis"].get_xlabel() == "Elapsed Time (s)"
+    secax = captured["axis"]
+    assert secax.get_xlabel() == "Elapsed Time (s)"
+    # Matplotlib's offset text on the secondary axis should be suppressed
+    assert secax.xaxis.get_offset_text().get_text() == ""
 
 
 def test_plot_time_series_uncertainty_band(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- ensure radon activity full plot uses integer ticks on the elapsed-time axis and hides auto offset text
- cover regression with a test using large epoch values

## Testing
- `pytest tests/test_plot_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1028572a0832bbab051fb6a172eda