### PR TITLE
Standardize radon plot time axes

### DIFF
--- a/plot_utils/radon.py
+++ b/plot_utils/radon.py
@@ -13,7 +13,16 @@ def _save(fig, outdir: Path, name: str) -> None:
 
 
 def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None) -> None:
-    t = np.asarray(ts_dict["time"], dtype=float)
+    ts_array = np.asarray(ts_dict["time"])
+    if np.issubdtype(ts_array.dtype, "datetime64"):
+        t = ts_array.astype("int64") / 1e9
+    elif np.issubdtype(ts_array.dtype, np.object_):
+        if ts_array.size > 0 and isinstance(ts_array.flat[0], datetime):
+            t = np.array([dt.timestamp() for dt in ts_array], dtype=float)
+        else:
+            t = ts_array.astype(float)
+    else:
+        t = ts_array.astype(float)
     a = np.asarray(ts_dict["activity"], dtype=float)
     e = np.asarray(ts_dict["error"], dtype=float)
     times_dt = mdates.date2num([datetime.utcfromtimestamp(tt) for tt in t])
@@ -45,6 +54,7 @@ def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None
 
     ax.xaxis.get_offset_text().set_visible(False)
     secax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.get_offset_text().set_visible(False)
     fig.autofmt_xdate()
     fig.tight_layout()
     if out_png is not None:
@@ -55,7 +65,16 @@ def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None
 
 
 def plot_radon_trend(ts_dict, outdir: Path, out_png: str | Path | None = None) -> None:
-    t = np.asarray(ts_dict["time"], dtype=float)
+    ts_array = np.asarray(ts_dict["time"])
+    if np.issubdtype(ts_array.dtype, "datetime64"):
+        t = ts_array.astype("int64") / 1e9
+    elif np.issubdtype(ts_array.dtype, np.object_):
+        if ts_array.size > 0 and isinstance(ts_array.flat[0], datetime):
+            t = np.array([dt.timestamp() for dt in ts_array], dtype=float)
+        else:
+            t = ts_array.astype(float)
+    else:
+        t = ts_array.astype(float)
     a = np.asarray(ts_dict["activity"], dtype=float)
     times_dt = mdates.date2num([datetime.utcfromtimestamp(tt) for tt in t])
     if times_dt.size < 2:
@@ -91,6 +110,7 @@ def plot_radon_trend(ts_dict, outdir: Path, out_png: str | Path | None = None) -
 
     ax.xaxis.get_offset_text().set_visible(False)
     secax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.get_offset_text().set_visible(False)
     fig.autofmt_xdate()
     fig.tight_layout()
     if out_png is not None:

--- a/plotting.py
+++ b/plotting.py
@@ -3,6 +3,7 @@ _mpl.use("Agg")
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 import matplotlib.ticker as mticker
+import numpy as np
 from datetime import datetime
 from pathlib import Path
 
@@ -21,8 +22,17 @@ def plot_radon_activity(ts, outdir):
     """
     outdir = Path(outdir)
     fig, ax = plt.subplots()
-    times = [datetime.utcfromtimestamp(t) for t in ts.time]
-    times_dt = mdates.date2num(times)
+    ts_array = np.asarray(ts.time)
+    if np.issubdtype(ts_array.dtype, "datetime64"):
+        times_s = ts_array.astype("int64") / 1e9
+    elif np.issubdtype(ts_array.dtype, np.object_):
+        if ts_array.size > 0 and isinstance(ts_array.flat[0], datetime):
+            times_s = np.array([dt.timestamp() for dt in ts_array], dtype=float)
+        else:
+            times_s = ts_array.astype(float)
+    else:
+        times_s = ts_array.astype(float)
+    times_dt = mdates.date2num([datetime.utcfromtimestamp(t) for t in times_s])
     ax.errorbar(times_dt, ts.activity, yerr=getattr(ts, "error", None), fmt="o")
     ax.set_ylabel("Radon activity [Bq]")
     ax.set_xlabel("Time (UTC)")
@@ -49,6 +59,7 @@ def plot_radon_activity(ts, outdir):
 
     ax.xaxis.get_offset_text().set_visible(False)
     secax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.get_offset_text().set_visible(False)
     fig.autofmt_xdate()
     fig.tight_layout()
     fig.savefig(outdir / "radon_activity.png", dpi=300)
@@ -59,8 +70,17 @@ def plot_radon_trend(ts, outdir):
     """Plot radon activity trend without uncertainties."""
     outdir = Path(outdir)
     fig, ax = plt.subplots()
-    times = [datetime.utcfromtimestamp(t) for t in ts.time]
-    times_dt = mdates.date2num(times)
+    ts_array = np.asarray(ts.time)
+    if np.issubdtype(ts_array.dtype, "datetime64"):
+        times_s = ts_array.astype("int64") / 1e9
+    elif np.issubdtype(ts_array.dtype, np.object_):
+        if ts_array.size > 0 and isinstance(ts_array.flat[0], datetime):
+            times_s = np.array([dt.timestamp() for dt in ts_array], dtype=float)
+        else:
+            times_s = ts_array.astype(float)
+    else:
+        times_s = ts_array.astype(float)
+    times_dt = mdates.date2num([datetime.utcfromtimestamp(t) for t in times_s])
     ax.plot(times_dt, ts.activity, "o-")
     ax.set_ylabel("Radon activity [Bq]")
     ax.set_xlabel("Time (UTC)")
@@ -87,6 +107,7 @@ def plot_radon_trend(ts, outdir):
 
     ax.xaxis.get_offset_text().set_visible(False)
     secax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.get_offset_text().set_visible(False)
     fig.autofmt_xdate()
     fig.tight_layout()
     fig.savefig(outdir / "radon_trend.png", dpi=300)

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -851,6 +851,7 @@ def test_plot_radon_activity_no_offset(tmp_path, monkeypatch):
     ax = plt.gca()
     assert not ax.xaxis.get_offset_text().get_visible()
     assert not captured["axis"].xaxis.get_offset_text().get_visible()
+    assert not ax.yaxis.get_offset_text().get_visible()
 
 
 def test_plot_radon_activity_full_no_offset(tmp_path, monkeypatch):
@@ -880,6 +881,7 @@ def test_plot_radon_activity_full_no_offset(tmp_path, monkeypatch):
     ax = plt.gca()
     assert not ax.xaxis.get_offset_text().get_visible()
     assert not captured["axis"].xaxis.get_offset_text().get_visible()
+    assert not ax.yaxis.get_offset_text().get_visible()
 
 
 def test_plot_time_series_uncertainty_band(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- show UTC datetimes on radon plots with a top axis of elapsed hours
- hide Matplotlib's scientific-notation offsets on both x-axes
- adjust tests for the new hour-based secondary axis

## Testing
- `pytest tests/test_plot_utils.py::test_plot_radon_activity_axis_labels tests/test_plot_utils.py::test_plot_radon_activity_no_offset tests/test_plot_utils.py::test_plot_radon_activity_full_no_offset`

------
https://chatgpt.com/codex/tasks/task_e_68a112db4e44832b9ea05a4111643a7d