### PR TITLE
Standardize radon plot time axes

### DIFF
--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from color_schemes import COLOR_SCHEMES
 from constants import PO214, PO218, PO210, RN222
 from .paths import get_targets
+from .time_axes import configure_time_axes
 
 # Half-life constants used for the time-series overlay [seconds]
 PO214_HALF_LIFE_S = PO214.half_life_s
@@ -555,34 +556,7 @@ def plot_radon_activity_full(
     ax.set_ylabel("Rn-222 Activity (Bq)")
     ax.set_title("Extrapolated Radon Activity vs. Time")
 
-    locator = mdates.AutoDateLocator()
-    try:
-        formatter = mdates.ConciseDateFormatter(locator)
-    except AttributeError:
-        formatter = mdates.AutoDateFormatter(locator)
-    ax.xaxis.set_major_locator(locator)
-    ax.xaxis.set_major_formatter(formatter)
-
-    base_dt = times_dt[0]
-
-    def _to_seconds(x):
-        return (x - base_dt) * 86400.0
-
-    def _to_dates(x):
-        return base_dt + x / 86400.0
-
-    secax = ax.secondary_xaxis("top", functions=(_to_seconds, _to_dates))
-
-    def _sec_formatter(x, pos=None):
-        h = x / 3600.0
-        if h >= 1:
-            if abs(h - round(h)) < 1e-6:
-                return f"{int(x)} s ({int(h)} h)"
-            return f"{int(x)} s ({h:g} h)"
-        return f"{int(x)} s"
-
-    secax.xaxis.set_major_formatter(mticker.FuncFormatter(_sec_formatter))
-    secax.set_xlabel("Elapsed Time (s)")
+    configure_time_axes(ax, times_dt)
 
     if po214_activity is not None:
         po214_activity = np.asarray(po214_activity, dtype=float)
@@ -601,8 +575,6 @@ def plot_radon_activity_full(
         ax.legend(lines1 + lines2, labels1 + labels2, loc="best")
 
     plt.gcf().autofmt_xdate()
-    ax.xaxis.get_offset_text().set_visible(False)
-    secax.xaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
     targets = get_targets(config, out_png)
     for p in targets.values():
@@ -720,20 +692,13 @@ def plot_radon_trend_full(times, activity, out_png, config=None):
     palette = COLOR_SCHEMES.get(palette_name, COLOR_SCHEMES["default"])
     color = palette.get("radon_activity", "#9467bd")
     plt.plot(times_dt, activity, "o-", color=color)
-    plt.xlabel("Time")
+    plt.xlabel("Time (UTC)")
     plt.ylabel("Radon Activity (Bq)")
     plt.title("Radon Activity Trend")
 
     ax = plt.gca()
-    locator = mdates.AutoDateLocator()
-    try:
-        formatter = mdates.ConciseDateFormatter(locator)
-    except AttributeError:
-        formatter = mdates.AutoDateFormatter(locator)
-    ax.xaxis.set_major_locator(locator)
-    ax.xaxis.set_major_formatter(formatter)
+    configure_time_axes(ax, times_dt)
     plt.gcf().autofmt_xdate()
-    ax.xaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
 
     targets = get_targets(config, out_png)
@@ -757,15 +722,8 @@ def plot_radon_activity(ts_dict, outdir):
     plt.xlabel("Time (UTC)")
 
     ax = plt.gca()
-    locator = mdates.AutoDateLocator()
-    try:
-        formatter = mdates.ConciseDateFormatter(locator)
-    except AttributeError:
-        formatter = mdates.AutoDateFormatter(locator)
-    ax.xaxis.set_major_locator(locator)
-    ax.xaxis.set_major_formatter(formatter)
+    configure_time_axes(ax, times_dt)
     plt.gcf().autofmt_xdate()
-    ax.xaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
     plt.savefig(outdir / "radon_activity.png", dpi=300)
     plt.close()
@@ -787,15 +745,8 @@ def plot_radon_trend(ts_dict, outdir):
     plt.xlabel("Time (UTC)")
 
     ax = plt.gca()
-    locator = mdates.AutoDateLocator()
-    try:
-        formatter = mdates.ConciseDateFormatter(locator)
-    except AttributeError:
-        formatter = mdates.AutoDateFormatter(locator)
-    ax.xaxis.set_major_locator(locator)
-    ax.xaxis.set_major_formatter(formatter)
+    configure_time_axes(ax, times_dt)
     plt.gcf().autofmt_xdate()
-    ax.xaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
     plt.savefig(outdir / "radon_trend.png", dpi=300)
     plt.close()

--- a/plot_utils/radon.py
+++ b/plot_utils/radon.py
@@ -1,6 +1,11 @@
+from pathlib import Path
+from datetime import datetime
+
+import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import numpy as np
-from pathlib import Path
+
+from .time_axes import configure_time_axes
 
 
 def _save(fig, outdir: Path, name: str) -> None:
@@ -10,13 +15,17 @@ def _save(fig, outdir: Path, name: str) -> None:
 
 
 def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None) -> None:
-    t = np.asarray(ts_dict["time"])
-    a = np.asarray(ts_dict["activity"])
-    e = np.asarray(ts_dict["error"])
+    t = np.asarray(ts_dict["time"], dtype=float)
+    a = np.asarray(ts_dict["activity"], dtype=float)
+    e = np.asarray(ts_dict["error"], dtype=float)
+    times_dt = mdates.date2num([datetime.utcfromtimestamp(x) for x in t])
+
     fig, ax = plt.subplots()
-    ax.errorbar(t, a, yerr=e, fmt="o")
+    ax.errorbar(times_dt, a, yerr=e, fmt="o")
     ax.set_ylabel("Rn-222 activity [Bq]")
     ax.set_xlabel("Time (UTC)")
+    configure_time_axes(ax, times_dt)
+    fig.autofmt_xdate()
     if out_png is not None:
         fig.savefig(out_png, dpi=300)
         plt.close(fig)
@@ -25,17 +34,22 @@ def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None
 
 
 def plot_radon_trend(ts_dict, outdir: Path, out_png: str | Path | None = None) -> None:
-    t = np.asarray(ts_dict["time"])
-    a = np.asarray(ts_dict["activity"])
-    if t.size < 2:
+    t = np.asarray(ts_dict["time"], dtype=float)
+    a = np.asarray(ts_dict["activity"], dtype=float)
+    times_dt = mdates.date2num([datetime.utcfromtimestamp(x) for x in t])
+
+    if times_dt.size < 2:
         coeff = np.array([0.0, a[0] if a.size else 0.0])
     else:
-        coeff = np.polyfit(t, a, 1)
+        coeff = np.polyfit(times_dt, a, 1)
+
     fig, ax = plt.subplots()
-    ax.plot(t, a, "o")
-    ax.plot(t, np.polyval(coeff, t), label=f"slope={coeff[0]:.2e} Bq/s")
+    ax.plot(times_dt, a, "o")
+    ax.plot(times_dt, np.polyval(coeff, times_dt), label=f"slope={coeff[0]:.2e} Bq/s")
     ax.set_ylabel("Rn-222 activity [Bq]")
     ax.set_xlabel("Time (UTC)")
+    configure_time_axes(ax, times_dt)
+    fig.autofmt_xdate()
     ax.legend()
     if out_png is not None:
         fig.savefig(out_png, dpi=300)

--- a/plot_utils/time_axes.py
+++ b/plot_utils/time_axes.py
@@ -1,0 +1,41 @@
+import matplotlib.dates as mdates
+import matplotlib.ticker as mticker
+
+
+def configure_time_axes(ax, times_dt, *, label="Elapsed Time (h)"):
+    """Format bottom axis as datetimes and add elapsed-hours on top.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        Axis to format.
+    times_dt : array-like
+        Times expressed as Matplotlib datetimes (days since epoch).
+    label : str, optional
+        Label to use for the secondary elapsed-time axis.
+    """
+    locator = mdates.AutoDateLocator()
+    try:
+        formatter = mdates.ConciseDateFormatter(locator)
+    except AttributeError:  # pragma: no cover - old matplotlib
+        formatter = mdates.AutoDateFormatter(locator)
+    ax.xaxis.set_major_locator(locator)
+    ax.xaxis.set_major_formatter(formatter)
+
+    base = times_dt[0] if len(times_dt) else 0.0
+
+    def _to_hours(x):
+        return (x - base) * 24.0
+
+    def _to_dates(h):
+        return base + h / 24.0
+
+    secax = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
+    secax.set_xlabel(label)
+    secax.xaxis.set_major_formatter(
+        mticker.FuncFormatter(lambda h, _pos: f"{h:g}")
+    )
+
+    ax.xaxis.get_offset_text().set_visible(False)
+    secax.xaxis.get_offset_text().set_visible(False)
+    return secax

--- a/plotting.py
+++ b/plotting.py
@@ -5,6 +5,8 @@ import matplotlib.dates as mdates
 from datetime import datetime
 from pathlib import Path
 
+from plot_utils.time_axes import configure_time_axes
+
 __all__ = ["plot_radon_activity", "plot_radon_trend"]
 
 
@@ -26,14 +28,7 @@ def plot_radon_activity(ts, outdir):
     ax.set_ylabel("Radon activity [Bq]")
     ax.set_xlabel("Time (UTC)")
 
-    locator = mdates.AutoDateLocator()
-    try:
-        formatter = mdates.ConciseDateFormatter(locator)
-    except AttributeError:
-        formatter = mdates.AutoDateFormatter(locator)
-    ax.xaxis.set_major_locator(locator)
-    ax.xaxis.set_major_formatter(formatter)
-    ax.xaxis.get_offset_text().set_visible(False)
+    configure_time_axes(ax, times_dt)
     fig.autofmt_xdate()
     fig.tight_layout()
     fig.savefig(outdir / "radon_activity.png", dpi=300)
@@ -50,14 +45,7 @@ def plot_radon_trend(ts, outdir):
     ax.set_ylabel("Radon activity [Bq]")
     ax.set_xlabel("Time (UTC)")
 
-    locator = mdates.AutoDateLocator()
-    try:
-        formatter = mdates.ConciseDateFormatter(locator)
-    except AttributeError:
-        formatter = mdates.AutoDateFormatter(locator)
-    ax.xaxis.set_major_locator(locator)
-    ax.xaxis.set_major_formatter(formatter)
-    ax.xaxis.get_offset_text().set_visible(False)
+    configure_time_axes(ax, times_dt)
     fig.autofmt_xdate()
     fig.tight_layout()
     fig.savefig(outdir / "radon_trend.png", dpi=300)

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -823,7 +823,7 @@ def test_plot_radon_activity_axis_labels(tmp_path, monkeypatch):
     ax = plt.gca()
     assert ax.get_xlabel() == "Time (UTC)"
     assert "axis" in captured
-    assert captured["axis"].get_xlabel() == "Elapsed Time (s)"
+    assert captured["axis"].get_xlabel() == "Elapsed Time (h)"
 
 
 def test_plot_radon_activity_no_offset(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add `configure_time_axes` helper to render datetimes with elapsed-hour secondary axis
- update radon plotting utilities to use the new time-axis formatting
- adjust tests for new elapsed time units

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a112db4e44832b9ea05a4111643a7d