### PR TITLE
Skip plotting invalid Po-214 time fits

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -3199,32 +3199,38 @@ def main(argv=None):
         if "Po214" in time_fit_results:
             fit_result = time_fit_results["Po214"]
             fit = _fit_params(fit_result)
-            E = fit.get("E_corrected", fit.get("E_Po214"))
-            dE = fit.get("dE_corrected", fit.get("dE_Po214", 0.0))
-            N0 = fit.get("N0_Po214", 0.0)
-            dN0 = fit.get("dN0_Po214", 0.0)
-            hl = _hl_value(cfg, "Rn222")
-            cov = _cov_lookup(fit_result, "E_Po214", "N0_Po214")
-            A214, dA214 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl, cov)
-            plot_radon_activity(
-                times,
-                A214,
-                Path(out_dir) / "radon_activity_po214.png",
-                dA214,
-                config=cfg.get("plotting", {}),
-            )
+            if fit.get("fit_valid", True):
+                E = fit.get("E_corrected", fit.get("E_Po214"))
+                dE = fit.get("dE_corrected", fit.get("dE_Po214", 0.0))
+                N0 = fit.get("N0_Po214", 0.0)
+                dN0 = fit.get("dN0_Po214", 0.0)
+                hl = _hl_value(cfg, "Rn222")
+                cov = _cov_lookup(fit_result, "E_Po214", "N0_Po214")
+                A214, dA214 = radon_activity_curve(
+                    t_rel, E, dE, N0, dN0, hl, cov
+                )
+                plot_radon_activity(
+                    times,
+                    A214,
+                    Path(out_dir) / "radon_activity_po214.png",
+                    dA214,
+                    config=cfg.get("plotting", {}),
+                )
 
         A218 = dA218 = None
         if "Po218" in time_fit_results:
             fit_result = time_fit_results["Po218"]
             fit = _fit_params(fit_result)
-            E = fit.get("E_corrected", fit.get("E_Po218"))
-            dE = fit.get("dE_corrected", fit.get("dE_Po218", 0.0))
-            N0 = fit.get("N0_Po218", 0.0)
-            dN0 = fit.get("dN0_Po218", 0.0)
-            hl = _hl_value(cfg, "Rn222")
-            cov = _cov_lookup(fit_result, "E_Po218", "N0_Po218")
-            A218, dA218 = radon_activity_curve(t_rel, E, dE, N0, dN0, hl, cov)
+            if fit.get("fit_valid", True):
+                E = fit.get("E_corrected", fit.get("E_Po218"))
+                dE = fit.get("dE_corrected", fit.get("dE_Po218", 0.0))
+                N0 = fit.get("N0_Po218", 0.0)
+                dN0 = fit.get("dN0_Po218", 0.0)
+                hl = _hl_value(cfg, "Rn222")
+                cov = _cov_lookup(fit_result, "E_Po218", "N0_Po218")
+                A218, dA218 = radon_activity_curve(
+                    t_rel, E, dE, N0, dN0, hl, cov
+                )
 
         activity_arr = np.zeros_like(times, dtype=float)
         err_arr = np.zeros_like(times, dtype=float)
@@ -3272,28 +3278,30 @@ def main(argv=None):
             if "Po214" in time_fit_results:
                 fit_result = time_fit_results["Po214"]
                 fit = _fit_params(fit_result)
-                E214 = fit.get("E_corrected", fit.get("E_Po214"))
-                dE214 = fit.get("dE_corrected", fit.get("dE_Po214", 0.0))
-                N0214 = fit.get("N0_Po214", 0.0)
-                dN0214 = fit.get("dN0_Po214", 0.0)
-                hl214 = _hl_value(cfg, "Rn222")
-                cov214 = _cov_lookup(fit_result, "E_Po214", "N0_Po214")
-                A214_tr, _ = radon_activity_curve(
-                    rel_trend, E214, dE214, N0214, dN0214, hl214, cov214
-                )
+                if fit.get("fit_valid", True):
+                    E214 = fit.get("E_corrected", fit.get("E_Po214"))
+                    dE214 = fit.get("dE_corrected", fit.get("dE_Po214", 0.0))
+                    N0214 = fit.get("N0_Po214", 0.0)
+                    dN0214 = fit.get("dN0_Po214", 0.0)
+                    hl214 = _hl_value(cfg, "Rn222")
+                    cov214 = _cov_lookup(fit_result, "E_Po214", "N0_Po214")
+                    A214_tr, _ = radon_activity_curve(
+                        rel_trend, E214, dE214, N0214, dN0214, hl214, cov214
+                    )
             A218_tr = None
             if "Po218" in time_fit_results:
                 fit_result = time_fit_results["Po218"]
                 fit = _fit_params(fit_result)
