### PR TITLE
Gate S_bkg on log-linear background model

### DIFF
--- a/fitting.py
+++ b/fitting.py
@@ -360,16 +360,16 @@ def fit_spectrum(
     E_lo = float(edges[0])
     E_hi = float(edges[-1])
 
-    # Augment priors with a background amplitude if not provided
     priors = dict(priors)
-    if "S_bkg" not in priors:
-        b0_mu = priors.get("b0", (0.0, 1.0))[0]
-        b1_mu = priors.get("b1", (0.0, 1.0))[0]
-        mu = b0_mu * (E_hi - E_lo) + 0.5 * b1_mu * (E_hi**2 - E_lo**2)
-        mu = max(mu, 0.0)
-        sig = max(abs(mu) * 0.1, 1.0)
-        priors["S_bkg"] = (mu, sig)
-    if flags.get("background_model") == "loglin_unit":
+    background_model = flags.get("background_model")
+    if background_model == "loglin_unit":
+        if "S_bkg" not in priors:
+            b0_mu = priors.get("b0", (0.0, 1.0))[0]
+            b1_mu = priors.get("b1", (0.0, 1.0))[0]
+            mu = b0_mu * (E_hi - E_lo) + 0.5 * b1_mu * (E_hi**2 - E_lo**2)
+            mu = max(mu, 0.0)
+            sig = max(abs(mu) * 0.1, 1.0)
+            priors["S_bkg"] = (mu, sig)
         required = {"b0", "b1"}
         missing = required - priors.keys()
         if missing:
@@ -432,8 +432,9 @@ def fit_spectrum(
     param_order.append("b0")
     param_index["b1"] = len(param_order)
     param_order.append("b1")
-    param_index["S_bkg"] = len(param_order)
-    param_order.append("S_bkg")
+    if background_model == "loglin_unit":
+        param_index["S_bkg"] = len(param_order)
+        param_order.append("S_bkg")
 
     p0 = []
     bounds_lo, bounds_hi = [], []
@@ -474,8 +475,12 @@ def fit_spectrum(
         bounds_hi.append(hi)
 
     iso_list = ["Po210", "Po218", "Po214"]
-    area_keys = [f"S_{iso}" for iso in iso_list] + ["S_bkg"]
-    bkg_shape = _make_linear_bkg(E_lo, E_hi)
+    if background_model == "loglin_unit":
+        area_keys = [f"S_{iso}" for iso in iso_list] + ["S_bkg"]
+        bkg_shape = _make_linear_bkg(E_lo, E_hi)
+    else:
+        area_keys = [f"S_{iso}" for iso in iso_list]
+        bkg_shape = None
 
     def _model_density(x, *params):
         if fix_sigma0:
@@ -503,9 +508,12 @@ def fit_spectrum(
                 y += S * gaussian(x, mu, sigma)
         beta0 = params[param_index["b0"]]
         beta1 = params[param_index["b1"]]
-        B_raw = params[param_index["S_bkg"]]
-        B = _softplus(B_raw)
-        y += B * bkg_shape(x, beta0, beta1)
+        if background_model == "loglin_unit":
+            B_raw = params[param_index["S_bkg"]]
+            B = _softplus(B_raw)
+            y += B * bkg_shape(x, beta0, beta1)
+        else:
+            y += beta0 + beta1 * x
         return np.clip(y, 1e-300, np.inf)
 
     def _model_binned(x, *params):

--- a/likelihood_ext.py
+++ b/likelihood_ext.py
@@ -50,15 +50,12 @@ def neg_loglike_extended(
     """
     E = np.asarray(E, dtype=float)
 
-    if background_model == "loglin_unit":
-        required = {"S_bkg", "beta0", "beta1"}
-        missing = required - params.keys()
-        if missing:
-            got = sorted(params.keys())
-            raise ValueError(
-                "background_model=loglin_unit requires params {S_bkg, beta0, beta1}; got: "
-                f"{got}"
-            )
+    if background_model == "loglin_unit" and "S_bkg" not in params:
+        got = sorted(params.keys())
+        raise ValueError(
+            "background_model=loglin_unit requires param S_bkg; got: "
+            f"{got}"
+        )
 
     missing_areas = [k for k in area_keys if k not in params]
     if missing_areas:

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -165,6 +165,28 @@ def test_extended_likelihood_missing_area_key():
     )
 
 
+def test_extended_likelihood_requires_s_bkg_for_loglin():
+    from likelihood_ext import neg_loglike_extended
+
+    E = np.array([1.0, 2.0])
+
+    def intensity(E_vals, params):
+        return np.ones_like(E_vals)
+
+    params = {"beta0": 0.0, "beta1": 0.0}
+    with pytest.raises(ValueError) as exc:
+        neg_loglike_extended(
+            E,
+            intensity,
+            params,
+            area_keys=(),
+            background_model="loglin_unit",
+        )
+    assert "requires param S_bkg" in str(exc.value)
+
+    neg_loglike_extended(E, intensity, params, area_keys=(), background_model=None)
+
+
 def test_fit_spectrum_fixed_parameter_bounds():
     """Fixing a parameter should not trigger a bound error."""
     rng = np.random.default_rng(1)
@@ -272,7 +294,7 @@ def test_fit_spectrum_background_only_irregular_edges():
     }
 
     result = fit_spectrum(energies, priors, bin_edges=edges)
-    assert np.isclose(result.params["S_bkg"], 40.0, atol=0.1)
+    assert np.isclose(result.params["b0"], 10.0, atol=0.1)
 
 
 def test_model_binned_variable_width(monkeypatch):


### PR DESCRIPTION
## Summary
- require/inject S_bkg only when using log-linear unit background
- drop S_bkg from legacy linear background path and update extended likelihood validation
- test coverage for S_bkg gating and log-linear likelihood error handling

## Testing
- `pytest tests/test_fitting.py::test_loglin_unit_bootstraps_background tests/test_fitting.py::test_fit_spectrum_background_only_irregular_edges tests/test_fitting.py::test_extended_likelihood_requires_s_bkg_for_loglin -q`

------
https://chatgpt.com/codex/tasks/task_e_68a112bad43c832bae336afd3381d5af