### PR TITLE
Prevent conflicting resolution settings

### DIFF
--- a/tests/test_resolution_flags.py
+++ b/tests/test_resolution_flags.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import analyze
+import pytest
+
+
+def test_conflict_between_float_and_fix_sigma0():
+    cfg = {"float_sigma_E": True, "flags": {"fix_sigma0": True}}
+    with pytest.raises(ValueError):
+        analyze._resolve_spectral_flags(cfg)
+
+
+def test_no_conflict_when_flag_absent():
+    cfg = {"float_sigma_E": True, "flags": {}}
+    flags = analyze._resolve_spectral_flags(cfg)
+    assert flags == {}


### PR DESCRIPTION
## Summary
- validate spectral resolution flags and forbid float_sigma_E with fix_sigma0
- add tests covering invalid resolution flag combinations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a112d042e0832b8975960218ad3128