### PR TITLE
Wire feature selectors for background and likelihood options

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,13 @@ to ``False``.  Passing ``strict=True`` (or ``--strict-covariance`` on the
 command line) instead raises a ``RuntimeError`` as soon as the matrix is
 found to be non-positive definite.
 
+## Experimental knobs
+
+- `analysis.background_model` / `--background-model` – choose the spectral background model. Safe default: `linear`.
+- `linear` – legacy linear continuum recommended for most spectra.
+- `analysis.likelihood` / `--likelihood` – select the unbinned likelihood variant. Safe default: `current`.
+- `current` – existing negative log-likelihood; use `extended` to enable an extended formulation.
+
 ## Configuration
 
 The parser is case sensitive, so all keys in `config.yaml` should be lowercase. Mixed-case names from older files remain supported for backward compatibility but are deprecated.

--- a/analyze.py
+++ b/analyze.py
@@ -49,6 +49,7 @@ import argparse
 import sys
 import logging
 import random
+from types import SimpleNamespace
 
 logger = logging.getLogger(__name__)
 random.seed(0)
@@ -362,6 +363,7 @@ def _spectral_fit_with_check(
         "priors": priors_mapped,
         "flags": flags,
     }
+    fit_kwargs["opts"] = SimpleNamespace(**cfg.get("analysis", {}))
     if bins is not None or bin_edges is not None:
         fit_kwargs.update({"bins": bins, "bin_edges": bin_edges})
     if bounds:

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -1,0 +1,60 @@
+import numpy as np
+import pytest
+from types import SimpleNamespace
+
+from fitting import fit_spectrum
+import likelihood_ext
+
+
+def _short_spectrum():
+    rng = np.random.default_rng(0)
+    energies = np.concatenate([
+        rng.normal(5.3, 0.05, 20),
+        rng.normal(6.0, 0.05, 20),
+        rng.normal(7.7, 0.05, 20),
+    ])
+    priors = {
+        "sigma0": (0.05, 0.01),
+        "F": (0.0, 0.01),
+        "mu_Po210": (5.3, 0.1),
+        "S_Po210": (20, 5),
+        "mu_Po218": (6.0, 0.1),
+        "S_Po218": (20, 5),
+        "mu_Po214": (7.7, 0.1),
+        "S_Po214": (20, 5),
+        "b0": (0.0, 1.0),
+        "b1": (0.0, 1.0),
+    }
+    return energies, priors
+
+
+def test_background_linear_noop():
+    energies, priors = _short_spectrum()
+    out_default = fit_spectrum(energies, priors)
+    out_linear = fit_spectrum(energies, priors, opts=SimpleNamespace(background_model="linear"))
+    for key in ("b0", "b1", "S_bkg"):
+        assert out_default.params[key] == pytest.approx(out_linear.params[key])
+
+
+def test_likelihood_extended_switch(monkeypatch):
+    energies, priors = _short_spectrum()
+    called = {}
+    orig = likelihood_ext.neg_loglike_extended
+
+    def wrapped(E, intensity_fn, params, *, area_keys, clip=1e-300):
+        called["called"] = True
+        return orig(E, intensity_fn, params, area_keys=area_keys, clip=clip)
+
+    monkeypatch.setattr(likelihood_ext, "neg_loglike_extended", wrapped)
+
+    fit_spectrum(energies, priors, unbinned=True)
+    assert "called" not in called
+
+    called.clear()
+    fit_spectrum(
+        energies,
+        priors,
+        unbinned=True,
+        opts=SimpleNamespace(likelihood="extended"),
+    )
+    assert called.get("called")


### PR DESCRIPTION
## Summary
- route spectral background and likelihood through feature selectors
- expose analysis options to spectral fit and document experimental flags
- add tests for background and likelihood flags

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1041bf680832bbd59267a8f8e51c9