### PR TITLE
Scale radon activity plots to mBq

### DIFF
--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -526,6 +526,10 @@ def plot_radon_activity_full(times, activity, errors, out_png, config=None):
     activity = np.asarray(activity, dtype=float)
     errors = np.asarray(errors, dtype=float)
 
+    # Convert from Bq to mBq for readability
+    activity *= 1e3
+    errors *= 1e3
+
     times_dt = mdates.date2num([datetime.utcfromtimestamp(t) for t in times])
 
     plt.figure(figsize=(8, 4))
@@ -534,10 +538,11 @@ def plot_radon_activity_full(times, activity, errors, out_png, config=None):
     color = palette.get("radon_activity", "#9467bd")
     plt.errorbar(times_dt, activity, yerr=errors, fmt="o-", color=color)
     plt.xlabel("Time (UTC)")
-    plt.ylabel("Radon Activity (Bq)")
+    plt.ylabel("Radon Activity (mBq)")
     plt.title("Extrapolated Radon Activity vs. Time")
 
     ax = plt.gca()
+    ax.ticklabel_format(style="plain", axis="y", useOffset=False)
     locator = mdates.AutoDateLocator()
     try:
         formatter = mdates.ConciseDateFormatter(locator)
@@ -638,7 +643,7 @@ def plot_modeled_radon_activity(
 def plot_radon_trend_full(times, activity, out_png, config=None):
     """Plot modeled radon activity trend without uncertainties."""
     times = np.asarray(times, dtype=float)
-    activity = np.asarray(activity, dtype=float)
+    activity = np.asarray(activity, dtype=float) * 1e3
 
     times_dt = mdates.date2num([datetime.utcfromtimestamp(t) for t in times])
 
@@ -648,10 +653,11 @@ def plot_radon_trend_full(times, activity, out_png, config=None):
     color = palette.get("radon_activity", "#9467bd")
     plt.plot(times_dt, activity, "o-", color=color)
     plt.xlabel("Time")
-    plt.ylabel("Radon Activity (Bq)")
+    plt.ylabel("Radon Activity (mBq)")
     plt.title("Radon Activity Trend")
 
     ax = plt.gca()
+    ax.ticklabel_format(style="plain", axis="y", useOffset=False)
     locator = mdates.AutoDateLocator()
     try:
         formatter = mdates.ConciseDateFormatter(locator)
@@ -673,10 +679,12 @@ def plot_radon_activity(ts_dict, outdir):
     import matplotlib.pyplot as plt
     outdir = Path(outdir)
     t = ts_dict["time"]
-    y = ts_dict["activity"]
-    e = ts_dict["error"]
+    y = np.asarray(ts_dict["activity"]) * 1e3
+    e = np.asarray(ts_dict["error"]) * 1e3
     plt.errorbar(t, y, yerr=e, fmt="o")
-    plt.ylabel("Radon activity [Bq]")
+    ax = plt.gca()
+    ax.ticklabel_format(style="plain", axis="y", useOffset=False)
+    plt.ylabel("Radon activity [mBq]")
     plt.xlabel("Time (UTC)")
     plt.tight_layout()
     plt.savefig(outdir / "radon_activity.png", dpi=300)
@@ -689,11 +697,13 @@ def plot_radon_trend(ts_dict, outdir):
     import matplotlib.pyplot as plt
     outdir = Path(outdir)
     t = np.asarray(ts_dict["time"])
-    y = np.asarray(ts_dict["activity"])
+    y = np.asarray(ts_dict["activity"]) * 1e3
     coeff = np.polyfit(t, y, 1)
     plt.plot(t, y, "o")
     plt.plot(t, np.polyval(coeff, t))
-    plt.ylabel("Radon activity [Bq]")
+    ax = plt.gca()
+    ax.ticklabel_format(style="plain", axis="y", useOffset=False)
+    plt.ylabel("Radon activity [mBq]")
     plt.xlabel("Time (UTC)")
     plt.tight_layout()
     plt.savefig(outdir / "radon_trend.png", dpi=300)
@@ -767,6 +777,9 @@ def plot_activity_grid(result_map, out_png="burst_scan.png", config=None):
         for j, w in enumerate(wins):
             grid[i, j] = result_map.get((m, w), np.nan)
 
+    # Convert from Bq to mBq for readability
+    grid *= 1e3
+
     fig, ax = plt.subplots(figsize=(6, 5))
     im = ax.imshow(
         grid,
@@ -777,7 +790,7 @@ def plot_activity_grid(result_map, out_png="burst_scan.png", config=None):
     ax.set_xlabel("burst_window_size_s")
     ax.set_ylabel("burst_multiplier")
     cbar = plt.colorbar(im, ax=ax)
-    cbar.set_label("Radon Activity (Bq)")
+    cbar.set_label("Radon Activity (mBq)")
     plt.tight_layout()
     Path(out_png).parent.mkdir(parents=True, exist_ok=True)
     plt.savefig(out_png, dpi=300)

--- a/plot_utils/radon.py
+++ b/plot_utils/radon.py
@@ -11,11 +11,12 @@ def _save(fig, outdir: Path, name: str) -> None:
 
 def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None) -> None:
     t = np.asarray(ts_dict["time"])
-    a = np.asarray(ts_dict["activity"])
-    e = np.asarray(ts_dict["error"])
+    a = np.asarray(ts_dict["activity"]) * 1e3
+    e = np.asarray(ts_dict["error"]) * 1e3
     fig, ax = plt.subplots()
     ax.errorbar(t, a, yerr=e, fmt="o")
-    ax.set_ylabel("Rn-222 activity [Bq]")
+    ax.ticklabel_format(style="plain", axis="y", useOffset=False)
+    ax.set_ylabel("Rn-222 activity [mBq]")
     ax.set_xlabel("Time (UTC)")
     if out_png is not None:
         fig.savefig(out_png, dpi=300)
@@ -26,15 +27,16 @@ def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None
 
 def plot_radon_trend(ts_dict, outdir: Path, out_png: str | Path | None = None) -> None:
     t = np.asarray(ts_dict["time"])
-    a = np.asarray(ts_dict["activity"])
+    a = np.asarray(ts_dict["activity"]) * 1e3
     if t.size < 2:
         coeff = np.array([0.0, a[0] if a.size else 0.0])
     else:
         coeff = np.polyfit(t, a, 1)
     fig, ax = plt.subplots()
     ax.plot(t, a, "o")
-    ax.plot(t, np.polyval(coeff, t), label=f"slope={coeff[0]:.2e} Bq/s")
-    ax.set_ylabel("Rn-222 activity [Bq]")
+    ax.plot(t, np.polyval(coeff, t), label=f"slope={coeff[0]:.2e} mBq/s")
+    ax.ticklabel_format(style="plain", axis="y", useOffset=False)
+    ax.set_ylabel("Rn-222 activity [mBq]")
     ax.set_xlabel("Time (UTC)")
     ax.legend()
     if out_png is not None:

--- a/plotting.py
+++ b/plotting.py
@@ -1,6 +1,7 @@
 import matplotlib as _mpl
 _mpl.use("Agg")
 import matplotlib.pyplot as plt
+import numpy as np
 from pathlib import Path
 
 __all__ = ["plot_radon_activity", "plot_radon_trend"]
@@ -18,8 +19,13 @@ def plot_radon_activity(ts, outdir):
     """
     outdir = Path(outdir)
     fig, ax = plt.subplots()
-    ax.errorbar(ts.time, ts.activity, yerr=getattr(ts, "error", None), fmt="o")
-    ax.set_ylabel("Radon activity [Bq]")
+    activity = np.asarray(ts.activity) * 1e3
+    errors = getattr(ts, "error", None)
+    if errors is not None:
+        errors = np.asarray(errors) * 1e3
+    ax.errorbar(ts.time, activity, yerr=errors, fmt="o")
+    ax.ticklabel_format(style="plain", axis="y", useOffset=False)
+    ax.set_ylabel("Radon activity [mBq]")
     ax.set_xlabel("Time (UTC)")
     fig.tight_layout()
     fig.savefig(outdir / "radon_activity.png", dpi=300)
@@ -30,8 +36,10 @@ def plot_radon_trend(ts, outdir):
     """Plot radon activity trend without uncertainties."""
     outdir = Path(outdir)
     fig, ax = plt.subplots()
-    ax.plot(ts.time, ts.activity, "o-")
-    ax.set_ylabel("Radon activity [Bq]")
+    activity = np.asarray(ts.activity) * 1e3
+    ax.plot(ts.time, activity, "o-")
+    ax.ticklabel_format(style="plain", axis="y", useOffset=False)
+    ax.set_ylabel("Radon activity [mBq]")
     ax.set_xlabel("Time (UTC)")
     fig.tight_layout()
     fig.savefig(outdir / "radon_trend.png", dpi=300)


### PR DESCRIPTION
## Summary
- Plot radon activity in millibecquerels across utility modules
- Format radon plots with plain y-axis tick labels to avoid scientific notation
- Update radon activity grid colorbar to use mBq units

## Testing
- `pytest tests/test_plot_utils.py -k radon -q`

------
https://chatgpt.com/codex/tasks/task_e_68a103014fa4832b98474d744d008eea