### PR TITLE
Skip plotting for invalid Po-214 fits

### DIFF
--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -306,8 +306,9 @@ def plot_time_series(
             )
 
         # Overlay the continuous model curve (scaled to counts/bin)
-        # only when fit results are provided for this isotope.
-        has_fit = any(k in fit_results for k in (f"E_{iso}", "E"))
+        # only when fit results are provided for this isotope and the
+        # fit was deemed valid.
+        has_fit = any(k in fit_results for k in (f"E_{iso}", "E")) and fit_results.get("fit_valid", True)
         if has_fit:
             lam = np.log(2.0) / iso_params[iso]["half_life"]
             eff = iso_params[iso]["eff"]

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -291,6 +291,35 @@ def test_plot_time_series_invalid_half_life_po218(tmp_path):
         )
 
 
+def test_plot_time_series_skips_invalid_fit(tmp_path, monkeypatch):
+    times = np.array([1000.1, 1000.6, 1001.2])
+    energies = np.full_like(times, 7.7)
+    cfg = basic_config()
+    cfg.update({"plot_time_bin_width_s": 1.0})
+
+    calls = {}
+
+    def fake_plot(*args, **kwargs):
+        calls["plot"] = True
+
+    monkeypatch.setattr("plot_utils.plt.plot", fake_plot)
+    monkeypatch.setattr("plot_utils.plt.savefig", lambda *a, **k: None)
+
+    fit_results = {"E_Po214": 0.1, "B_Po214": 0.0, "N0_Po214": 0.0, "fit_valid": False}
+
+    plot_time_series(
+        times,
+        energies,
+        fit_results,
+        1000.0,
+        1003.0,
+        cfg,
+        str(tmp_path / "ts_invalid.png"),
+    )
+
+    assert "plot" not in calls
+
+
 def test_plot_time_series_line_style(tmp_path, monkeypatch):
     times = np.array([1000.2, 1000.8])
     energies = np.array([7.7, 7.8])


### PR DESCRIPTION
## Summary
- skip model overlays and radon extrapolation when a time fit is flagged as invalid
- avoid baseline summary errors when baseline subtraction is disabled
- add regression test for skipping invalid time-fit overlays

## Testing
- `pytest tests/test_plot_utils.py::test_plot_time_series_skips_invalid_fit -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a10b61be44832bafe09c76be1348d2