### PR TITLE
Skip invalid Po-214 fits in time series

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -3118,7 +3118,10 @@ def main(argv=None):
                 for k in ("Po214", "Po218", "Po210"):
                     obj = time_fit_results.get(k)
                     if obj:
-                        fit_dict.update(_fit_params(obj))
+                        params = dict(_fit_params(obj))
+                        if "fit_valid" in params:
+                            params[f"fit_valid_{k}"] = params.pop("fit_valid")
+                        fit_dict.update(params)
 
             centers, widths = _ts_bin_centers_widths(
                 ts_times, plot_cfg, t0_global.timestamp(), t_end_global_ts

--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -306,8 +306,13 @@ def plot_time_series(
             )
 
         # Overlay the continuous model curve (scaled to counts/bin)
-        # only when fit results are provided for this isotope.
-        has_fit = any(k in fit_results for k in (f"E_{iso}", "E"))
+        # only when fit results are provided for this isotope and the fit
+        # itself is marked as valid.  Older summaries may omit ``fit_valid``;
+        # in that case we assume the fit is valid by default.
+        fit_ok = bool(
+            fit_results.get(f"fit_valid_{iso}", fit_results.get("fit_valid", True))
+        )
+        has_fit = fit_ok and any(k in fit_results for k in (f"E_{iso}", "E"))
         if has_fit:
             lam = np.log(2.0) / iso_params[iso]["half_life"]
             eff = iso_params[iso]["eff"]

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -324,6 +324,34 @@ def test_plot_time_series_line_style(tmp_path, monkeypatch):
     assert called.get("plot") and "step" not in called
 
 
+def test_plot_time_series_skips_invalid_fit(tmp_path, monkeypatch):
+    times = np.array([1000.2, 1000.8])
+    energies = np.array([7.7, 7.8])
+    cfg = basic_config()
+
+    calls = []
+
+    def fake_plot(*args, **kwargs):
+        calls.append((args, kwargs))
+        return type("obj", (), {})()
+
+    monkeypatch.setattr("plot_utils.plt.plot", fake_plot)
+    monkeypatch.setattr("plot_utils.plt.savefig", lambda *a, **k: None)
+
+    fit_dict = {"E_Po214": 0.1, "B_Po214": 0.0, "N0_Po214": 0.0, "fit_valid": False}
+    plot_time_series(
+        times,
+        energies,
+        fit_dict,
+        1000.0,
+        1001.0,
+        cfg,
+        str(tmp_path / "ts_invalid.png"),
+    )
+
+    assert calls == []
+
+
 def test_plot_time_series_po210_no_model(tmp_path, monkeypatch):
     times = np.array([1000.1, 1000.2])
     energies = np.array([5.3, 5.25])


### PR DESCRIPTION
## Summary
- avoid plotting time-series models when Po-214 fit is invalid
- propagate per-isotope `fit_valid` flags when overlaying plots
- test that invalid fits no longer draw model curves

## Testing
- `pytest tests/test_plot_utils.py::test_plot_time_series_fallback tests/test_plot_utils.py::test_plot_time_series_line_style tests/test_plot_time_series_skips_invalid_fit -q`
- `pytest tests/test_analyze_config_merge.py::test_plot_time_series_receives_merged_config -q`


------
https://chatgpt.com/codex/tasks/task_e_68a10b61be44832bafe09c76be1348d2