### PR TITLE
Validate resolution conflict in configs

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -354,6 +354,12 @@ def load_config(config_path):
     else:
         val = bool(emg_cfg)
         spec["use_emg"] = {iso: val for iso in default_emg}
+
+    # Validation: cannot both float resolution and fix sigma0
+    if spec.get("float_sigma_E") and spec.get("fix_sigma0"):
+        raise ValueError(
+            "Configuration error: cannot float energy resolution while fixing sigma0"
+        )
     # CONFIG_SCHEMA validation already checks required keys
 
     return cfg

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -514,3 +514,24 @@ def test_load_config_unknown_key(tmp_path):
     with pytest.raises(jsonschema.exceptions.ValidationError):
         load_config(p)
 
+
+def test_load_config_resolution_conflict(tmp_path):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "spectral_fit": {
+            "expected_peaks": {"Po210": 1},
+            "float_sigma_E": True,
+            "fix_sigma0": True,
+        },
+        "time_fit": {"do_time_fit": True},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    p = tmp_path / "cfg.yaml"
+    with open(p, "w") as f:
+        json.dump(cfg, f)
+    with pytest.raises(
+        ValueError, match="cannot float energy resolution while fixing sigma0"
+    ):
+        load_config(p)
+


### PR DESCRIPTION
## Summary
- prevent configuration from floating energy resolution while fixing sigma0
- test failure when both resolution floating and sigma0 fixing are requested

## Testing
- `pytest tests/test_io_utils.py::test_load_config_resolution_conflict -q`

------
https://chatgpt.com/codex/tasks/task_e_68a159944378832b9f40d3ff81a7013c