### PR TITLE
Skip overlays for invalid fits

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -268,9 +268,9 @@ def plot_radon_activity(times, activity, out_png, errors=None, *, config=None):
     return plot_radon_activity_full(times, activity, errors, out_png, config=config)
 
 
-def plot_radon_trend(times, activity, out_png, *, config=None):
+def plot_radon_trend(times, activity, out_png, *, config=None, fit_valid=True):
     """Wrapper used by tests expecting output path as third argument."""
-    return plot_radon_trend_full(times, activity, out_png, config=config)
+    return plot_radon_trend_full(times, activity, out_png, config=config, fit_valid=fit_valid)
 
 
 def _fit_params(obj: FitResult | Mapping[str, float] | None) -> FitParams:
@@ -3205,7 +3205,7 @@ def main(argv=None):
         if "Po214" in time_fit_results:
             fit_result = time_fit_results["Po214"]
             fit = _fit_params(fit_result)
-            if fit.get("fit_valid", True):
+            if fit.get("fit_valid", True) and fit.get("fit_valid_Po214", True):
                 E = fit.get("E_corrected", fit.get("E_Po214"))
                 dE = fit.get("dE_corrected", fit.get("dE_Po214", 0.0))
                 N0 = fit.get("N0_Po214", 0.0)
@@ -3227,7 +3227,7 @@ def main(argv=None):
         if "Po218" in time_fit_results:
             fit_result = time_fit_results["Po218"]
             fit = _fit_params(fit_result)
-            if fit.get("fit_valid", True):
+            if fit.get("fit_valid", True) and fit.get("fit_valid_Po218", True):
                 E = fit.get("E_corrected", fit.get("E_Po218"))
                 dE = fit.get("dE_corrected", fit.get("dE_Po218", 0.0))
                 N0 = fit.get("N0_Po218", 0.0)
@@ -3238,39 +3238,48 @@ def main(argv=None):
                     t_rel, E, dE, N0, dN0, hl, cov
                 )
 
