### PR TITLE
feat: standardize radon plot time axes

### DIFF
--- a/plot_utils/radon.py
+++ b/plot_utils/radon.py
@@ -1,6 +1,39 @@
+"""Radon plotting helpers with standardized time axes."""
+
+import matplotlib as _mpl
+_mpl.use("Agg")
 import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+import matplotlib.ticker as mticker
 import numpy as np
+from datetime import datetime
 from pathlib import Path
+
+
+def _format_time_axes(ax, times_dt):
+    locator = mdates.AutoDateLocator()
+    try:
+        formatter = mdates.ConciseDateFormatter(locator)
+    except AttributeError:
+        formatter = mdates.AutoDateFormatter(locator)
+    ax.xaxis.set_major_locator(locator)
+    ax.xaxis.set_major_formatter(formatter)
+    ax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.get_offset_text().set_visible(False)
+
+    t0 = times_dt[0]
+
+    def to_hours(x):
+        return (x - t0) * 24.0
+
+    def to_dates(h):
+        return t0 + h / 24.0
+
+    secax = ax.secondary_xaxis("top", functions=(to_hours, to_dates))
+    secax.set_xlabel("Elapsed Time (h)")
+    secax.xaxis.set_major_formatter(mticker.ScalarFormatter(useOffset=False))
+    secax.xaxis.get_offset_text().set_visible(False)
+    return secax
 
 
 def _save(fig, outdir: Path, name: str) -> None:
@@ -9,14 +42,19 @@ def _save(fig, outdir: Path, name: str) -> None:
     plt.close(fig)
 
 
-def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None) -> None:
-    t = np.asarray(ts_dict["time"])
-    a = np.asarray(ts_dict["activity"])
-    e = np.asarray(ts_dict["error"])
+def plot_radon_activity(
+    ts_dict, outdir: Path, out_png: str | Path | None = None
+) -> None:
+    t = np.asarray(ts_dict["time"], dtype=float)
+    a = np.asarray(ts_dict["activity"], dtype=float)
+    e = np.asarray(ts_dict["error"], dtype=float)
+    times_dt = mdates.date2num([datetime.utcfromtimestamp(val) for val in t])
     fig, ax = plt.subplots()
-    ax.errorbar(t, a, yerr=e, fmt="o")
+    ax.errorbar(times_dt, a, yerr=e, fmt="o")
     ax.set_ylabel("Rn-222 activity [Bq]")
     ax.set_xlabel("Time (UTC)")
+    _format_time_axes(ax, times_dt)
+    fig.autofmt_xdate()
     if out_png is not None:
         fig.savefig(out_png, dpi=300)
         plt.close(fig)
@@ -24,21 +62,31 @@ def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None
         _save(fig, outdir, "radon_activity")
 
 
-def plot_radon_trend(ts_dict, outdir: Path, out_png: str | Path | None = None) -> None:
-    t = np.asarray(ts_dict["time"])
-    a = np.asarray(ts_dict["activity"])
-    if t.size < 2:
+def plot_radon_trend(
+    ts_dict, outdir: Path, out_png: str | Path | None = None
+) -> None:
+    t = np.asarray(ts_dict["time"], dtype=float)
+    a = np.asarray(ts_dict["activity"], dtype=float)
+    times_dt = mdates.date2num([datetime.utcfromtimestamp(val) for val in t])
+    if times_dt.size < 2:
         coeff = np.array([0.0, a[0] if a.size else 0.0])
     else:
-        coeff = np.polyfit(t, a, 1)
+        coeff = np.polyfit(times_dt, a, 1)
     fig, ax = plt.subplots()
-    ax.plot(t, a, "o")
-    ax.plot(t, np.polyval(coeff, t), label=f"slope={coeff[0]:.2e} Bq/s")
+    ax.plot(times_dt, a, "o")
+    ax.plot(
+        times_dt,
+        np.polyval(coeff, times_dt),
+        label=f"slope={coeff[0] / 86400.0:.2e} Bq/s",
+    )
     ax.set_ylabel("Rn-222 activity [Bq]")
     ax.set_xlabel("Time (UTC)")
     ax.legend()
+    _format_time_axes(ax, times_dt)
+    fig.autofmt_xdate()
     if out_png is not None:
         fig.savefig(out_png, dpi=300)
         plt.close(fig)
     else:
         _save(fig, outdir, "radon_trend")
