### PR TITLE
Skip invalid Po-214 time fits

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -2758,28 +2758,32 @@ def main(argv=None):
     rate214 = None
     err214 = None
     if "Po214" in time_fit_results:
-        fit_dict = _fit_params(time_fit_results["Po214"])
-        rate214 = fit_dict.get("E_corrected", fit_dict.get("E_Po214"))
-        err214 = fit_dict.get("dE_corrected", fit_dict.get("dE_Po214"))
-        if err214 is None or not math.isfinite(float(err214)):
-            err214 = _fallback_uncertainty(
-                rate214,
-                time_fit_results.get("Po214"),
-                "E_Po214",
-            )
+        fit_obj = time_fit_results["Po214"]
+        fit_dict = _fit_params(fit_obj)
+        if fit_dict.get("fit_valid", True):
+            rate214 = fit_dict.get("E_corrected", fit_dict.get("E_Po214"))
+            err214 = fit_dict.get("dE_corrected", fit_dict.get("dE_Po214"))
+            if err214 is None or not math.isfinite(float(err214)):
+                err214 = _fallback_uncertainty(
+                    rate214,
+                    fit_obj,
+                    "E_Po214",
+                )
 
     rate218 = None
     err218 = None
     if "Po218" in time_fit_results:
-        fit_dict = _fit_params(time_fit_results["Po218"])
-        rate218 = fit_dict.get("E_corrected", fit_dict.get("E_Po218"))
-        err218 = fit_dict.get("dE_corrected", fit_dict.get("dE_Po218"))
-        if err218 is None or not math.isfinite(float(err218)):
-            err218 = _fallback_uncertainty(
-                rate218,
-                time_fit_results.get("Po218"),
-                "E_Po218",
-            )
+        fit_obj = time_fit_results["Po218"]
+        fit_dict = _fit_params(fit_obj)
+        if fit_dict.get("fit_valid", True):
+            rate218 = fit_dict.get("E_corrected", fit_dict.get("E_Po218"))
+            err218 = fit_dict.get("dE_corrected", fit_dict.get("dE_Po218"))
+            if err218 is None or not math.isfinite(float(err218)):
+                err218 = _fallback_uncertainty(
+                    rate218,
+                    fit_obj,
+                    "E_Po218",
+                )
 
     A_radon, dA_radon = compute_radon_activity(
         rate218, err218, eff_po218, rate214, err214, eff_po214
@@ -2837,43 +2841,45 @@ def main(argv=None):
         if "Po214" in time_fit_results:
             fit_result = time_fit_results["Po214"]
             fit = _fit_params(fit_result)
-            E = fit.get("E_corrected", fit.get("E_Po214"))
-            dE = fit.get("dE_corrected", fit.get("dE_Po214", 0.0))
-            N0 = fit.get("N0_Po214", 0.0)
-            dN0 = fit.get("dN0_Po214", 0.0)
-            hl = _hl_value(cfg, "Po214")
-            cov = _cov_lookup(fit_result, "E_Po214", "N0_Po214")
-            delta214, err_delta214 = radon_delta(
-                t_start_rel,
-                t_end_rel,
-                E,
-                dE,
-                N0,
-                dN0,
-                hl,
-                cov,
-            )
+            if fit.get("fit_valid", True):
+                E = fit.get("E_corrected", fit.get("E_Po214"))
+                dE = fit.get("dE_corrected", fit.get("dE_Po214", 0.0))
+                N0 = fit.get("N0_Po214", 0.0)
+                dN0 = fit.get("dN0_Po214", 0.0)
+                hl = _hl_value(cfg, "Po214")
+                cov = _cov_lookup(fit_result, "E_Po214", "N0_Po214")
+                delta214, err_delta214 = radon_delta(
+                    t_start_rel,
+                    t_end_rel,
+                    E,
+                    dE,
+                    N0,
+                    dN0,
+                    hl,
+                    cov,
+                )
 
         delta218 = err_delta218 = None
         if "Po218" in time_fit_results:
             fit_result = time_fit_results["Po218"]
             fit = _fit_params(fit_result)
-            E = fit.get("E_corrected", fit.get("E_Po218"))
-            dE = fit.get("dE_corrected", fit.get("dE_Po218", 0.0))
-            N0 = fit.get("N0_Po218", 0.0)
-            dN0 = fit.get("dN0_Po218", 0.0)
-            hl = _hl_value(cfg, "Po218")
-            cov = _cov_lookup(fit_result, "E_Po218", "N0_Po218")
-            delta218, err_delta218 = radon_delta(
-                t_start_rel,
-                t_end_rel,
-                E,
-                dE,
-                N0,
-                dN0,
-                hl,
-                cov,
-            )
+            if fit.get("fit_valid", True):
+                E = fit.get("E_corrected", fit.get("E_Po218"))
+                dE = fit.get("dE_corrected", fit.get("dE_Po218", 0.0))
+                N0 = fit.get("N0_Po218", 0.0)
+                dN0 = fit.get("dN0_Po218", 0.0)
+                hl = _hl_value(cfg, "Po218")
+                cov = _cov_lookup(fit_result, "E_Po218", "N0_Po218")
+                delta218, err_delta218 = radon_delta(
+                    t_start_rel,
+                    t_end_rel,
+                    E,
+                    dE,
+                    N0,
+                    dN0,
+                    hl,
+                    cov,
+                )
 
         d_radon, d_err = compute_radon_activity(
             delta218,
@@ -3092,7 +3098,10 @@ def main(argv=None):
                 for k in ("Po214", "Po218", "Po210"):
                     obj = time_fit_results.get(k)
                     if obj:
-                        fit_dict.update(_fit_params(obj))
+                        d = _fit_params(obj)
+                        if "fit_valid" in d:
+                            d[f"fit_valid_{k}"] = d.pop("fit_valid")
+                        fit_dict.update(d)
 
             centers, widths = _ts_bin_centers_widths(
                 ts_times, plot_cfg, t0_global.timestamp(), t_end_global_ts
@@ -3173,32 +3182,34 @@ def main(argv=None):
         if "Po214" in time_fit_results:
             fit_result = time_fit_results["Po214"]
             fit = _fit_params(fit_result)
-            E = fit.get("E_corrected", fit.get("E_Po214"))
-            dE = fit.get("dE_corrected", fit.get("dE_Po214", 0.0))
-            N0 = fit.get("N0_Po214", 0.0)
-            dN0 = fit.get("dN0_Po214", 0.0)
-            hl = _hl_value(cfg, "Po214")
-            cov = _cov_lookup(fit_result, "E_Po214", "N0_Po214")
-            A214, dA214 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl, cov)
-            plot_radon_activity(
-                times,
-                A214,
-                Path(out_dir) / "radon_activity_po214.png",
-                dA214,
-                config=cfg.get("plotting", {}),
-            )
+            if fit.get("fit_valid", True):
+                E = fit.get("E_corrected", fit.get("E_Po214"))
+                dE = fit.get("dE_corrected", fit.get("dE_Po214", 0.0))
+                N0 = fit.get("N0_Po214", 0.0)
+                dN0 = fit.get("dN0_Po214", 0.0)
+                hl = _hl_value(cfg, "Po214")
+                cov = _cov_lookup(fit_result, "E_Po214", "N0_Po214")
+                A214, dA214 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl, cov)
+                plot_radon_activity(
+                    times,
+                    A214,
+                    Path(out_dir) / "radon_activity_po214.png",
+                    dA214,
+                    config=cfg.get("plotting", {}),
+                )
 
         A218 = dA218 = None
         if "Po218" in time_fit_results:
             fit_result = time_fit_results["Po218"]
             fit = _fit_params(fit_result)
-            E = fit.get("E_corrected", fit.get("E_Po218"))
-            dE = fit.get("dE_corrected", fit.get("dE_Po218", 0.0))
-            N0 = fit.get("N0_Po218", 0.0)
-            dN0 = fit.get("dN0_Po218", 0.0)
-            hl = _hl_value(cfg, "Po218")
-            cov = _cov_lookup(fit_result, "E_Po218", "N0_Po218")
-            A218, dA218 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl, cov)
+            if fit.get("fit_valid", True):
+                E = fit.get("E_corrected", fit.get("E_Po218"))
+                dE = fit.get("dE_corrected", fit.get("dE_Po218", 0.0))
+                N0 = fit.get("N0_Po218", 0.0)
+                dN0 = fit.get("dN0_Po218", 0.0)
+                hl = _hl_value(cfg, "Po218")
+                cov = _cov_lookup(fit_result, "E_Po218", "N0_Po218")
+                A218, dA218 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl, cov)
 
         activity_arr = np.zeros_like(times, dtype=float)
         err_arr = np.zeros_like(times, dtype=float)
