### PR TITLE
Normalize radon time axis handling

### DIFF
--- a/plot_utils/_time_utils.py
+++ b/plot_utils/_time_utils.py
@@ -1,0 +1,73 @@
+"""Internal helpers for time axis formatting and conversions."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable
+
+import matplotlib.dates as mdates
+import matplotlib.ticker as mticker
+import numpy as np
+
+
+def to_mpl_times(times: Iterable) -> np.ndarray:
+    """Convert an array-like of times to Matplotlib date numbers.
+
+    Parameters
+    ----------
+    times : Iterable
+        Sequence of epoch seconds, :class:`numpy.datetime64`, or
+        :class:`datetime.datetime` objects.
+
+    Returns
+    -------
+    np.ndarray
+        Array of floats suitable for Matplotlib time plotting.
+    """
+
+    arr = np.asarray(list(times))
+    if np.issubdtype(arr.dtype, np.datetime64):
+        secs = arr.astype("datetime64[s]").astype(np.int64).astype(float)
+    elif arr.dtype == object:
+        secs_list: list[float] = []
+        for t in arr:
+            if isinstance(t, datetime):
+                secs_list.append(t.timestamp())
+            elif isinstance(t, np.datetime64):
+                secs_list.append(float(t.astype("datetime64[s]").astype(np.int64)))
+            else:
+                secs_list.append(float(t))
+        secs = np.array(secs_list, dtype=float)
+    else:
+        secs = arr.astype(float)
+    # mdates.epoch2num is not available in older Matplotlib versions,
+    # so perform the conversion manually: seconds to days since 1970-01-01.
+    epoch = mdates.date2num(datetime(1970, 1, 1))
+    return secs / 86400.0 + epoch
+
+
+def setup_time_axis(ax, times_mpl: np.ndarray):
+    """Apply UTC date labels and elapsed-hour secondary axis."""
+    locator = mdates.AutoDateLocator()
+    try:  # Concise formatter is available on newer Matplotlib
+        formatter = mdates.ConciseDateFormatter(locator)
+    except AttributeError:  # pragma: no cover - fallback for old MPL
+        formatter = mdates.AutoDateFormatter(locator)
+    ax.xaxis.set_major_locator(locator)
+    ax.xaxis.set_major_formatter(formatter)
+
+    base = times_mpl[0]
+
+    def _to_hours(x):
+        return (x - base) * 24.0
+
+    def _to_dates(x):
+        return base + x / 24.0
+
+    secax = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
+    secax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda x, pos=None: f"{x:g}"))
+    secax.set_xlabel("Elapsed Time (h)")
+
+    ax.xaxis.get_offset_text().set_visible(False)
+    secax.xaxis.get_offset_text().set_visible(False)
+    return secax

--- a/plot_utils/radon.py
+++ b/plot_utils/radon.py
@@ -1,9 +1,8 @@
 import matplotlib.pyplot as plt
-import matplotlib.dates as mdates
-import matplotlib.ticker as mticker
 import numpy as np
-from datetime import datetime
 from pathlib import Path
+
+from ._time_utils import setup_time_axis, to_mpl_times
 
 
 def _save(fig, outdir: Path, name: str) -> None:
@@ -13,40 +12,17 @@ def _save(fig, outdir: Path, name: str) -> None:
 
 
 def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None) -> None:
-    t = np.asarray(ts_dict["time"], dtype=float)
-    a = np.asarray(ts_dict["activity"], dtype=float)
-    e = np.asarray(ts_dict["error"], dtype=float)
-    times_dt = mdates.date2num([datetime.utcfromtimestamp(x) for x in t])
+    times_mpl = to_mpl_times(ts_dict["time"])
+    activity = np.asarray(ts_dict["activity"], dtype=float)
+    errors = np.asarray(ts_dict["error"], dtype=float)
     fig, ax = plt.subplots()
-    ax.errorbar(times_dt, a, yerr=e, fmt="o")
+    ax.errorbar(times_mpl, activity, yerr=errors, fmt="o")
     ax.set_ylabel("Rn-222 activity [Bq]")
     ax.set_xlabel("Time (UTC)")
     ax.ticklabel_format(axis="y", style="plain")
-
-    locator = mdates.AutoDateLocator()
-    try:
-        formatter = mdates.ConciseDateFormatter(locator)
-    except AttributeError:
-        formatter = mdates.AutoDateFormatter(locator)
-    ax.xaxis.set_major_locator(locator)
-    ax.xaxis.set_major_formatter(formatter)
-
-    base_dt = times_dt[0]
-
-    def _to_hours(x):
-        return (x - base_dt) * 24.0
-
-    def _to_dates(x):
-        return base_dt + x / 24.0
-
-    secax = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
-    secax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda x, pos=None: f"{x:g}"))
-    secax.set_xlabel("Elapsed Time (h)")
-
+    setup_time_axis(ax, times_mpl)
     fig.autofmt_xdate()
-    ax.xaxis.get_offset_text().set_visible(False)
     ax.yaxis.get_offset_text().set_visible(False)
-    secax.xaxis.get_offset_text().set_visible(False)
     if out_png is not None:
         fig.savefig(out_png, dpi=300)
         plt.close(fig)
@@ -55,45 +31,22 @@ def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None
 
 
 def plot_radon_trend(ts_dict, outdir: Path, out_png: str | Path | None = None) -> None:
-    t = np.asarray(ts_dict["time"], dtype=float)
-    a = np.asarray(ts_dict["activity"], dtype=float)
-    times_dt = mdates.date2num([datetime.utcfromtimestamp(x) for x in t])
-    if times_dt.size < 2:
-        coeff = np.array([0.0, a[0] if a.size else 0.0])
+    times_mpl = to_mpl_times(ts_dict["time"])
+    activity = np.asarray(ts_dict["activity"], dtype=float)
+    if times_mpl.size < 2:
+        coeff = np.array([0.0, activity[0] if activity.size else 0.0])
     else:
-        coeff = np.polyfit(times_dt, a, 1)
+        coeff = np.polyfit(times_mpl, activity, 1)
     fig, ax = plt.subplots()
-    ax.plot(times_dt, a, "o")
-    ax.plot(times_dt, np.polyval(coeff, times_dt), label=f"slope={coeff[0]:.2e} Bq/s")
+    ax.plot(times_mpl, activity, "o")
+    ax.plot(times_mpl, np.polyval(coeff, times_mpl), label=f"slope={coeff[0]:.2e} Bq/s")
     ax.set_ylabel("Rn-222 activity [Bq]")
     ax.set_xlabel("Time (UTC)")
     ax.ticklabel_format(axis="y", style="plain")
     ax.legend()
-
-    locator = mdates.AutoDateLocator()
-    try:
-        formatter = mdates.ConciseDateFormatter(locator)
-    except AttributeError:
-        formatter = mdates.AutoDateFormatter(locator)
-    ax.xaxis.set_major_locator(locator)
-    ax.xaxis.set_major_formatter(formatter)
-
-    base_dt = times_dt[0]
-
-    def _to_hours(x):
-        return (x - base_dt) * 24.0
-
-    def _to_dates(x):
-        return base_dt + x / 24.0
-
-    secax = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
-    secax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda x, pos=None: f"{x:g}"))
-    secax.set_xlabel("Elapsed Time (h)")
-
+    setup_time_axis(ax, times_mpl)
     fig.autofmt_xdate()
-    ax.xaxis.get_offset_text().set_visible(False)
     ax.yaxis.get_offset_text().set_visible(False)
-    secax.xaxis.get_offset_text().set_visible(False)
     if out_png is not None:
         fig.savefig(out_png, dpi=300)
         plt.close(fig)


### PR DESCRIPTION
## Summary
- add shared helpers to normalize mixed timestamp inputs and configure time axes
- standardize radon time plots to use the helpers with UTC and elapsed-hour labels

## Testing
- `pytest tests/test_plot_utils.py -q`
- `pytest tests/test_time_series_po210_plot.py::test_plot_time_series_po210_png -q`


------
https://chatgpt.com/codex/tasks/task_e_68a12ef66ee4832ba6977005668d2594