### PR TITLE
Improve radon plot axis formatting

### DIFF
--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -565,24 +565,15 @@ def plot_radon_activity_full(
 
     base_dt = times_dt[0]
 
-    def _to_seconds(x):
-        return (x - base_dt) * 86400.0
+    def _to_hours(x):
+        return (x - base_dt) * 24.0
 
     def _to_dates(x):
-        return base_dt + x / 86400.0
+        return base_dt + x / 24.0
 
-    secax = ax.secondary_xaxis("top", functions=(_to_seconds, _to_dates))
-
-    def _sec_formatter(x, pos=None):
-        h = x / 3600.0
-        if h >= 1:
-            if abs(h - round(h)) < 1e-6:
-                return f"{int(x)} s ({int(h)} h)"
-            return f"{int(x)} s ({h:g} h)"
-        return f"{int(x)} s"
-
-    secax.xaxis.set_major_formatter(mticker.FuncFormatter(_sec_formatter))
-    secax.set_xlabel("Elapsed Time (s)")
+    secax = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
+    secax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda h, _=None: f"{h:g}"))
+    secax.set_xlabel("Elapsed Time (h)")
 
     if po214_activity is not None:
         po214_activity = np.asarray(po214_activity, dtype=float)
@@ -596,12 +587,16 @@ def plot_radon_activity_full(
             label="Po-214 Activity (QC)",
         )
         ax2.set_ylabel("Po-214 Activity (Bq)")
+        ax2.ticklabel_format(axis="y", style="plain")
+        ax2.yaxis.get_offset_text().set_visible(False)
         lines1, labels1 = ax.get_legend_handles_labels()
         lines2, labels2 = ax2.get_legend_handles_labels()
         ax.legend(lines1 + lines2, labels1 + labels2, loc="best")
 
     plt.gcf().autofmt_xdate()
+    ax.ticklabel_format(axis="y", style="plain")
     ax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.get_offset_text().set_visible(False)
     secax.xaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
     targets = get_targets(config, out_png)
@@ -732,8 +727,24 @@ def plot_radon_trend_full(times, activity, out_png, config=None):
         formatter = mdates.AutoDateFormatter(locator)
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
+
+    base_dt = times_dt[0]
+
+    def _to_hours(x):
+        return (x - base_dt) * 24.0
+
+    def _to_dates(x):
+        return base_dt + x / 24.0
+
+    secax = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
+    secax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda h, _=None: f"{h:g}"))
+    secax.set_xlabel("Elapsed Time (h)")
+
     plt.gcf().autofmt_xdate()
+    ax.ticklabel_format(axis="y", style="plain")
     ax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.get_offset_text().set_visible(False)
+    secax.xaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
 
     targets = get_targets(config, out_png)
@@ -764,8 +775,24 @@ def plot_radon_activity(ts_dict, outdir):
         formatter = mdates.AutoDateFormatter(locator)
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
+
+    base_dt = times_dt[0]
+
+    def _to_hours(x):
+        return (x - base_dt) * 24.0
+
+    def _to_dates(x):
+        return base_dt + x / 24.0
+
+    secax = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
+    secax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda h, _=None: f"{h:g}"))
+    secax.set_xlabel("Elapsed Time (h)")
+
     plt.gcf().autofmt_xdate()
+    ax.ticklabel_format(axis="y", style="plain")
     ax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.get_offset_text().set_visible(False)
+    secax.xaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
     plt.savefig(outdir / "radon_activity.png", dpi=300)
     plt.close()
@@ -794,8 +821,24 @@ def plot_radon_trend(ts_dict, outdir):
         formatter = mdates.AutoDateFormatter(locator)
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
+
+    base_dt = times_dt[0]
+
+    def _to_hours(x):
+        return (x - base_dt) * 24.0
+
+    def _to_dates(x):
+        return base_dt + x / 24.0
+
+    secax = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
+    secax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda h, _=None: f"{h:g}"))
+    secax.set_xlabel("Elapsed Time (h)")
+
     plt.gcf().autofmt_xdate()
