### PR TITLE
prevent conflicting resolution flags

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -2005,7 +2005,13 @@ def main(argv=None):
 
         # Flags controlling the spectral fit
         spec_flags = cfg["spectral_fit"].get("flags", {}).copy()
-        if not cfg["spectral_fit"].get("float_sigma_E", True):
+        float_resolution = cfg["spectral_fit"].get("float_sigma_E", True)
+        if float_resolution and spec_flags.get("fix_sigma0"):
+            raise ValueError(
+                "Configuration conflict: float_sigma_E is true but "
+                "fix_sigma0 flag is set"
+            )
+        if not float_resolution:
             spec_flags["fix_sigma0"] = True
             spec_flags.setdefault("fix_F", True)
 

--- a/fitting.py
+++ b/fitting.py
@@ -332,6 +332,12 @@ def fit_spectrum(
         flags.setdefault("fix_sigma0", True)
         flags.setdefault("fix_F", True)
 
+    if flags.get("fix_sigma0", False) and not flags.get("fix_F", True):
+        raise ValueError(
+            "Resolution flags conflict: cannot fix sigma0 while allowing "
+            "the energy resolution to float"
+        )
+
     e = np.asarray(energies, dtype=float)
     n_events = e.size
     if e.size == 0:

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -754,3 +754,26 @@ def test_spectrum_positive_amplitude_bound():
     assert res.params["fit_valid"]
     for key in ("S_Po210", "S_Po218", "S_Po214"):
         assert res.params[key] >= 0
+
+
+def test_resolution_flag_conflict():
+    rng = np.random.default_rng(0)
+    energies = np.concatenate([
+        rng.normal(5.3, 0.05, 10),
+        rng.normal(6.0, 0.05, 10),
+        rng.normal(7.7, 0.05, 10),
+    ])
+    priors = {
+        "sigma0": (0.05, 0.01),
+        "F": (0.0, 0.01),
+        "mu_Po210": (5.3, 0.1),
+        "S_Po210": (10, 1),
+        "mu_Po218": (6.0, 0.1),
+        "S_Po218": (10, 1),
+        "mu_Po214": (7.7, 0.1),
+        "S_Po214": (10, 1),
+        "b0": (0.0, 1.0),
+        "b1": (0.0, 1.0),
+    }
+    with pytest.raises(ValueError):
+        fit_spectrum(energies, priors, flags={"fix_sigma0": True, "fix_F": False})


### PR DESCRIPTION
## Summary
- prevent configuration that sets both `float_sigma_E` and `fix_sigma0`
- guard `fit_spectrum` against fixing `sigma0` while floating resolution
- cover resolution flag conflict with a regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a112d042e0832b8975960218ad3128