### PR TITLE
Normalize time-axis handling across plot utilities

### DIFF
--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -254,7 +254,7 @@ def plot_time_series(
         edges = np.linspace(0, (t_end - t_start), n_bins + 1)
     centers = 0.5 * (edges[:-1] + edges[1:])
     centers_abs = t_start + centers
-    centers_dt = mdates.date2num([datetime.utcfromtimestamp(t) for t in centers_abs])
+    centers_mpl = to_mpl_times(centers_abs)
     bin_widths = np.diff(edges)
 
     # Optional normalisation to counts / s (set in config)
@@ -288,7 +288,7 @@ def plot_time_series(
         style = str(config.get("plot_time_style", "steps")).lower()
         if style == "lines":
             plt.plot(
-                centers_dt,
+                centers_mpl,
                 counts_iso,
                 marker="o",
                 linestyle="-",
@@ -297,7 +297,7 @@ def plot_time_series(
             )
         else:
             plt.step(
-                centers_dt,
+                centers_mpl,
                 counts_iso,
                 where="mid",
                 color=colors[iso],
@@ -334,7 +334,7 @@ def plot_time_series(
             # Convert rate (counts/s) to expected counts per bin if not normalising
             model_counts = r_rel if normalise_rate else r_rel * bin_widths
             plt.plot(
-                centers_dt,
+                centers_mpl,
                 model_counts,
                 color=colors[iso],
                 lw=2,
@@ -346,7 +346,7 @@ def plot_time_series(
                 if err.size == model_counts.size:
                     kw = {"step": "mid"} if style != "lines" else {}
                     plt.fill_between(
-                        centers_dt,
+                        centers_mpl,
                         model_counts - err,
                         model_counts + err,
                         color=colors[iso],

--- a/plotting.py
+++ b/plotting.py
@@ -1,10 +1,9 @@
 import matplotlib as _mpl
 _mpl.use("Agg")
 import matplotlib.pyplot as plt
-import matplotlib.dates as mdates
-import matplotlib.ticker as mticker
-from datetime import datetime
 from pathlib import Path
+
+from plot_utils import setup_time_axis, to_mpl_times
 
 __all__ = ["plot_radon_activity", "plot_radon_trend"]
 
@@ -21,36 +20,14 @@ def plot_radon_activity(ts, outdir):
     """
     outdir = Path(outdir)
     fig, ax = plt.subplots()
-    times = [datetime.utcfromtimestamp(t) for t in ts.time]
-    times_dt = mdates.date2num(times)
-    ax.errorbar(times_dt, ts.activity, yerr=getattr(ts, "error", None), fmt="o")
+    times_mpl = to_mpl_times(ts.time)
+    ax.errorbar(times_mpl, ts.activity, yerr=getattr(ts, "error", None), fmt="o")
     ax.set_ylabel("Radon activity [Bq]")
     ax.set_xlabel("Time (UTC)")
     ax.ticklabel_format(axis="y", style="plain")
 
-    locator = mdates.AutoDateLocator()
-    try:
-        formatter = mdates.ConciseDateFormatter(locator)
-    except AttributeError:
-        formatter = mdates.AutoDateFormatter(locator)
-    ax.xaxis.set_major_locator(locator)
-    ax.xaxis.set_major_formatter(formatter)
-
-    base_dt = times_dt[0]
-
-    def _to_hours(x):
-        return (x - base_dt) * 24.0
-
-    def _to_dates(x):
-        return base_dt + x / 24.0
-
-    secax = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
-    secax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda x, pos=None: f"{x:g}"))
-    secax.set_xlabel("Elapsed Time (h)")
-
-    ax.xaxis.get_offset_text().set_visible(False)
+    setup_time_axis(ax, times_mpl)
     ax.yaxis.get_offset_text().set_visible(False)
-    secax.xaxis.get_offset_text().set_visible(False)
     fig.autofmt_xdate()
     fig.tight_layout()
     fig.savefig(outdir / "radon_activity.png", dpi=300)
@@ -61,36 +38,14 @@ def plot_radon_trend(ts, outdir):
     """Plot radon activity trend without uncertainties."""
     outdir = Path(outdir)
     fig, ax = plt.subplots()
-    times = [datetime.utcfromtimestamp(t) for t in ts.time]
-    times_dt = mdates.date2num(times)
-    ax.plot(times_dt, ts.activity, "o-")
+    times_mpl = to_mpl_times(ts.time)
+    ax.plot(times_mpl, ts.activity, "o-")
     ax.set_ylabel("Radon activity [Bq]")
     ax.set_xlabel("Time (UTC)")
     ax.ticklabel_format(axis="y", style="plain")
 
-    locator = mdates.AutoDateLocator()
-    try:
-        formatter = mdates.ConciseDateFormatter(locator)
-    except AttributeError:
-        formatter = mdates.AutoDateFormatter(locator)
-    ax.xaxis.set_major_locator(locator)
-    ax.xaxis.set_major_formatter(formatter)
-
-    base_dt = times_dt[0]
-
-    def _to_hours(x):
-        return (x - base_dt) * 24.0
-
-    def _to_dates(x):
-        return base_dt + x / 24.0
-
-    secax = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
-    secax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda x, pos=None: f"{x:g}"))
-    secax.set_xlabel("Elapsed Time (h)")
-
-    ax.xaxis.get_offset_text().set_visible(False)
+    setup_time_axis(ax, times_mpl)
     ax.yaxis.get_offset_text().set_visible(False)
-    secax.xaxis.get_offset_text().set_visible(False)
     fig.autofmt_xdate()
     fig.tight_layout()
     fig.savefig(outdir / "radon_trend.png", dpi=300)


### PR DESCRIPTION
## Summary
- Use `to_mpl_times` and `setup_time_axis` for time conversion and axis formatting in plotting helpers
- Replace manual date conversions with `to_mpl_times` and unify naming to `centers_mpl`

## Testing
- `pytest tests/test_plot_utils.py::test_plot_radon_activity_output -q`
- `pytest tests/test_plot_utils.py::test_plot_radon_trend_output -q`
- `pytest tests/test_plot_utils.py::test_plot_radon_activity_no_offset -q`
- `pytest tests/test_plot_utils.py::test_plot_time_series_datetime64 -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1599fc950832b9b4c2ea2f0a60292