+    ax.ticklabel_format(axis="y", style="plain")
     ax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.get_offset_text().set_visible(False)
+    secax.xaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
     plt.savefig(outdir / "radon_trend.png", dpi=300)
     plt.close()

--- a/plot_utils/radon.py
+++ b/plot_utils/radon.py
@@ -1,5 +1,8 @@
 import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+import matplotlib.ticker as mticker
 import numpy as np
+from datetime import datetime
 from pathlib import Path
 
 
@@ -10,13 +13,41 @@ def _save(fig, outdir: Path, name: str) -> None:
 
 
 def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None) -> None:
-    t = np.asarray(ts_dict["time"])
-    a = np.asarray(ts_dict["activity"])
-    e = np.asarray(ts_dict["error"])
+    t = np.asarray(ts_dict["time"], dtype=float)
+    a = np.asarray(ts_dict["activity"], dtype=float)
+    e = np.asarray(ts_dict["error"], dtype=float)
+    times_dt = mdates.date2num([datetime.utcfromtimestamp(tt) for tt in t])
     fig, ax = plt.subplots()
-    ax.errorbar(t, a, yerr=e, fmt="o")
+    ax.errorbar(times_dt, a, yerr=e, fmt="o")
     ax.set_ylabel("Rn-222 activity [Bq]")
     ax.set_xlabel("Time (UTC)")
+
+    locator = mdates.AutoDateLocator()
+    try:
+        formatter = mdates.ConciseDateFormatter(locator)
+    except AttributeError:
+        formatter = mdates.AutoDateFormatter(locator)
+    ax.xaxis.set_major_locator(locator)
+    ax.xaxis.set_major_formatter(formatter)
+
+    base_dt = times_dt[0]
+
+    def _to_hours(x):
+        return (x - base_dt) * 24.0
+
+    def _to_dates(x):
+        return base_dt + x / 24.0
+
+    secax = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
+    secax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda h, _=None: f"{h:g}"))
+    secax.set_xlabel("Elapsed Time (h)")
+
+    fig.autofmt_xdate()
+    ax.ticklabel_format(axis="y", style="plain")
+    ax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.get_offset_text().set_visible(False)
+    secax.xaxis.get_offset_text().set_visible(False)
+    fig.tight_layout()
     if out_png is not None:
         fig.savefig(out_png, dpi=300)
         plt.close(fig)
@@ -25,18 +56,46 @@ def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None
 
 
 def plot_radon_trend(ts_dict, outdir: Path, out_png: str | Path | None = None) -> None:
-    t = np.asarray(ts_dict["time"])
-    a = np.asarray(ts_dict["activity"])
-    if t.size < 2:
+    t = np.asarray(ts_dict["time"], dtype=float)
+    a = np.asarray(ts_dict["activity"], dtype=float)
+    times_dt = mdates.date2num([datetime.utcfromtimestamp(tt) for tt in t])
+    if times_dt.size < 2:
         coeff = np.array([0.0, a[0] if a.size else 0.0])
     else:
-        coeff = np.polyfit(t, a, 1)
+        coeff = np.polyfit(times_dt, a, 1)
     fig, ax = plt.subplots()
-    ax.plot(t, a, "o")
-    ax.plot(t, np.polyval(coeff, t), label=f"slope={coeff[0]:.2e} Bq/s")
+    ax.plot(times_dt, a, "o")
+    ax.plot(times_dt, np.polyval(coeff, times_dt), label=f"slope={coeff[0]:.2e} Bq/s")
     ax.set_ylabel("Rn-222 activity [Bq]")
     ax.set_xlabel("Time (UTC)")
     ax.legend()
