### PR TITLE
Skip plotting for invalid Po-214 time fits

### DIFF
--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -308,7 +308,8 @@ def plot_time_series(
         # Overlay the continuous model curve (scaled to counts/bin)
         # only when fit results are provided for this isotope.
         has_fit = any(k in fit_results for k in (f"E_{iso}", "E"))
-        if has_fit:
+        fit_is_valid = bool(fit_results.get("fit_valid", True))
+        if has_fit and fit_is_valid:
             lam = np.log(2.0) / iso_params[iso]["half_life"]
             eff = iso_params[iso]["eff"]
 
@@ -350,6 +351,13 @@ def plot_time_series(
                     )
                 else:
                     raise ValueError("model_errors array length mismatch")
+        elif has_fit and not fit_is_valid:
+            plt.axvspan(
+                centers_dt[0],
+                centers_dt[-1],
+                color="0.9",
+                label=f"Invalid fit {iso}",
+            )
 
     plt.xlabel("Time")
     plt.ylabel("Counts / s" if normalise_rate else "Counts per bin")


### PR DESCRIPTION
## Summary
- avoid drawing model curves in `plot_time_series` when `fit_valid` is false, shading the invalid range instead
- skip Po-214/Po-218 radon activity contributions and plots when their time fits are invalid

## Testing
- `pytest tests/test_plot_utils.py::test_plot_time_series_time_fit_half_lives tests/test_plot_utils.py::test_plot_time_series_invalid_half_life_po214 tests/test_plot_utils.py::test_plot_time_series_invalid_half_life_po218`
- `pytest tests/test_radon_activity.py::test_compute_radon_activity_weighted tests/test_radon_activity.py::test_compute_radon_activity_only_214_error`


------
https://chatgpt.com/codex/tasks/task_e_68a102207188832b8ca1e2dc5ed9088a