@@ -3246,28 +3257,30 @@ def main(argv=None):
             if "Po214" in time_fit_results:
                 fit_result = time_fit_results["Po214"]
                 fit = _fit_params(fit_result)
-                E214 = fit.get("E_corrected", fit.get("E_Po214"))
-                dE214 = fit.get("dE_corrected", fit.get("dE_Po214", 0.0))
-                N0214 = fit.get("N0_Po214", 0.0)
-                dN0214 = fit.get("dN0_Po214", 0.0)
-                hl214 = _hl_value(cfg, "Po214")
-                cov214 = _cov_lookup(fit_result, "E_Po214", "N0_Po214")
-                A214_tr, _ = radon_activity_curve(
-                    rel_trend, E214, dE214, N0214, dN0214, hl214, cov214
-                )
+                if fit.get("fit_valid", True):
+                    E214 = fit.get("E_corrected", fit.get("E_Po214"))
+                    dE214 = fit.get("dE_corrected", fit.get("dE_Po214", 0.0))
+                    N0214 = fit.get("N0_Po214", 0.0)
+                    dN0214 = fit.get("dN0_Po214", 0.0)
+                    hl214 = _hl_value(cfg, "Po214")
+                    cov214 = _cov_lookup(fit_result, "E_Po214", "N0_Po214")
+                    A214_tr, _ = radon_activity_curve(
+                        rel_trend, E214, dE214, N0214, dN0214, hl214, cov214
+                    )
             A218_tr = None
             if "Po218" in time_fit_results:
                 fit_result = time_fit_results["Po218"]
                 fit = _fit_params(fit_result)
