### PR TITLE
Handle S_bkg only for log-linear background

### DIFF
--- a/fitting.py
+++ b/fitting.py
@@ -360,16 +360,17 @@ def fit_spectrum(
     E_lo = float(edges[0])
     E_hi = float(edges[-1])
 
-    # Augment priors with a background amplitude if not provided
+    # Augment priors with a background amplitude only for log-linear model
     priors = dict(priors)
-    if "S_bkg" not in priors:
+    is_loglin = flags.get("background_model") == "loglin_unit"
+    if is_loglin and "S_bkg" not in priors:
         b0_mu = priors.get("b0", (0.0, 1.0))[0]
         b1_mu = priors.get("b1", (0.0, 1.0))[0]
         mu = b0_mu * (E_hi - E_lo) + 0.5 * b1_mu * (E_hi**2 - E_lo**2)
         mu = max(mu, 0.0)
         sig = max(abs(mu) * 0.1, 1.0)
         priors["S_bkg"] = (mu, sig)
-    if flags.get("background_model") == "loglin_unit":
+    if is_loglin:
         required = {"b0", "b1"}
         missing = required - priors.keys()
         if missing:
@@ -432,8 +433,9 @@ def fit_spectrum(
     param_order.append("b0")
     param_index["b1"] = len(param_order)
     param_order.append("b1")
-    param_index["S_bkg"] = len(param_order)
-    param_order.append("S_bkg")
+    if is_loglin:
+        param_index["S_bkg"] = len(param_order)
+        param_order.append("S_bkg")
 
     p0 = []
     bounds_lo, bounds_hi = [], []
@@ -474,8 +476,12 @@ def fit_spectrum(
         bounds_hi.append(hi)
 
     iso_list = ["Po210", "Po218", "Po214"]
-    area_keys = [f"S_{iso}" for iso in iso_list] + ["S_bkg"]
-    bkg_shape = _make_linear_bkg(E_lo, E_hi)
+    area_keys = [f"S_{iso}" for iso in iso_list]
+    if is_loglin:
+        area_keys.append("S_bkg")
+        bkg_shape = _make_linear_bkg(E_lo, E_hi)
+    else:
+        bkg_shape = None
 
     def _model_density(x, *params):
         if fix_sigma0:
@@ -503,9 +509,12 @@ def fit_spectrum(
                 y += S * gaussian(x, mu, sigma)
         beta0 = params[param_index["b0"]]
         beta1 = params[param_index["b1"]]
-        B_raw = params[param_index["S_bkg"]]
-        B = _softplus(B_raw)
-        y += B * bkg_shape(x, beta0, beta1)
+        if is_loglin:
+            B_raw = params[param_index["S_bkg"]]
+            B = _softplus(B_raw)
+            y += B * bkg_shape(x, beta0, beta1)
+        else:
+            y += beta0 + beta1 * x
         return np.clip(y, 1e-300, np.inf)
 
     def _model_binned(x, *params):

--- a/likelihood_ext.py
+++ b/likelihood_ext.py
@@ -29,8 +29,9 @@ def neg_loglike_extended(
     clip : float, optional
         Lower bound for the intensity to avoid ``log(0)``. Default is ``1e-300``.
     background_model : str, optional
-        Name of the background model. When set to ``"loglin_unit"`` required
-        background parameters are validated before evaluation.
+        Name of the background model. When set to ``"loglin_unit"`` an
+        additional background area parameter ``S_bkg`` must be supplied in
+        ``params``.
 
     Returns
     -------
@@ -50,15 +51,11 @@ def neg_loglike_extended(
     """
     E = np.asarray(E, dtype=float)
 
-    if background_model == "loglin_unit":
-        required = {"S_bkg", "beta0", "beta1"}
-        missing = required - params.keys()
-        if missing:
-            got = sorted(params.keys())
-            raise ValueError(
-                "background_model=loglin_unit requires params {S_bkg, beta0, beta1}; got: "
-                f"{got}"
-            )
+    if background_model == "loglin_unit" and "S_bkg" not in params:
+        got = sorted(params.keys())
+        raise ValueError(
+            "background_model=loglin_unit requires param S_bkg; got: " f"{got}"
+        )
 
     missing_areas = [k for k in area_keys if k not in params]
     if missing_areas:


### PR DESCRIPTION
## Summary
- Bootstrap and validate `S_bkg` only when using the `loglin_unit` background model
- Skip `S_bkg` injection for legacy linear backgrounds and adjust likelihood checks
- Add tests ensuring `S_bkg` appears only for log-linear background and that extended likelihood requires it

## Testing
- `pytest tests/test_fitting.py::test_loglin_unit_bootstraps_background tests/test_fitting.py::test_linear_background_does_not_add_S_bkg tests/test_fitting.py::test_extended_likelihood_requires_S_bkg_when_loglin tests/test_fitting.py::test_fit_spectrum_background_only_irregular_edges -q`
- `pytest tests/test_fitting.py::test_extended_likelihood_missing_area_key -q`

------
https://chatgpt.com/codex/tasks/task_e_68a112bad43c832bae336afd3381d5af