### PR TITLE
Handle invalid Po-214 time fits in plots

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -646,6 +646,8 @@ def _model_uncertainty(centers, widths, fit_obj, iso, cfg, normalise):
     if fit_obj is None:
         return None
     params = _fit_params(fit_obj)
+    if not params.get("fit_valid", True):
+        return None
     # Po-214 and Po-218 activities follow the radon (Rn-222) decay constant
     if iso in ("Po214", "Po218"):
         hl = _hl_value(cfg, "Rn222")
@@ -3118,7 +3120,11 @@ def main(argv=None):
                 for k in ("Po214", "Po218", "Po210"):
                     obj = time_fit_results.get(k)
                     if obj:
-                        fit_dict.update(_fit_params(obj))
+                        params = _fit_params(obj)
+                        fit_dict[f"fit_valid_{k}"] = params.get("fit_valid", True)
+                        params = {pk: pv for pk, pv in params.items() if pk != "fit_valid"}
+                        if fit_dict[f"fit_valid_{k}"]:
+                            fit_dict.update(params)
 
             centers, widths = _ts_bin_centers_widths(
                 ts_times, plot_cfg, t0_global.timestamp(), t_end_global_ts

--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -308,7 +308,8 @@ def plot_time_series(
         # Overlay the continuous model curve (scaled to counts/bin)
         # only when fit results are provided for this isotope.
         has_fit = any(k in fit_results for k in (f"E_{iso}", "E"))
-        if has_fit:
+        fit_flag = fit_results.get(f"fit_valid_{iso}", fit_results.get("fit_valid", True))
+        if has_fit and fit_flag:
             lam = np.log(2.0) / iso_params[iso]["half_life"]
             eff = iso_params[iso]["eff"]
 
@@ -350,6 +351,9 @@ def plot_time_series(
                     )
                 else:
                     raise ValueError("model_errors array length mismatch")
+        elif has_fit and not fit_flag:
+            # Explicitly skip plotting the model for invalid fits
+            pass
 
     plt.xlabel("Time")
     plt.ylabel("Counts / s" if normalise_rate else "Counts per bin")

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -57,6 +57,30 @@ def test_plot_time_series_none_fit_results(tmp_path):
     assert out_png.exists()
 
 
+def test_plot_time_series_skips_invalid_fit(tmp_path, monkeypatch):
+    times = np.array([1001.0, 1002.0])
+    energies = np.array([7.6, 7.8])
+    out_png = tmp_path / "ts_invalid.png"
+    calls = {"plot": 0}
+
+    def fake_plot(*args, **kwargs):
+        calls["plot"] += 1
+        return type("obj", (), {})()
+
+    monkeypatch.setattr("plot_utils.plt.plot", fake_plot)
+    plot_time_series(
+        times,
+        energies,
+        {"E_Po214": 0.1, "B_Po214": 0.0, "N0_Po214": 0.0, "fit_valid": False},
+        1000.0,
+        1005.0,
+        basic_config(),
+        str(out_png),
+    )
+    assert out_png.exists()
+    assert calls["plot"] == 0
+
+
 def test_plot_time_series_auto_fd(tmp_path):
     # 100 uniform events over 5 seconds
     times = 1000.0 + np.linspace(0, 5, 100)


### PR DESCRIPTION
## Summary
- skip plotting time-series model when a fit result is flagged invalid
- propagate per-isotope fit validity through analysis pipeline
- add regression test ensuring invalid fits are ignored

## Testing
- `pytest` *(fails: Segmentation fault in test_noise_cutoff.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a10b61be44832bafe09c76be1348d2