### PR TITLE
Fix background regression and restore linear defaults

### DIFF
--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -272,7 +272,7 @@ def test_fit_spectrum_background_only_irregular_edges():
     }
 
     result = fit_spectrum(energies, priors, bin_edges=edges)
-    assert np.isclose(result.params["S_bkg"], 40.0, atol=0.1)
+    assert np.isclose(result.params["b0"], 10.0, atol=0.1)
 
 
 def test_model_binned_variable_width(monkeypatch):
@@ -720,7 +720,6 @@ def test_spectrum_tail_amplitude_stability():
         "S_Po214": (300, 30),
         "b0": (0.0, 1.0),
         "b1": (0.0, 1.0),
-        "S_bkg": (0.0, 100.0),
     }
 
     res = fit_spectrum(energies, priors, unbinned=True)


### PR DESCRIPTION
## Summary
- keep default background model linear
- restrict S_bkg prior and parameter handling to `loglin_unit` background
- update tests for background-only fit and tail amplitude stability

## Testing
- `pytest tests/test_fitting.py::test_spectrum_tail_amplitude_stability tests/test_fitting.py::test_fit_spectrum_background_only_irregular_edges -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a12ed33788832ba9cf42896ea28031