+
+    locator = mdates.AutoDateLocator()
+    try:
+        formatter = mdates.ConciseDateFormatter(locator)
+    except AttributeError:
+        formatter = mdates.AutoDateFormatter(locator)
+    ax.xaxis.set_major_locator(locator)
+    ax.xaxis.set_major_formatter(formatter)
+
+    base_dt = times_dt[0]
+
+    def _to_hours(x):
+        return (x - base_dt) * 24.0
+
+    def _to_dates(x):
+        return base_dt + x / 24.0
+
+    secax = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
+    secax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda h, _=None: f"{h:g}"))
+    secax.set_xlabel("Elapsed Time (h)")
+
+    fig.autofmt_xdate()
+    ax.ticklabel_format(axis="y", style="plain")
+    ax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.get_offset_text().set_visible(False)
+    secax.xaxis.get_offset_text().set_visible(False)
+    fig.tight_layout()
     if out_png is not None:
         fig.savefig(out_png, dpi=300)
         plt.close(fig)

--- a/plotting.py
+++ b/plotting.py
@@ -2,6 +2,7 @@ import matplotlib as _mpl
 _mpl.use("Agg")
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
+import matplotlib.ticker as mticker
 from datetime import datetime
 from pathlib import Path
 
@@ -33,8 +34,24 @@ def plot_radon_activity(ts, outdir):
         formatter = mdates.AutoDateFormatter(locator)
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
-    ax.xaxis.get_offset_text().set_visible(False)
+
+    base_dt = times_dt[0]
+
+    def _to_hours(x):
+        return (x - base_dt) * 24.0
+
+    def _to_dates(x):
+        return base_dt + x / 24.0
+
+    secax = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
+    secax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda h, _=None: f"{h:g}"))
+    secax.set_xlabel("Elapsed Time (h)")
+
     fig.autofmt_xdate()
+    ax.ticklabel_format(axis="y", style="plain")
+    ax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.get_offset_text().set_visible(False)
+    secax.xaxis.get_offset_text().set_visible(False)
     fig.tight_layout()
     fig.savefig(outdir / "radon_activity.png", dpi=300)
     plt.close(fig)
@@ -57,8 +74,24 @@ def plot_radon_trend(ts, outdir):
         formatter = mdates.AutoDateFormatter(locator)
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
-    ax.xaxis.get_offset_text().set_visible(False)
+
+    base_dt = times_dt[0]
+
+    def _to_hours(x):
+        return (x - base_dt) * 24.0
+
+    def _to_dates(x):
+        return base_dt + x / 24.0
+
+    secax = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
+    secax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda h, _=None: f"{h:g}"))
+    secax.set_xlabel("Elapsed Time (h)")
+
     fig.autofmt_xdate()
+    ax.ticklabel_format(axis="y", style="plain")
+    ax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.get_offset_text().set_visible(False)
+    secax.xaxis.get_offset_text().set_visible(False)
     fig.tight_layout()
     fig.savefig(outdir / "radon_trend.png", dpi=300)
     plt.close(fig)

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -823,7 +823,7 @@ def test_plot_radon_activity_axis_labels(tmp_path, monkeypatch):
     ax = plt.gca()
     assert ax.get_xlabel() == "Time (UTC)"
     assert "axis" in captured
-    assert captured["axis"].get_xlabel() == "Elapsed Time (s)"
+    assert captured["axis"].get_xlabel() == "Elapsed Time (h)"
 
 
 def test_plot_radon_activity_no_offset(tmp_path, monkeypatch):
@@ -839,6 +839,7 @@ def test_plot_radon_activity_no_offset(tmp_path, monkeypatch):
 
     ax = plt.gca()
     assert not ax.xaxis.get_offset_text().get_visible()
+    assert not ax.yaxis.get_offset_text().get_visible()
 
 
 def test_plot_radon_activity_full_no_offset(tmp_path, monkeypatch):
@@ -867,6 +868,7 @@ def test_plot_radon_activity_full_no_offset(tmp_path, monkeypatch):
 
     ax = plt.gca()
     assert not ax.xaxis.get_offset_text().get_visible()
+    assert not ax.yaxis.get_offset_text().get_visible()
     assert not captured["axis"].xaxis.get_offset_text().get_visible()
 
 


### PR DESCRIPTION
## Summary
- standardize radon plotting helpers on Matplotlib date numbers
- show elapsed time in hours on a secondary axis
- suppress scientific-notation offsets on activity axes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a112c9926c832ba507953b1508f9b8