### PR TITLE
Skip overlay for invalid time-series fits

### DIFF
--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -306,9 +306,12 @@ def plot_time_series(
             )
 
         # Overlay the continuous model curve (scaled to counts/bin)
-        # only when fit results are provided for this isotope.
+        # only when fit results are provided *and* deemed valid for this isotope.
         has_fit = any(k in fit_results for k in (f"E_{iso}", "E"))
-        if has_fit:
+        fit_ok = fit_results.get(
+            f"fit_valid_{iso}", fit_results.get("fit_valid", True)
+        )
+        if has_fit and fit_ok:
             lam = np.log(2.0) / iso_params[iso]["half_life"]
             eff = iso_params[iso]["eff"]
 

--- a/tests/test_plot_time_series_invalid_fit.py
+++ b/tests/test_plot_time_series_invalid_fit.py
@@ -1,0 +1,34 @@
+import numpy as np
+from pathlib import Path
+import plot_utils
+from plot_utils import plot_time_series
+
+
+def test_plot_time_series_skips_invalid_fit(tmp_path, monkeypatch):
+    times = np.array([1000.1, 1000.2, 1000.3])
+    energies = np.array([7.7, 7.75, 7.7])
+    cfg = {"window_po214": [7.6, 7.8], "eff_po214": [1.0]}
+
+    labels = []
+    orig_plot = plot_utils.plt.plot
+
+    def wrapped_plot(*args, **kwargs):
+        lbl = kwargs.get("label")
+        if lbl:
+            labels.append(lbl)
+        return orig_plot(*args, **kwargs)
+
+    monkeypatch.setattr(plot_utils.plt, "plot", wrapped_plot)
+
+    fit_res = {
+        "E_Po214": 1.0,
+        "B_Po214": 0.0,
+        "N0_Po214": 0.0,
+        "fit_valid": False,
+    }
+
+    out_png = tmp_path / "po214.png"
+    plot_time_series(times, energies, fit_res, 1000.0, 1001.0, cfg, str(out_png))
+
+    assert out_png.exists()
+    assert "Model Po214" not in labels


### PR DESCRIPTION
## Summary
- avoid plotting model overlays when a decay fit reports `fit_valid=False`
- test that invalid Po-214 fits do not produce model curves

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a102207188832b8ca1e2dc5ed9088a