### PR TITLE
Normalize time handling for radon plots

### DIFF
--- a/plot_utils/time_axis.py
+++ b/plot_utils/time_axis.py
@@ -1,0 +1,64 @@
+import numpy as np
+import matplotlib.dates as mdates
+import matplotlib.ticker as mticker
+from datetime import datetime, timezone
+from typing import Sequence
+
+__all__ = ["to_mpl_times", "setup_time_axis"]
+
+def to_mpl_times(times: Sequence) -> np.ndarray:
+    """Convert an array of time values to Matplotlib's numeric format.
+
+    Parameters
+    ----------
+    times : sequence of float, numpy.datetime64, or datetime.datetime
+        Input time values. Floats are interpreted as seconds since the UNIX epoch.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of floats suitable for plotting with Matplotlib's date functions.
+    """
+    arr = np.asarray(list(times))
+    if arr.size == 0:
+        return arr.astype(float)
+    if np.issubdtype(arr.dtype, np.datetime64):
+        seconds = arr.astype("datetime64[s]").astype(int)
+    else:
+        first = arr.flat[0]
+        if isinstance(first, datetime):
+            seconds = np.array(
+                [
+                    (t if t.tzinfo is None else t.astimezone(timezone.utc))
+                    .replace(tzinfo=timezone.utc)
+                    .timestamp()
+                    for t in arr
+                ],
+                dtype=float,
+            )
+        else:
+            seconds = arr.astype(float)
+    datetimes = [datetime.utcfromtimestamp(float(s)) for s in seconds]
+    return mdates.date2num(datetimes)
+
+def setup_time_axis(ax, times_mpl: np.ndarray) -> None:
+    """Configure ``ax`` with UTC dates and elapsed hours secondary axis."""
+    locator = mdates.AutoDateLocator()
+    try:
+        formatter = mdates.ConciseDateFormatter(locator)
+    except AttributeError:
+        formatter = mdates.AutoDateFormatter(locator)
+    ax.xaxis.set_major_locator(locator)
+    ax.xaxis.set_major_formatter(formatter)
+    base = times_mpl[0]
+    def _to_hours(x):
+        return (x - base) * 24.0
+    def _to_dates(x):
+        return base + x / 24.0
+    secax = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
+    secax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda x, pos=None: f"{x:g}"))
+    secax.set_xlabel("Elapsed Time (h)")
+    ax.xaxis.get_offset_text().set_visible(False)
+    secax.xaxis.get_offset_text().set_visible(False)
+    return secax
+

--- a/plotting.py
+++ b/plotting.py
@@ -1,10 +1,9 @@
 import matplotlib as _mpl
 _mpl.use("Agg")
 import matplotlib.pyplot as plt
-import matplotlib.dates as mdates
-import matplotlib.ticker as mticker
-from datetime import datetime
 from pathlib import Path
+
+from plot_utils.time_axis import to_mpl_times, setup_time_axis
 
 __all__ = ["plot_radon_activity", "plot_radon_trend"]
 
@@ -21,36 +20,14 @@ def plot_radon_activity(ts, outdir):
     """
     outdir = Path(outdir)
     fig, ax = plt.subplots()
-    times = [datetime.utcfromtimestamp(t) for t in ts.time]
-    times_dt = mdates.date2num(times)
-    ax.errorbar(times_dt, ts.activity, yerr=getattr(ts, "error", None), fmt="o")
+    times_mpl = to_mpl_times(ts.time)
+    ax.errorbar(times_mpl, ts.activity, yerr=getattr(ts, "error", None), fmt="o")
     ax.set_ylabel("Radon activity [Bq]")
     ax.set_xlabel("Time (UTC)")
     ax.ticklabel_format(axis="y", style="plain")
 
-    locator = mdates.AutoDateLocator()
-    try:
-        formatter = mdates.ConciseDateFormatter(locator)
-    except AttributeError:
-        formatter = mdates.AutoDateFormatter(locator)
-    ax.xaxis.set_major_locator(locator)
-    ax.xaxis.set_major_formatter(formatter)
-
-    base_dt = times_dt[0]
-
-    def _to_hours(x):
-        return (x - base_dt) * 24.0
-
-    def _to_dates(x):
-        return base_dt + x / 24.0
-
-    secax = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
-    secax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda x, pos=None: f"{x:g}"))
-    secax.set_xlabel("Elapsed Time (h)")
-
-    ax.xaxis.get_offset_text().set_visible(False)
+    setup_time_axis(ax, times_mpl)
     ax.yaxis.get_offset_text().set_visible(False)
-    secax.xaxis.get_offset_text().set_visible(False)
     fig.autofmt_xdate()
     fig.tight_layout()
     fig.savefig(outdir / "radon_activity.png", dpi=300)
@@ -61,36 +38,14 @@ def plot_radon_trend(ts, outdir):
     """Plot radon activity trend without uncertainties."""
     outdir = Path(outdir)
     fig, ax = plt.subplots()
-    times = [datetime.utcfromtimestamp(t) for t in ts.time]
-    times_dt = mdates.date2num(times)
-    ax.plot(times_dt, ts.activity, "o-")
+    times_mpl = to_mpl_times(ts.time)
+    ax.plot(times_mpl, ts.activity, "o-")
     ax.set_ylabel("Radon activity [Bq]")
     ax.set_xlabel("Time (UTC)")
     ax.ticklabel_format(axis="y", style="plain")
 
-    locator = mdates.AutoDateLocator()
-    try:
-        formatter = mdates.ConciseDateFormatter(locator)
-    except AttributeError:
-        formatter = mdates.AutoDateFormatter(locator)
-    ax.xaxis.set_major_locator(locator)
-    ax.xaxis.set_major_formatter(formatter)
-
-    base_dt = times_dt[0]
-
-    def _to_hours(x):
-        return (x - base_dt) * 24.0
-
-    def _to_dates(x):
-        return base_dt + x / 24.0
-
-    secax = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
-    secax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda x, pos=None: f"{x:g}"))
-    secax.set_xlabel("Elapsed Time (h)")
-
-    ax.xaxis.get_offset_text().set_visible(False)
+    setup_time_axis(ax, times_mpl)
     ax.yaxis.get_offset_text().set_visible(False)
-    secax.xaxis.get_offset_text().set_visible(False)
     fig.autofmt_xdate()
     fig.tight_layout()
     fig.savefig(outdir / "radon_trend.png", dpi=300)


### PR DESCRIPTION
## Summary
- add shared helpers to convert timestamps and configure dual time axes
- refactor radon time-series plots to use canonical `times_mpl` array
- support datetime inputs and suppress y-axis offsets across radon plots

## Testing
- `pytest tests/test_plot_utils.py`
- `pytest tests/test_time_series_po210_plot.py::test_plot_time_series_po210_png`


------
https://chatgpt.com/codex/tasks/task_e_68a12ef66ee4832ba6977005668d2594