### PR TITLE
Restore linear background defaults and guard S_bkg usage

### DIFF
--- a/feature_selectors.py
+++ b/feature_selectors.py
@@ -40,7 +40,7 @@ def select_background_factory(opts: Any, Emin: float, Emax: float) -> Callable:
         shape = make_linear_bkg(Emin, Emax)
 
         def bkg(E, params):
-            val = shape(E, params["beta0"], params["beta1"])
+            val = shape(E, params["b0"], params["b1"])
             return softplus(params["S_bkg"]) * val
 
         return bkg

--- a/likelihood_ext.py
+++ b/likelihood_ext.py
@@ -51,12 +51,12 @@ def neg_loglike_extended(
     E = np.asarray(E, dtype=float)
 
     if background_model == "loglin_unit":
-        required = {"S_bkg", "beta0", "beta1"}
+        required = {"S_bkg", "b0", "b1"}
         missing = required - params.keys()
         if missing:
             got = sorted(params.keys())
             raise ValueError(
-                "background_model=loglin_unit requires params {S_bkg, beta0, beta1}; got: "
+                "background_model=loglin_unit requires params {S_bkg, b0, b1}; got: "
                 f"{got}"
             )
 

--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -474,12 +474,13 @@ def plot_spectrum(
         sigma_E = fit_vals.get("sigma_E", 1.0)
         b0 = fit_vals.get("b0", 0.0)
         b1 = fit_vals.get("b1", 0.0)
-        S_bkg = fit_vals.get("S_bkg", 0.0)
         bkg_cent = b0 + b1 * centers
         bkg_norm = b0 * (edges[-1] - edges[0]) + 0.5 * b1 * (edges[-1] ** 2 - edges[0] ** 2)
         y_cent = np.zeros_like(centers)
-        if bkg_norm > 0:
-            y_cent += S_bkg * bkg_cent / bkg_norm
+        if "S_bkg" in fit_vals and bkg_norm > 0:
+            y_cent += fit_vals["S_bkg"] * bkg_cent / bkg_norm
+        else:
+            y_cent += bkg_cent
         for pk in ("Po210", "Po218", "Po214"):
             mu_key = f"mu_{pk}"
             amp_key = f"S_{pk}"

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -272,7 +272,10 @@ def test_fit_spectrum_background_only_irregular_edges():
     }
 
     result = fit_spectrum(energies, priors, bin_edges=edges)
-    assert np.isclose(result.params["S_bkg"], 40.0, atol=0.1)
+    b0 = result.params["b0"]
+    b1 = result.params["b1"]
+    total = b0 * (edges[-1] - edges[0]) + 0.5 * b1 * (edges[-1] ** 2 - edges[0] ** 2)
+    assert np.isclose(total, 40.0, atol=0.1)
 
 
 def test_model_binned_variable_width(monkeypatch):

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -222,7 +222,7 @@ def test_plot_spectrum_irregular_edges_residuals(tmp_path, monkeypatch):
     monkeypatch.setattr(matplotlib.axes.Axes, "bar", fake_bar)
     monkeypatch.setattr("plot_utils.plt.savefig", lambda *a, **k: None)
 
-    fit_vals = {"b0": 10.0, "b1": 0.0, "S_bkg": 40.0}
+    fit_vals = {"b0": 10.0, "b1": 0.0}
     plot_spectrum(
         energies,
         fit_vals=fit_vals,
@@ -233,12 +233,7 @@ def test_plot_spectrum_irregular_edges_residuals(tmp_path, monkeypatch):
     hist, _ = np.histogram(energies, bins=edges)
     width = np.diff(edges)
     centers = edges[:-1] + width / 2.0
-    norm = fit_vals["b0"] * (edges[-1] - edges[0]) + 0.5 * fit_vals["b1"] * (
-        edges[-1] ** 2 - edges[0] ** 2
-    )
-    model_counts = (
-        fit_vals["S_bkg"] * (fit_vals["b0"] + fit_vals["b1"] * centers) / norm * width
-    )
+    model_counts = (fit_vals["b0"] + fit_vals["b1"] * centers) * width
     expected = hist - model_counts
 
     assert len(captured) >= 2


### PR DESCRIPTION
## Summary
- keep linear background as the default fit path
- only bootstrap and require `S_bkg` when using `loglin_unit` or explicitly provided
- update plotting and helpers for optional background amplitude

## Testing
- `pytest tests/test_fitting.py::test_spectrum_tail_amplitude_stability -q`
- `pytest tests/test_fitting.py::test_fit_spectrum_background_only_irregular_edges -q`
- `pytest tests/test_plot_utils.py::test_plot_spectrum_irregular_edges_residuals -q`
- `pytest tests/test_fitting.py::test_loglin_unit_bootstraps_background -q`


------
https://chatgpt.com/codex/tasks/task_e_68a12ed33788832ba9cf42896ea28031