### PR TITLE
Refine radon plot axes and units

### DIFF
--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -371,6 +371,16 @@ def plot_time_series(
         formatter = mdates.AutoDateFormatter(locator)
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
+    ax.ticklabel_format(axis="y", style="plain", useOffset=False)
+    ax.yaxis.get_offset_text().set_visible(False)
+    base_dt = centers_dt[0] if len(centers_dt) else 0.0
+    secax = ax.secondary_xaxis(
+        "top",
+        functions=(lambda x: (x - base_dt) * 24.0, lambda h: h / 24.0 + base_dt),
+    )
+    secax.set_xlabel("Elapsed time (h)")
+    secax.xaxis.set_major_locator(mticker.MaxNLocator(integer=True))
+    secax.xaxis.get_offset_text().set_visible(False)
     plt.gcf().autofmt_xdate()
     ax.xaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
@@ -562,27 +572,21 @@ def plot_radon_activity_full(
         formatter = mdates.AutoDateFormatter(locator)
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
+    ax.ticklabel_format(axis="y", style="plain", useOffset=False)
+    ax.yaxis.get_offset_text().set_visible(False)
 
     base_dt = times_dt[0]
 
-    def _to_seconds(x):
-        return (x - base_dt) * 86400.0
+    def _to_hours(x):
+        return (x - base_dt) * 24.0
 
-    def _to_dates(x):
-        return base_dt + x / 86400.0
+    def _to_dates(h):
+        return base_dt + h / 24.0
 
-    secax = ax.secondary_xaxis("top", functions=(_to_seconds, _to_dates))
-
-    def _sec_formatter(x, pos=None):
-        h = x / 3600.0
-        if h >= 1:
-            if abs(h - round(h)) < 1e-6:
-                return f"{int(x)} s ({int(h)} h)"
-            return f"{int(x)} s ({h:g} h)"
-        return f"{int(x)} s"
-
-    secax.xaxis.set_major_formatter(mticker.FuncFormatter(_sec_formatter))
-    secax.set_xlabel("Elapsed Time (s)")
+    secax = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
+    secax.set_xlabel("Elapsed time (h)")
+    secax.xaxis.set_major_locator(mticker.MaxNLocator(integer=True))
+    secax.xaxis.get_offset_text().set_visible(False)
 
     if po214_activity is not None:
         po214_activity = np.asarray(po214_activity, dtype=float)
@@ -602,7 +606,6 @@ def plot_radon_activity_full(
 
     plt.gcf().autofmt_xdate()
     ax.xaxis.get_offset_text().set_visible(False)
-    secax.xaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
     targets = get_targets(config, out_png)
     for p in targets.values():
@@ -646,6 +649,16 @@ def plot_equivalent_air(times, volumes, errors, conc, out_png, config=None):
         formatter = mdates.AutoDateFormatter(locator)
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
+    ax.ticklabel_format(axis="y", style="plain", useOffset=False)
+    ax.yaxis.get_offset_text().set_visible(False)
+    base_dt = times_dt[0]
+    secax = ax.secondary_xaxis(
+        "top",
+        functions=(lambda x: (x - base_dt) * 24.0, lambda h: h / 24.0 + base_dt),
+    )
+    secax.set_xlabel("Elapsed time (h)")
+    secax.xaxis.set_major_locator(mticker.MaxNLocator(integer=True))
+    secax.xaxis.get_offset_text().set_visible(False)
     plt.gcf().autofmt_xdate()
     ax.xaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
@@ -732,6 +745,16 @@ def plot_radon_trend_full(times, activity, out_png, config=None):
         formatter = mdates.AutoDateFormatter(locator)
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
+    ax.ticklabel_format(axis="y", style="plain", useOffset=False)
+    ax.yaxis.get_offset_text().set_visible(False)
+    base_dt = times_dt[0] if len(times_dt) else 0.0
+    secax = ax.secondary_xaxis(
+        "top",
+        functions=(lambda x: (x - base_dt) * 24.0, lambda h: h / 24.0 + base_dt),
+    )
+    secax.set_xlabel("Elapsed time (h)")
+    secax.xaxis.set_major_locator(mticker.MaxNLocator(integer=True))
+    secax.xaxis.get_offset_text().set_visible(False)
     plt.gcf().autofmt_xdate()
     ax.xaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
@@ -752,11 +775,11 @@ def plot_radon_activity(ts_dict, outdir):
     e = np.asarray(ts_dict["error"], dtype=float)
 
     times_dt = mdates.date2num([datetime.utcfromtimestamp(t) for t in times])
-    plt.errorbar(times_dt, y, yerr=e, fmt="o")
-    plt.ylabel("Radon activity [Bq]")
-    plt.xlabel("Time (UTC)")
+    fig, ax = plt.subplots()
+    ax.errorbar(times_dt, y, yerr=e, fmt="o")
+    ax.set_ylabel("Radon activity [Bq]")
+    ax.set_xlabel("Time (UTC)")
 
-    ax = plt.gca()
     locator = mdates.AutoDateLocator()
     try:
         formatter = mdates.ConciseDateFormatter(locator)
@@ -764,11 +787,21 @@ def plot_radon_activity(ts_dict, outdir):
         formatter = mdates.AutoDateFormatter(locator)
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
-    plt.gcf().autofmt_xdate()
     ax.xaxis.get_offset_text().set_visible(False)
+    ax.ticklabel_format(axis="y", style="plain", useOffset=False)
+    ax.yaxis.get_offset_text().set_visible(False)
+    t0 = times_dt[0] if times_dt.size else 0.0
+    secax = ax.secondary_xaxis(
+        "top",
+        functions=(lambda x: (x - t0) * 24.0, lambda h: h / 24.0 + t0),
+    )
+    secax.set_xlabel("Elapsed time (h)")
+    secax.xaxis.set_major_locator(mticker.MaxNLocator(integer=True))
+    secax.xaxis.get_offset_text().set_visible(False)
+    plt.gcf().autofmt_xdate()
     plt.tight_layout()
     plt.savefig(outdir / "radon_activity.png", dpi=300)
-    plt.close()
+    plt.close(fig)
 
 
 def plot_radon_trend(ts_dict, outdir):
@@ -780,13 +813,17 @@ def plot_radon_trend(ts_dict, outdir):
     times = np.asarray(ts_dict["time"], dtype=float)
     y = np.asarray(ts_dict["activity"], dtype=float)
     times_dt = mdates.date2num([datetime.utcfromtimestamp(t) for t in times])
-    coeff = np.polyfit(times_dt, y, 1)
-    plt.plot(times_dt, y, "o")
-    plt.plot(times_dt, np.polyval(coeff, times_dt))
-    plt.ylabel("Radon activity [Bq]")
-    plt.xlabel("Time (UTC)")
+    if times.size < 2:
+        coeff = np.array([0.0, y[0] if y.size else 0.0])
+    else:
+        coeff = np.polyfit(times, y, 1)
+    fig, ax = plt.subplots()
+    ax.plot(times_dt, y, "o")
+    ax.plot(times_dt, np.polyval(coeff, times), label=f"slope={coeff[0]:.2e} Bq/s")
+    ax.set_ylabel("Radon activity [Bq]")
+    ax.set_xlabel("Time (UTC)")
+    ax.legend()
 
-    ax = plt.gca()
     locator = mdates.AutoDateLocator()
     try:
         formatter = mdates.ConciseDateFormatter(locator)
@@ -794,11 +831,21 @@ def plot_radon_trend(ts_dict, outdir):
         formatter = mdates.AutoDateFormatter(locator)
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
-    plt.gcf().autofmt_xdate()
     ax.xaxis.get_offset_text().set_visible(False)
+    ax.ticklabel_format(axis="y", style="plain", useOffset=False)
+    ax.yaxis.get_offset_text().set_visible(False)
+    t0 = times_dt[0] if times_dt.size else 0.0
+    secax = ax.secondary_xaxis(
+        "top",
+        functions=(lambda x: (x - t0) * 24.0, lambda h: h / 24.0 + t0),
+    )
+    secax.set_xlabel("Elapsed time (h)")
+    secax.xaxis.set_major_locator(mticker.MaxNLocator(integer=True))
+    secax.xaxis.get_offset_text().set_visible(False)
+    plt.gcf().autofmt_xdate()
     plt.tight_layout()
     plt.savefig(outdir / "radon_trend.png", dpi=300)
-    plt.close()
+    plt.close(fig)
 
 
 def plot_spectrum_comparison(

--- a/plot_utils/radon.py
+++ b/plot_utils/radon.py
@@ -1,4 +1,6 @@
 import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+import matplotlib.ticker as mticker
 import numpy as np
 from pathlib import Path
 
@@ -10,13 +12,34 @@ def _save(fig, outdir: Path, name: str) -> None:
 
 
 def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None) -> None:
-    t = np.asarray(ts_dict["time"])
-    a = np.asarray(ts_dict["activity"])
-    e = np.asarray(ts_dict["error"])
+    t = np.asarray(ts_dict["time"], dtype=float)
+    a = np.asarray(ts_dict["activity"], dtype=float)
+    e = np.asarray(ts_dict["error"], dtype=float)
+    times_dt = mdates.epoch2num(t)
     fig, ax = plt.subplots()
-    ax.errorbar(t, a, yerr=e, fmt="o")
+    ax.errorbar(times_dt, a, yerr=e, fmt="o")
     ax.set_ylabel("Rn-222 activity [Bq]")
     ax.set_xlabel("Time (UTC)")
+
+    locator = mdates.AutoDateLocator()
+    try:
+        formatter = mdates.ConciseDateFormatter(locator)
+    except AttributeError:
+        formatter = mdates.AutoDateFormatter(locator)
+    ax.xaxis.set_major_locator(locator)
+    ax.xaxis.set_major_formatter(formatter)
+    ax.xaxis.get_offset_text().set_visible(False)
+    ax.ticklabel_format(axis="y", style="plain", useOffset=False)
+    ax.yaxis.get_offset_text().set_visible(False)
+    t0 = times_dt[0] if times_dt.size else 0.0
+    secax = ax.secondary_xaxis(
+        "top",
+        functions=(lambda x: (x - t0) * 24.0, lambda h: h / 24.0 + t0),
+    )
+    secax.set_xlabel("Elapsed time (h)")
+    secax.xaxis.set_major_locator(mticker.MaxNLocator(integer=True))
+    secax.xaxis.get_offset_text().set_visible(False)
+    fig.autofmt_xdate()
     if out_png is not None:
         fig.savefig(out_png, dpi=300)
         plt.close(fig)
@@ -25,18 +48,39 @@ def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None
 
 
 def plot_radon_trend(ts_dict, outdir: Path, out_png: str | Path | None = None) -> None:
-    t = np.asarray(ts_dict["time"])
-    a = np.asarray(ts_dict["activity"])
+    t = np.asarray(ts_dict["time"], dtype=float)
+    a = np.asarray(ts_dict["activity"], dtype=float)
+    times_dt = mdates.epoch2num(t)
     if t.size < 2:
         coeff = np.array([0.0, a[0] if a.size else 0.0])
     else:
         coeff = np.polyfit(t, a, 1)
     fig, ax = plt.subplots()
-    ax.plot(t, a, "o")
-    ax.plot(t, np.polyval(coeff, t), label=f"slope={coeff[0]:.2e} Bq/s")
+    ax.plot(times_dt, a, "o")
+    ax.plot(times_dt, np.polyval(coeff, t), label=f"slope={coeff[0]:.2e} Bq/s")
     ax.set_ylabel("Rn-222 activity [Bq]")
     ax.set_xlabel("Time (UTC)")
     ax.legend()
+
+    locator = mdates.AutoDateLocator()
+    try:
+        formatter = mdates.ConciseDateFormatter(locator)
+    except AttributeError:
+        formatter = mdates.AutoDateFormatter(locator)
+    ax.xaxis.set_major_locator(locator)
+    ax.xaxis.set_major_formatter(formatter)
+    ax.xaxis.get_offset_text().set_visible(False)
+    ax.ticklabel_format(axis="y", style="plain", useOffset=False)
+    ax.yaxis.get_offset_text().set_visible(False)
+    t0 = times_dt[0] if times_dt.size else 0.0
+    secax = ax.secondary_xaxis(
+        "top",
+        functions=(lambda x: (x - t0) * 24.0, lambda h: h / 24.0 + t0),
+    )
+    secax.set_xlabel("Elapsed time (h)")
+    secax.xaxis.set_major_locator(mticker.MaxNLocator(integer=True))
+    secax.xaxis.get_offset_text().set_visible(False)
+    fig.autofmt_xdate()
     if out_png is not None:
         fig.savefig(out_png, dpi=300)
         plt.close(fig)

--- a/plotting.py
+++ b/plotting.py
@@ -2,6 +2,7 @@ import matplotlib as _mpl
 _mpl.use("Agg")
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
+import matplotlib.ticker as mticker
 from datetime import datetime
 from pathlib import Path
 
@@ -34,6 +35,16 @@ def plot_radon_activity(ts, outdir):
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
     ax.xaxis.get_offset_text().set_visible(False)
+    ax.ticklabel_format(style="plain", axis="y", useOffset=False)
+    ax.yaxis.get_offset_text().set_visible(False)
+    t0 = times_dt[0] if len(times_dt) else 0.0
+    secax = ax.secondary_xaxis(
+        "top",
+        functions=(lambda x: (x - t0) * 24.0, lambda h: h / 24.0 + t0),
+    )
+    secax.set_xlabel("Elapsed time (h)")
+    secax.xaxis.set_major_locator(mticker.MaxNLocator(integer=True))
+    secax.xaxis.get_offset_text().set_visible(False)
     fig.autofmt_xdate()
     fig.tight_layout()
     fig.savefig(outdir / "radon_activity.png", dpi=300)
@@ -58,6 +69,16 @@ def plot_radon_trend(ts, outdir):
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
     ax.xaxis.get_offset_text().set_visible(False)
+    ax.ticklabel_format(style="plain", axis="y", useOffset=False)
+    ax.yaxis.get_offset_text().set_visible(False)
+    t0 = times_dt[0] if len(times_dt) else 0.0
+    secax = ax.secondary_xaxis(
+        "top",
+        functions=(lambda x: (x - t0) * 24.0, lambda h: h / 24.0 + t0),
+    )
+    secax.set_xlabel("Elapsed time (h)")
+    secax.xaxis.set_major_locator(mticker.MaxNLocator(integer=True))
+    secax.xaxis.get_offset_text().set_visible(False)
     fig.autofmt_xdate()
     fig.tight_layout()
     fig.savefig(outdir / "radon_trend.png", dpi=300)

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -823,7 +823,7 @@ def test_plot_radon_activity_axis_labels(tmp_path, monkeypatch):
     ax = plt.gca()
     assert ax.get_xlabel() == "Time (UTC)"
     assert "axis" in captured
-    assert captured["axis"].get_xlabel() == "Elapsed Time (s)"
+    assert captured["axis"].get_xlabel() == "Elapsed time (h)"
 
 
 def test_plot_radon_activity_no_offset(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- ensure radon plots keep values in Bq with plain Y tick labels
- show time axes as matplotlib date numbers and add top axis for elapsed hours
- update tests for new elapsed-time labelling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a112c9926c832ba507953b1508f9b8