### PR TITLE
Add resolution flag conflict validation

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -354,6 +354,13 @@ def load_config(config_path):
     else:
         val = bool(emg_cfg)
         spec["use_emg"] = {iso: val for iso in default_emg}
+    # Validate resolution settings
+    float_sigma_E = spec.get("float_sigma_E", True)
+    fix_sigma0 = spec.get("flags", {}).get("fix_sigma0", False)
+    if float_sigma_E and fix_sigma0:
+        raise ValueError(
+            "Resolution flags conflict: cannot float energy resolution while fixing sigma0"
+        )
     # CONFIG_SCHEMA validation already checks required keys
 
     return cfg

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -68,6 +68,24 @@ def test_load_config_missing_section(tmp_path):
         load_config(p)
 
 
+def test_load_config_resolution_conflict(tmp_path):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "spectral_fit": {
+            "float_sigma_E": True,
+            "flags": {"fix_sigma0": True},
+        },
+        "time_fit": {"do_time_fit": True},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    p = tmp_path / "cfg.yaml"
+    with open(p, "w") as f:
+        json.dump(cfg, f)
+    with pytest.raises(ValueError):
+        load_config(p)
+
+
 def test_load_events(tmp_path, caplog):
     df = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- ensure configs can't float energy resolution when sigma0 is fixed
- add unit test for resolution conflict check

## Testing
- `pytest tests/test_io_utils.py::test_load_config_resolution_conflict -q`


------
https://chatgpt.com/codex/tasks/task_e_68a159944378832b9f40d3ff81a7013c