+

--- a/plotting.py
+++ b/plotting.py
@@ -2,10 +2,37 @@ import matplotlib as _mpl
 _mpl.use("Agg")
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
+import matplotlib.ticker as mticker
 from datetime import datetime
 from pathlib import Path
 
 __all__ = ["plot_radon_activity", "plot_radon_trend"]
+
+
+def _format_time_axes(ax, times_dt):
+    locator = mdates.AutoDateLocator()
+    try:
+        formatter = mdates.ConciseDateFormatter(locator)
+    except AttributeError:
+        formatter = mdates.AutoDateFormatter(locator)
+    ax.xaxis.set_major_locator(locator)
+    ax.xaxis.set_major_formatter(formatter)
+    ax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.get_offset_text().set_visible(False)
+
+    t0 = times_dt[0]
+
+    def to_hours(x):
+        return (x - t0) * 24.0
+
+    def to_dates(h):
+        return t0 + h / 24.0
+
+    secax = ax.secondary_xaxis("top", functions=(to_hours, to_dates))
+    secax.set_xlabel("Elapsed Time (h)")
+    secax.xaxis.set_major_formatter(mticker.ScalarFormatter(useOffset=False))
+    secax.xaxis.get_offset_text().set_visible(False)
+    return secax
 
 
 def plot_radon_activity(ts, outdir):
@@ -20,20 +47,11 @@ def plot_radon_activity(ts, outdir):
     """
     outdir = Path(outdir)
     fig, ax = plt.subplots()
-    times = [datetime.utcfromtimestamp(t) for t in ts.time]
-    times_dt = mdates.date2num(times)
+    times_dt = mdates.date2num([datetime.utcfromtimestamp(t) for t in ts.time])
     ax.errorbar(times_dt, ts.activity, yerr=getattr(ts, "error", None), fmt="o")
     ax.set_ylabel("Radon activity [Bq]")
     ax.set_xlabel("Time (UTC)")
-
-    locator = mdates.AutoDateLocator()
-    try:
-        formatter = mdates.ConciseDateFormatter(locator)
-    except AttributeError:
-        formatter = mdates.AutoDateFormatter(locator)
-    ax.xaxis.set_major_locator(locator)
-    ax.xaxis.set_major_formatter(formatter)
-    ax.xaxis.get_offset_text().set_visible(False)
+    _format_time_axes(ax, times_dt)
     fig.autofmt_xdate()
     fig.tight_layout()
     fig.savefig(outdir / "radon_activity.png", dpi=300)
@@ -44,20 +62,11 @@ def plot_radon_trend(ts, outdir):
     """Plot radon activity trend without uncertainties."""
     outdir = Path(outdir)
     fig, ax = plt.subplots()
-    times = [datetime.utcfromtimestamp(t) for t in ts.time]
-    times_dt = mdates.date2num(times)
+    times_dt = mdates.date2num([datetime.utcfromtimestamp(t) for t in ts.time])
     ax.plot(times_dt, ts.activity, "o-")
     ax.set_ylabel("Radon activity [Bq]")
     ax.set_xlabel("Time (UTC)")
-
-    locator = mdates.AutoDateLocator()
-    try:
-        formatter = mdates.ConciseDateFormatter(locator)
-    except AttributeError:
-        formatter = mdates.AutoDateFormatter(locator)
-    ax.xaxis.set_major_locator(locator)
-    ax.xaxis.set_major_formatter(formatter)
-    ax.xaxis.get_offset_text().set_visible(False)
+    _format_time_axes(ax, times_dt)
     fig.autofmt_xdate()
     fig.tight_layout()
     fig.savefig(outdir / "radon_trend.png", dpi=300)

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -823,7 +823,7 @@ def test_plot_radon_activity_axis_labels(tmp_path, monkeypatch):
     ax = plt.gca()
     assert ax.get_xlabel() == "Time (UTC)"
     assert "axis" in captured
-    assert captured["axis"].get_xlabel() == "Elapsed Time (s)"
+    assert captured["axis"].get_xlabel() == "Elapsed Time (h)"
 
 
 def test_plot_radon_activity_no_offset(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- show elapsed-hours on a top axis for all radon time series plots
- remove matplotlib offset text for clearer axes
- adjust tests for the new elapsed-hour label

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a112db4e44832b9ea05a4111643a7d