-                E218 = fit.get("E_corrected", fit.get("E_Po218"))
-                dE218 = fit.get("dE_corrected", fit.get("dE_Po218", 0.0))
-                N0218 = fit.get("N0_Po218", 0.0)
-                dN0218 = fit.get("dN0_Po218", 0.0)
-                hl218 = _hl_value(cfg, "Rn222")
-                cov218 = _cov_lookup(fit_result, "E_Po218", "N0_Po218")
-                A218_tr, _ = radon_activity_curve(
-                    rel_trend, E218, dE218, N0218, dN0218, hl218, cov218
-                )
+                if fit.get("fit_valid", True):
+                    E218 = fit.get("E_corrected", fit.get("E_Po218"))
+                    dE218 = fit.get("dE_corrected", fit.get("dE_Po218", 0.0))
+                    N0218 = fit.get("N0_Po218", 0.0)
+                    dN0218 = fit.get("dN0_Po218", 0.0)
+                    hl218 = _hl_value(cfg, "Rn222")
+                    cov218 = _cov_lookup(fit_result, "E_Po218", "N0_Po218")
+                    A218_tr, _ = radon_activity_curve(
+                        rel_trend, E218, dE218, N0218, dN0218, hl218, cov218
+                    )
             trend = np.zeros_like(times_trend)
             for i in range(times_trend.size):
                 r214 = A214_tr[i] if A214_tr is not None else None

--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -306,9 +306,12 @@ def plot_time_series(
             )
 
         # Overlay the continuous model curve (scaled to counts/bin)
-        # only when fit results are provided for this isotope.
+        # only when fit results are provided for this isotope and the fit
+        # itself is considered valid.  Invalid fits often yield unphysical
+        # parameters which would lead to wildly incorrect model curves.
         has_fit = any(k in fit_results for k in (f"E_{iso}", "E"))
-        if has_fit:
+        fit_ok = bool(fit_results.get("fit_valid", True))
+        if has_fit and fit_ok:
             lam = np.log(2.0) / iso_params[iso]["half_life"]
             eff = iso_params[iso]["eff"]
 

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -12,6 +12,7 @@ from plot_utils import (
     plot_radon_activity,
     plot_radon_activity_full,
 )
+import plot_utils
 
 
 def basic_config():
@@ -55,6 +56,34 @@ def test_plot_time_series_none_fit_results(tmp_path):
         str(out_png),
     )
     assert out_png.exists()
+
+
+def test_plot_time_series_invalid_fit_skips_model(tmp_path, monkeypatch):
+    times = np.array([1001.0, 1002.0, 1003.0])
+    energies = np.array([7.7, 7.8, 7.6])
+    out_png = tmp_path / "ts_invalid.png"
+
+    calls: list[object] = []
+
+    def fake_plot(*args, **kwargs):
+        calls.append(object())
+        return [None]
+
+    monkeypatch.setattr(plot_utils.plt, "plot", fake_plot)
+
+    fit_vals = {"E_Po214": 0.1, "B_Po214": 0.0, "N0_Po214": 0.0, "fit_valid": False}
+    plot_time_series(
+        times,
+        energies,
+        fit_vals,
+        1000.0,
+        1005.0,
+        basic_config(),
+        str(out_png),
+    )
+
+    assert out_png.exists()
+    assert not calls
 
 
 def test_plot_time_series_auto_fd(tmp_path):


### PR DESCRIPTION
## Summary
- avoid drawing time-series model curves when the underlying fit is flagged invalid
- guard radon activity extrapolations and trends against invalid Po-214/Po-218 time fits
- test that time-series plots skip overlays for invalid fits

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a10b61be44832bafe09c76be1348d2