-        activity_arr = np.zeros_like(times, dtype=float)
-        err_arr = np.zeros_like(times, dtype=float)
-        for i in range(times.size):
-            r214 = err214_i = None
-            if A214 is not None:
-                r214 = A214[i]
-                err214_i = dA214[i]
-            r218 = err218_i = None
-            if A218 is not None:
-                r218 = A218[i]
-                err218_i = dA218[i]
-            A, s = compute_radon_activity(
-                r218,
-                err218_i,
-                1.0,
-                r214,
-                err214_i,
-                1.0,
+        activity_arr = err_arr = None
+        if A214 is None and A218 is None:
+            if radon_results:
+                val = radon_results["radon_activity_Bq"]["value"]
+                unc = radon_results["radon_activity_Bq"]["uncertainty"]
+                activity_arr = np.full_like(times, val, dtype=float)
+                err_arr = np.full_like(times, unc, dtype=float)
+        else:
+            activity_arr = np.zeros_like(times, dtype=float)
+            err_arr = np.zeros_like(times, dtype=float)
+            for i in range(times.size):
+                r214 = err214_i = None
+                if A214 is not None:
+                    r214 = A214[i]
+                    err214_i = dA214[i]
+                r218 = err218_i = None
+                if A218 is not None:
+                    r218 = A218[i]
+                    err218_i = dA218[i]
+                A, s = compute_radon_activity(
+                    r218,
+                    err218_i,
+                    1.0,
+                    r214,
+                    err214_i,
+                    1.0,
+                )
+                activity_arr[i] = A
+                err_arr[i] = s
+
+            if np.all(activity_arr == 0) and radon_results:
+                activity_arr.fill(radon_results["radon_activity_Bq"]["value"])
+                err_arr.fill(radon_results["radon_activity_Bq"]["uncertainty"])
+
+        if activity_arr is not None and err_arr is not None:
+            plot_radon_activity(
+                times,
+                activity_arr,
+                Path(out_dir) / "radon_activity.png",
+                err_arr,
+                config=cfg.get("plotting", {}),
             )
-            activity_arr[i] = A
-            err_arr[i] = s
-
-        if np.all(activity_arr == 0):
-            activity_arr.fill(radon_results["radon_activity_Bq"]["value"])
-            err_arr.fill(radon_results["radon_activity_Bq"]["uncertainty"])
-
-        plot_radon_activity(
-            times,
-            activity_arr,
-            Path(out_dir) / "radon_activity.png",
-            err_arr,
-            config=cfg.get("plotting", {}),
-        )
 
         if radon_interval is not None:
             times_trend = np.linspace(
@@ -3284,7 +3293,7 @@ def main(argv=None):
             if "Po214" in time_fit_results:
                 fit_result = time_fit_results["Po214"]
                 fit = _fit_params(fit_result)
-                if fit.get("fit_valid", True):
+                if fit.get("fit_valid", True) and fit.get("fit_valid_Po214", True):
                     E214 = fit.get("E_corrected", fit.get("E_Po214"))
                     dE214 = fit.get("dE_corrected", fit.get("dE_Po214", 0.0))
                     N0214 = fit.get("N0_Po214", 0.0)
@@ -3298,7 +3307,7 @@ def main(argv=None):
             if "Po218" in time_fit_results:
                 fit_result = time_fit_results["Po218"]
                 fit = _fit_params(fit_result)
-                if fit.get("fit_valid", True):
+                if fit.get("fit_valid", True) and fit.get("fit_valid_Po218", True):
                     E218 = fit.get("E_corrected", fit.get("E_Po218"))
                     dE218 = fit.get("dE_corrected", fit.get("dE_Po218", 0.0))
                     N0218 = fit.get("N0_Po218", 0.0)
@@ -3308,18 +3317,19 @@ def main(argv=None):
                     A218_tr, _ = radon_activity_curve(
                         rel_trend, E218, dE218, N0218, dN0218, hl218, cov218
                     )
-            trend = np.zeros_like(times_trend)
-            for i in range(times_trend.size):
-                r214 = A214_tr[i] if A214_tr is not None else None
-                r218 = A218_tr[i] if A218_tr is not None else None
-                A, _ = compute_radon_activity(r218, None, 1.0, r214, None, 1.0)
-                trend[i] = A
-            plot_radon_trend(
-                times_trend,
-                trend,
-                Path(out_dir) / "radon_trend.png",
-                config=cfg.get("plotting", {}),
-            )
+            if A214_tr is not None or A218_tr is not None:
+                trend = np.zeros_like(times_trend)
+                for i in range(times_trend.size):
+                    r214 = A214_tr[i] if A214_tr is not None else None
+                    r218 = A218_tr[i] if A218_tr is not None else None
+                    A, _ = compute_radon_activity(r218, None, 1.0, r214, None, 1.0)
+                    trend[i] = A
+                plot_radon_trend(
+                    times_trend,
+                    trend,
+                    Path(out_dir) / "radon_trend.png",
+                    config=cfg.get("plotting", {}),
+                )
 
         ambient = cfg.get("analysis", {}).get("ambient_concentration")
         ambient_interp = None

--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -311,7 +311,10 @@ def plot_time_series(
         # itself is considered valid.  Invalid fits often yield unphysical
         # parameters which would lead to wildly incorrect model curves.
         has_fit = any(k in fit_results for k in (f"E_{iso}", "E"))
-        fit_ok = bool(fit_results.get("fit_valid", True))
+        fit_ok = bool(
+            fit_results.get("fit_valid", True)
+            and fit_results.get(f"fit_valid_{iso}", True)
+        )
         if has_fit and fit_ok:
             lam = np.log(2.0) / iso_params[iso]["half_life"]
             eff = iso_params[iso]["eff"]
@@ -665,6 +668,7 @@ def plot_modeled_radon_activity(
     config=None,
     *,
     overlay_po214=False,
+    fit_valid=True,
 ):
     """Compute and plot modeled Rn-222 activity over time.
 
@@ -677,6 +681,9 @@ def plot_modeled_radon_activity(
     overlay_po214 : bool, optional
         When ``True`` overlay the Po-214 activity for QC on a secondary axis.
     """
+    if not fit_valid:
+        return
+
     from radon_activity import radon_activity_curve
 
     lam_rn = math.log(2.0) / RN222.half_life_s
@@ -708,8 +715,10 @@ def plot_modeled_radon_activity(
     )
 
 
-def plot_radon_trend_full(times, activity, out_png, config=None):
+def plot_radon_trend_full(times, activity, out_png, config=None, *, fit_valid=True):
     """Plot modeled radon activity trend without uncertainties."""
+    if not fit_valid:
+        return
     times = np.asarray(times, dtype=float)
     activity = np.asarray(activity, dtype=float)
 

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -86,6 +86,42 @@ def test_plot_time_series_invalid_fit_skips_model(tmp_path, monkeypatch):
     assert not calls
 
 
+def test_plot_time_series_invalid_fit_po218_skips_model(tmp_path, monkeypatch):
+    times = np.array([1001.0, 1002.0, 1003.0])
+    energies = np.array([5.8, 5.9, 6.0])
+    out_png = tmp_path / "ts_invalid_po218.png"
+
+    calls: list[object] = []
+
+    def fake_plot(*args, **kwargs):
+        calls.append(object())
+        return [None]
+
+    monkeypatch.setattr(plot_utils.plt, "plot", fake_plot)
+
+    cfg = basic_config()
+    cfg.update({"window_po214": None, "window_po218": [5.5, 6.5]})
+    fit_vals = {
+        "E_Po218": 0.1,
+        "B_Po218": 0.0,
+        "N0_Po218": 0.0,
+        "fit_valid": True,
+        "fit_valid_Po218": False,
+    }
+    plot_time_series(
+        times,
+        energies,
+        fit_vals,
+        1000.0,
+        1005.0,
+        cfg,
+        str(out_png),
+    )
+
+    assert out_png.exists()
+    assert not calls
+
+
 def test_plot_time_series_auto_fd(tmp_path):
     # 100 uniform events over 5 seconds
     times = 1000.0 + np.linspace(0, 5, 100)
@@ -632,6 +668,47 @@ def test_plot_modeled_radon_activity_overlay(tmp_path):
     )
 
     assert out_png.exists()
+
+
+def test_plot_modeled_radon_activity_invalid_fit_skips_plot(tmp_path, monkeypatch):
+    times = np.array([0.0, 1.0, 2.0])
+    calls: list[object] = []
+
+    def fake_plot(*args, **kwargs):
+        calls.append(object())
+
+    monkeypatch.setattr("plot_utils.plot_radon_activity_full", fake_plot)
+
+    from plot_utils import plot_modeled_radon_activity
+
+    plot_modeled_radon_activity(
+        times,
+        1.0,
+        0.1,
+        2.0,
+        0.2,
+        str(tmp_path / "model_invalid.png"),
+        fit_valid=False,
+    )
+
+    assert not calls
+
+
+def test_plot_radon_trend_invalid_fit_skips_plot(tmp_path, monkeypatch):
+    times = np.array([0.0, 1.0, 2.0])
+    activity = np.array([1.0, 1.1, 1.2])
+    calls: list[object] = []
+
+    def fake_plot(*args, **kwargs):
+        calls.append(object())
+
+    monkeypatch.setattr(plot_utils.plt, "plot", fake_plot)
+
+    from plot_utils import plot_radon_trend_full
+
+    plot_radon_trend_full(times, activity, str(tmp_path / "trend.png"), fit_valid=False)
+
+    assert not calls
 def test_plot_radon_activity_multiple_formats(tmp_path):
     times = np.array([0.0, 1.0, 2.0])
     activity = np.array([1.0, 1.1, 1.2])


### PR DESCRIPTION
## Summary
- Avoid plotting time-series models for isotopes with invalid fits
- Stop projecting radon activity or trend when fits are flagged invalid
- Add tests that ensure invalid fits do not produce overlays

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a112bedb34832b938516b9c7afa5f3