### PR TITLE
Handle S_bkg only for log-linear background

### DIFF
--- a/likelihood_ext.py
+++ b/likelihood_ext.py
@@ -50,15 +50,11 @@ def neg_loglike_extended(
     """
     E = np.asarray(E, dtype=float)
 
-    if background_model == "loglin_unit":
-        required = {"S_bkg", "beta0", "beta1"}
-        missing = required - params.keys()
-        if missing:
-            got = sorted(params.keys())
-            raise ValueError(
-                "background_model=loglin_unit requires params {S_bkg, beta0, beta1}; got: "
-                f"{got}"
-            )
+    if background_model == "loglin_unit" and "S_bkg" not in params:
+        got = sorted(params.keys())
+        raise ValueError(
+            "background_model=loglin_unit requires param S_bkg; got: " f"{got}"
+        )
 
     missing_areas = [k for k in area_keys if k not in params]
     if missing_areas:

--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -473,12 +473,15 @@ def plot_spectrum(
         sigma_E = fit_vals.get("sigma_E", 1.0)
         b0 = fit_vals.get("b0", 0.0)
         b1 = fit_vals.get("b1", 0.0)
-        S_bkg = fit_vals.get("S_bkg", 0.0)
+        S_bkg = fit_vals.get("S_bkg")
         bkg_cent = b0 + b1 * centers
-        bkg_norm = b0 * (edges[-1] - edges[0]) + 0.5 * b1 * (edges[-1] ** 2 - edges[0] ** 2)
         y_cent = np.zeros_like(centers)
-        if bkg_norm > 0:
-            y_cent += S_bkg * bkg_cent / bkg_norm
+        if S_bkg is None:
+            y_cent += bkg_cent
+        else:
+            bkg_norm = b0 * (edges[-1] - edges[0]) + 0.5 * b1 * (edges[-1] ** 2 - edges[0] ** 2)
+            if bkg_norm > 0:
+                y_cent += S_bkg * bkg_cent / bkg_norm
         for pk in ("Po210", "Po218", "Po214"):
             mu_key = f"mu_{pk}"
             amp_key = f"S_{pk}"

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -165,6 +165,29 @@ def test_extended_likelihood_missing_area_key():
     )
 
 
+def test_extended_likelihood_requires_S_bkg_for_loglin_unit():
+    from likelihood_ext import neg_loglike_extended
+
+    E = np.array([1.0, 2.0, 3.0])
+
+    def intensity(E_vals, params):
+        return np.ones_like(E_vals)
+
+    params = {"beta0": 0.0, "beta1": 0.0}
+    with pytest.raises(ValueError) as exc:
+        neg_loglike_extended(
+            E,
+            intensity,
+            params,
+            area_keys=(),
+            background_model="loglin_unit",
+        )
+    assert (
+        str(exc.value)
+        == "background_model=loglin_unit requires param S_bkg; got: ['beta0', 'beta1']"
+    )
+
+
 def test_fit_spectrum_fixed_parameter_bounds():
     """Fixing a parameter should not trigger a bound error."""
     rng = np.random.default_rng(1)
@@ -272,7 +295,8 @@ def test_fit_spectrum_background_only_irregular_edges():
     }
 
     result = fit_spectrum(energies, priors, bin_edges=edges)
-    assert np.isclose(result.params["S_bkg"], 40.0, atol=0.1)
+    assert "S_bkg" not in result.params
+    assert np.isclose(result.params["b0"], 10.0, atol=0.1)
 
 
 def test_model_binned_variable_width(monkeypatch):
@@ -723,7 +747,12 @@ def test_spectrum_tail_amplitude_stability():
         "S_bkg": (0.0, 100.0),
     }
 
-    res = fit_spectrum(energies, priors, unbinned=True)
+    res = fit_spectrum(
+        energies,
+        priors,
+        unbinned=True,
+        flags={"background_model": "loglin_unit"},
+    )
     expected = 395  # median of 20 repeated fits → ~394.6
     tol = 0.03  # keep the same 3 % window
     assert abs(res.params["S_Po218"] - expected) / expected < tol


### PR DESCRIPTION
## Summary
- Only bootstrap and validate `S_bkg` when using the experimental log-linear background model
- Skip `S_bkg` for legacy linear background and update plots accordingly
- Require `S_bkg` in extended likelihood when log-linear background is selected

## Testing
- `pytest tests/test_fitting.py tests/test_plot_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a112bad43c832bae336afd3381d5af