### PR TITLE
feat: unify radon plot time axes

### DIFF
--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -34,6 +34,22 @@ __all__ = [
 ]
 
 
+def _elapsed_hours_axis(ax, times_dt):
+    base = times_dt[0]
+
+    def _to_hours(x):
+        return (x - base) * 24.0
+
+    def _to_dates(h):
+        return base + h / 24.0
+
+    sec = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
+    sec.set_xlabel("Elapsed time [h]")
+    sec.xaxis.set_major_formatter(mticker.ScalarFormatter(useOffset=False))
+    sec.xaxis.get_offset_text().set_visible(False)
+    return sec
+
+
 def extract_time_series(timestamps, energies, window, t_start, t_end, bin_width_s=1.0):
     """Return histogram counts for events within an energy window.
 
@@ -562,27 +578,7 @@ def plot_radon_activity_full(
         formatter = mdates.AutoDateFormatter(locator)
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
-
-    base_dt = times_dt[0]
-
-    def _to_seconds(x):
-        return (x - base_dt) * 86400.0
-
-    def _to_dates(x):
-        return base_dt + x / 86400.0
-
-    secax = ax.secondary_xaxis("top", functions=(_to_seconds, _to_dates))
-
-    def _sec_formatter(x, pos=None):
-        h = x / 3600.0
-        if h >= 1:
-            if abs(h - round(h)) < 1e-6:
-                return f"{int(x)} s ({int(h)} h)"
-            return f"{int(x)} s ({h:g} h)"
-        return f"{int(x)} s"
-
-    secax.xaxis.set_major_formatter(mticker.FuncFormatter(_sec_formatter))
-    secax.set_xlabel("Elapsed Time (s)")
+    _elapsed_hours_axis(ax, times_dt)
 
     if po214_activity is not None:
         po214_activity = np.asarray(po214_activity, dtype=float)
@@ -602,7 +598,8 @@ def plot_radon_activity_full(
 
     plt.gcf().autofmt_xdate()
     ax.xaxis.get_offset_text().set_visible(False)
-    secax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.set_major_formatter(mticker.ScalarFormatter(useOffset=False))
+    ax.yaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
     targets = get_targets(config, out_png)
     for p in targets.values():
@@ -646,8 +643,11 @@ def plot_equivalent_air(times, volumes, errors, conc, out_png, config=None):
         formatter = mdates.AutoDateFormatter(locator)
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
+    _elapsed_hours_axis(ax, times_dt)
     plt.gcf().autofmt_xdate()
     ax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.set_major_formatter(mticker.ScalarFormatter(useOffset=False))
+    ax.yaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
     targets = get_targets(config, out_png)
     for p in targets.values():
@@ -732,8 +732,11 @@ def plot_radon_trend_full(times, activity, out_png, config=None):
         formatter = mdates.AutoDateFormatter(locator)
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
+    _elapsed_hours_axis(ax, times_dt)
     plt.gcf().autofmt_xdate()
     ax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.set_major_formatter(mticker.ScalarFormatter(useOffset=False))
+    ax.yaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
 
     targets = get_targets(config, out_png)
@@ -764,8 +767,11 @@ def plot_radon_activity(ts_dict, outdir):
         formatter = mdates.AutoDateFormatter(locator)
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
+    _elapsed_hours_axis(ax, times_dt)
     plt.gcf().autofmt_xdate()
     ax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.set_major_formatter(mticker.ScalarFormatter(useOffset=False))
+    ax.yaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
     plt.savefig(outdir / "radon_activity.png", dpi=300)
     plt.close()
@@ -794,8 +800,11 @@ def plot_radon_trend(ts_dict, outdir):
         formatter = mdates.AutoDateFormatter(locator)
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
+    _elapsed_hours_axis(ax, times_dt)
     plt.gcf().autofmt_xdate()
     ax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.set_major_formatter(mticker.ScalarFormatter(useOffset=False))
+    ax.yaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
     plt.savefig(outdir / "radon_trend.png", dpi=300)
     plt.close()

--- a/plot_utils/radon.py
+++ b/plot_utils/radon.py
@@ -1,5 +1,8 @@
 import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+import matplotlib.ticker as mticker
 import numpy as np
+from datetime import datetime
 from pathlib import Path
 
 
@@ -9,14 +12,44 @@ def _save(fig, outdir: Path, name: str) -> None:
     plt.close(fig)
 
 
+def _hours_axis(ax, times_dt):
+    start = times_dt[0]
+
+    def _to_hours(x):
+        return (x - start) * 24.0
+
+    def _to_dates(h):
+        return h / 24.0 + start
+
+    sec = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
+    sec.set_xlabel("Elapsed time [h]")
+    sec.xaxis.set_major_formatter(mticker.ScalarFormatter(useOffset=False))
+    sec.xaxis.get_offset_text().set_visible(False)
+    return sec
+
+
 def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None) -> None:
-    t = np.asarray(ts_dict["time"])
-    a = np.asarray(ts_dict["activity"])
-    e = np.asarray(ts_dict["error"])
+    t = np.asarray(ts_dict["time"], dtype=float)
+    a = np.asarray(ts_dict["activity"], dtype=float)
+    e = np.asarray(ts_dict["error"], dtype=float)
+    times_dt = mdates.date2num([datetime.utcfromtimestamp(x) for x in t])
     fig, ax = plt.subplots()
-    ax.errorbar(t, a, yerr=e, fmt="o")
+    ax.errorbar(times_dt, a, yerr=e, fmt="o")
     ax.set_ylabel("Rn-222 activity [Bq]")
     ax.set_xlabel("Time (UTC)")
+
+    locator = mdates.AutoDateLocator()
+    try:
+        formatter = mdates.ConciseDateFormatter(locator)
+    except AttributeError:
+        formatter = mdates.AutoDateFormatter(locator)
+    ax.xaxis.set_major_locator(locator)
+    ax.xaxis.set_major_formatter(formatter)
+    _hours_axis(ax, times_dt)
+    ax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.set_major_formatter(mticker.ScalarFormatter(useOffset=False))
+    ax.yaxis.get_offset_text().set_visible(False)
+    fig.autofmt_xdate()
     if out_png is not None:
         fig.savefig(out_png, dpi=300)
         plt.close(fig)
@@ -25,18 +58,32 @@ def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None
 
 
 def plot_radon_trend(ts_dict, outdir: Path, out_png: str | Path | None = None) -> None:
-    t = np.asarray(ts_dict["time"])
-    a = np.asarray(ts_dict["activity"])
+    t = np.asarray(ts_dict["time"], dtype=float)
+    a = np.asarray(ts_dict["activity"], dtype=float)
     if t.size < 2:
         coeff = np.array([0.0, a[0] if a.size else 0.0])
     else:
         coeff = np.polyfit(t, a, 1)
+    times_dt = mdates.date2num([datetime.utcfromtimestamp(x) for x in t])
     fig, ax = plt.subplots()
-    ax.plot(t, a, "o")
-    ax.plot(t, np.polyval(coeff, t), label=f"slope={coeff[0]:.2e} Bq/s")
+    ax.plot(times_dt, a, "o")
+    ax.plot(times_dt, np.polyval(coeff, t), label=f"slope={coeff[0]:.2e} Bq/s")
     ax.set_ylabel("Rn-222 activity [Bq]")
     ax.set_xlabel("Time (UTC)")
+
+    locator = mdates.AutoDateLocator()
+    try:
+        formatter = mdates.ConciseDateFormatter(locator)
+    except AttributeError:
+        formatter = mdates.AutoDateFormatter(locator)
+    ax.xaxis.set_major_locator(locator)
+    ax.xaxis.set_major_formatter(formatter)
+    _hours_axis(ax, times_dt)
+    ax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.set_major_formatter(mticker.ScalarFormatter(useOffset=False))
+    ax.yaxis.get_offset_text().set_visible(False)
     ax.legend()
+    fig.autofmt_xdate()
     if out_png is not None:
         fig.savefig(out_png, dpi=300)
         plt.close(fig)

--- a/plotting.py
+++ b/plotting.py
@@ -2,10 +2,27 @@ import matplotlib as _mpl
 _mpl.use("Agg")
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
+import matplotlib.ticker as mticker
 from datetime import datetime
 from pathlib import Path
 
 __all__ = ["plot_radon_activity", "plot_radon_trend"]
+
+
+def _add_elapsed_hours_axis(ax, times_dt):
+    start = times_dt[0]
+
+    def _to_hours(x):
+        return (x - start) * 24.0
+
+    def _to_dates(h):
+        return h / 24.0 + start
+
+    sec = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
+    sec.set_xlabel("Elapsed time [h]")
+    sec.xaxis.set_major_formatter(mticker.ScalarFormatter(useOffset=False))
+    sec.xaxis.get_offset_text().set_visible(False)
+    return sec
 
 
 def plot_radon_activity(ts, outdir):
@@ -33,7 +50,10 @@ def plot_radon_activity(ts, outdir):
         formatter = mdates.AutoDateFormatter(locator)
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
+    _add_elapsed_hours_axis(ax, times_dt)
     ax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.set_major_formatter(mticker.ScalarFormatter(useOffset=False))
+    ax.yaxis.get_offset_text().set_visible(False)
     fig.autofmt_xdate()
     fig.tight_layout()
     fig.savefig(outdir / "radon_activity.png", dpi=300)
@@ -57,7 +77,10 @@ def plot_radon_trend(ts, outdir):
         formatter = mdates.AutoDateFormatter(locator)
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
+    _add_elapsed_hours_axis(ax, times_dt)
     ax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.set_major_formatter(mticker.ScalarFormatter(useOffset=False))
+    ax.yaxis.get_offset_text().set_visible(False)
     fig.autofmt_xdate()
     fig.tight_layout()
     fig.savefig(outdir / "radon_trend.png", dpi=300)

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -823,7 +823,7 @@ def test_plot_radon_activity_axis_labels(tmp_path, monkeypatch):
     ax = plt.gca()
     assert ax.get_xlabel() == "Time (UTC)"
     assert "axis" in captured
-    assert captured["axis"].get_xlabel() == "Elapsed Time (s)"
+    assert captured["axis"].get_xlabel() == "Elapsed time [h]"
 
 
 def test_plot_radon_activity_no_offset(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add helper for plotting elapsed-hours as a secondary x-axis
- standardize radon plots to use datetime bottom axes and hour offsets on top
- ensure Matplotlib offset annotations are hidden on all radon plots

## Testing
- `pytest -q`
- `pytest tests/test_plot_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a112db4e44832b9ea05a4111643a7d