### PR TITLE
Wire background and likelihood selectors for spectral fits

### DIFF
--- a/feature_selectors.py
+++ b/feature_selectors.py
@@ -45,7 +45,15 @@ def select_background_factory(opts: Any, Emin: float, Emax: float) -> Callable:
 
         return bkg
 
-    return lambda E, params: _existing_linear_bkg(E, params)
+    from fitting import make_linear_bkg
+
+    shape = make_linear_bkg(Emin, Emax)
+
+    def bkg(E, params):
+        val = shape(E, params["b0"], params["b1"])
+        return softplus(params["S_bkg"]) * val
+
+    return bkg
 
 
 def select_neg_loglike(opts: Any) -> Callable:


### PR DESCRIPTION
## Summary
- route spectral fits through background and likelihood selector factories
- allow `fit_spectrum` to accept injected background models and NLL functions
- select and reuse these factories in analysis pipelines

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a112b54c44832ba47af58022394592