-                E218 = fit.get("E_corrected", fit.get("E_Po218"))
-                dE218 = fit.get("dE_corrected", fit.get("dE_Po218", 0.0))
-                N0218 = fit.get("N0_Po218", 0.0)
-                dN0218 = fit.get("dN0_Po218", 0.0)
-                hl218 = _hl_value(cfg, "Po218")
-                cov218 = _cov_lookup(fit_result, "E_Po218", "N0_Po218")
-                A218_tr, _ = radon_activity_curve(
-                    rel_trend, E218, dE218, N0218, dN0218, hl218, cov218
-                )
+                if fit.get("fit_valid", True):
+                    E218 = fit.get("E_corrected", fit.get("E_Po218"))
+                    dE218 = fit.get("dE_corrected", fit.get("dE_Po218", 0.0))
+                    N0218 = fit.get("N0_Po218", 0.0)
+                    dN0218 = fit.get("dN0_Po218", 0.0)
+                    hl218 = _hl_value(cfg, "Po218")
+                    cov218 = _cov_lookup(fit_result, "E_Po218", "N0_Po218")
+                    A218_tr, _ = radon_activity_curve(
+                        rel_trend, E218, dE218, N0218, dN0218, hl218, cov218
+                    )
             trend = np.zeros_like(times_trend)
             for i in range(times_trend.size):
                 r214 = A214_tr[i] if A214_tr is not None else None

--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -308,6 +308,9 @@ def plot_time_series(
         # Overlay the continuous model curve (scaled to counts/bin)
         # only when fit results are provided for this isotope.
         has_fit = any(k in fit_results for k in (f"E_{iso}", "E"))
+        fit_valid_key = f"fit_valid_{iso}" if f"fit_valid_{iso}" in fit_results else "fit_valid"
+        if has_fit and not fit_results.get(fit_valid_key, True):
+            has_fit = False
         if has_fit:
             lam = np.log(2.0) / iso_params[iso]["half_life"]
             eff = iso_params[iso]["eff"]

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -812,6 +812,32 @@ def test_plot_time_series_uncertainty_band(tmp_path, monkeypatch):
     assert band_called.get("ok")
 
 
+def test_plot_time_series_skips_invalid_fit(tmp_path):
+    times = np.array([1001.0, 1002.0, 1003.0])
+    energies = np.array([7.7, 7.8, 7.6])
+    cfg = basic_config()
+    out_png = tmp_path / "ts_invalid.png"
+    fit_results = {
+        "E_Po214": 0.1,
+        "B_Po214": 0.0,
+        "N0_Po214": 0.0,
+        "fit_valid": False,
+    }
+    # Mismatched model_errors array should be ignored when fit is invalid
+    model_errs = {"Po214": np.full(5, 0.1)}
+    plot_time_series(
+        times,
+        energies,
+        fit_results,
+        1000.0,
+        1005.0,
+        cfg,
+        str(out_png),
+        model_errors=model_errs,
+    )
+    assert out_png.exists()
+
+
 def test_plot_time_series_datetime64(tmp_path):
     times = np.array(
         [


### PR DESCRIPTION
## Summary
- guard radon activity calculations against invalid Po-214/Po-218 time fits
- skip model overlays in `plot_time_series` when the fit is flagged invalid
- add regression test ensuring invalid fits do not trigger plotting errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a102207188832b8ca1e2dc5ed9088a