### PR TITLE
Normalize radon plot time axes to avoid offset labels

### DIFF
--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -368,6 +368,7 @@ def plot_time_series(
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
     plt.gcf().autofmt_xdate()
+    ax.xaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
     targets = get_targets(config, out_png)
     for p in targets.values():
@@ -567,6 +568,8 @@ def plot_radon_activity_full(times, activity, errors, out_png, config=None):
     secax.xaxis.set_major_formatter(mticker.FuncFormatter(_sec_formatter))
     secax.set_xlabel("Elapsed Time (s)")
     plt.gcf().autofmt_xdate()
+    ax.xaxis.get_offset_text().set_visible(False)
+    secax.xaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
     targets = get_targets(config, out_png)
     for p in targets.values():
@@ -611,6 +614,7 @@ def plot_equivalent_air(times, volumes, errors, conc, out_png, config=None):
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
     plt.gcf().autofmt_xdate()
+    ax.xaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
     targets = get_targets(config, out_png)
     for p in targets.values():
@@ -660,6 +664,7 @@ def plot_radon_trend_full(times, activity, out_png, config=None):
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
     plt.gcf().autofmt_xdate()
+    ax.xaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
 
     targets = get_targets(config, out_png)
@@ -671,13 +676,27 @@ def plot_radon_trend_full(times, activity, out_png, config=None):
 def plot_radon_activity(ts_dict, outdir):
     """Simple wrapper to plot radon activity time series."""
     import matplotlib.pyplot as plt
+
     outdir = Path(outdir)
-    t = ts_dict["time"]
-    y = ts_dict["activity"]
-    e = ts_dict["error"]
-    plt.errorbar(t, y, yerr=e, fmt="o")
+    times = np.asarray(ts_dict["time"], dtype=float)
+    y = np.asarray(ts_dict["activity"], dtype=float)
+    e = np.asarray(ts_dict["error"], dtype=float)
+
+    times_dt = mdates.date2num([datetime.utcfromtimestamp(t) for t in times])
+    plt.errorbar(times_dt, y, yerr=e, fmt="o")
     plt.ylabel("Radon activity [Bq]")
     plt.xlabel("Time (UTC)")
+
+    ax = plt.gca()
+    locator = mdates.AutoDateLocator()
+    try:
+        formatter = mdates.ConciseDateFormatter(locator)
+    except AttributeError:
+        formatter = mdates.AutoDateFormatter(locator)
+    ax.xaxis.set_major_locator(locator)
+    ax.xaxis.set_major_formatter(formatter)
+    plt.gcf().autofmt_xdate()
+    ax.xaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
     plt.savefig(outdir / "radon_activity.png", dpi=300)
     plt.close()
@@ -687,14 +706,27 @@ def plot_radon_trend(ts_dict, outdir):
     """Simple wrapper to plot a radon activity trend."""
     import numpy as np
     import matplotlib.pyplot as plt
+
     outdir = Path(outdir)
-    t = np.asarray(ts_dict["time"])
-    y = np.asarray(ts_dict["activity"])
-    coeff = np.polyfit(t, y, 1)
-    plt.plot(t, y, "o")
-    plt.plot(t, np.polyval(coeff, t))
+    times = np.asarray(ts_dict["time"], dtype=float)
+    y = np.asarray(ts_dict["activity"], dtype=float)
+    times_dt = mdates.date2num([datetime.utcfromtimestamp(t) for t in times])
+    coeff = np.polyfit(times_dt, y, 1)
+    plt.plot(times_dt, y, "o")
+    plt.plot(times_dt, np.polyval(coeff, times_dt))
     plt.ylabel("Radon activity [Bq]")
     plt.xlabel("Time (UTC)")
+
+    ax = plt.gca()
+    locator = mdates.AutoDateLocator()
+    try:
+        formatter = mdates.ConciseDateFormatter(locator)
+    except AttributeError:
+        formatter = mdates.AutoDateFormatter(locator)
+    ax.xaxis.set_major_locator(locator)
+    ax.xaxis.set_major_formatter(formatter)
+    plt.gcf().autofmt_xdate()
+    ax.xaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
     plt.savefig(outdir / "radon_trend.png", dpi=300)
     plt.close()

--- a/plotting.py
+++ b/plotting.py
@@ -1,6 +1,8 @@
 import matplotlib as _mpl
 _mpl.use("Agg")
 import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+from datetime import datetime
 from pathlib import Path
 
 __all__ = ["plot_radon_activity", "plot_radon_trend"]
@@ -18,9 +20,21 @@ def plot_radon_activity(ts, outdir):
     """
     outdir = Path(outdir)
     fig, ax = plt.subplots()
-    ax.errorbar(ts.time, ts.activity, yerr=getattr(ts, "error", None), fmt="o")
+    times = [datetime.utcfromtimestamp(t) for t in ts.time]
+    times_dt = mdates.date2num(times)
+    ax.errorbar(times_dt, ts.activity, yerr=getattr(ts, "error", None), fmt="o")
     ax.set_ylabel("Radon activity [Bq]")
     ax.set_xlabel("Time (UTC)")
+
+    locator = mdates.AutoDateLocator()
+    try:
+        formatter = mdates.ConciseDateFormatter(locator)
+    except AttributeError:
+        formatter = mdates.AutoDateFormatter(locator)
+    ax.xaxis.set_major_locator(locator)
+    ax.xaxis.set_major_formatter(formatter)
+    ax.xaxis.get_offset_text().set_visible(False)
+    fig.autofmt_xdate()
     fig.tight_layout()
     fig.savefig(outdir / "radon_activity.png", dpi=300)
     plt.close(fig)
@@ -30,9 +44,21 @@ def plot_radon_trend(ts, outdir):
     """Plot radon activity trend without uncertainties."""
     outdir = Path(outdir)
     fig, ax = plt.subplots()
-    ax.plot(ts.time, ts.activity, "o-")
+    times = [datetime.utcfromtimestamp(t) for t in ts.time]
+    times_dt = mdates.date2num(times)
+    ax.plot(times_dt, ts.activity, "o-")
     ax.set_ylabel("Radon activity [Bq]")
     ax.set_xlabel("Time (UTC)")
+
+    locator = mdates.AutoDateLocator()
+    try:
+        formatter = mdates.ConciseDateFormatter(locator)
+    except AttributeError:
+        formatter = mdates.AutoDateFormatter(locator)
+    ax.xaxis.set_major_locator(locator)
+    ax.xaxis.set_major_formatter(formatter)
+    ax.xaxis.get_offset_text().set_visible(False)
+    fig.autofmt_xdate()
     fig.tight_layout()
     fig.savefig(outdir / "radon_trend.png", dpi=300)
     plt.close(fig)


### PR DESCRIPTION
## Summary
- convert radon plotting functions to use matplotlib date numbers instead of raw epoch seconds
- suppress auto-offset text on both main and secondary axes for clean labels
- add regression tests covering absence of offset text

## Testing
- `pytest tests/test_plot_utils.py::test_plot_radon_activity_axis_labels tests/test_plot_utils.py::test_plot_radon_activity_no_offset tests/test_plot_utils.py::test_plot_radon_activity_full_no_offset -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1028572a0832bbab051fb6a172eda