### PR TITLE
refactor: unify time axis helpers

### DIFF
--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -8,7 +8,6 @@ import matplotlib as _mpl
 
 _mpl.use("Agg")
 import matplotlib.pyplot as plt
-import matplotlib.dates as mdates
 import math
 from datetime import datetime
 from pathlib import Path
@@ -254,7 +253,7 @@ def plot_time_series(
         edges = np.linspace(0, (t_end - t_start), n_bins + 1)
     centers = 0.5 * (edges[:-1] + edges[1:])
     centers_abs = t_start + centers
-    centers_dt = mdates.date2num([datetime.utcfromtimestamp(t) for t in centers_abs])
+    centers_mpl = to_mpl_times(centers_abs)
     bin_widths = np.diff(edges)
 
     # Optional normalisation to counts / s (set in config)
@@ -288,7 +287,7 @@ def plot_time_series(
         style = str(config.get("plot_time_style", "steps")).lower()
         if style == "lines":
             plt.plot(
-                centers_dt,
+                centers_mpl,
                 counts_iso,
                 marker="o",
                 linestyle="-",
@@ -297,7 +296,7 @@ def plot_time_series(
             )
         else:
             plt.step(
-                centers_dt,
+                centers_mpl,
                 counts_iso,
                 where="mid",
                 color=colors[iso],
@@ -334,7 +333,7 @@ def plot_time_series(
             # Convert rate (counts/s) to expected counts per bin if not normalising
             model_counts = r_rel if normalise_rate else r_rel * bin_widths
             plt.plot(
-                centers_dt,
+                centers_mpl,
                 model_counts,
                 color=colors[iso],
                 lw=2,
@@ -346,7 +345,7 @@ def plot_time_series(
                 if err.size == model_counts.size:
                     kw = {"step": "mid"} if style != "lines" else {}
                     plt.fill_between(
-                        centers_dt,
+                        centers_mpl,
                         model_counts - err,
                         model_counts + err,
                         color=colors[iso],
@@ -356,7 +355,7 @@ def plot_time_series(
                 else:
                     raise ValueError("model_errors array length mismatch")
 
-    plt.xlabel("Time")
+    plt.xlabel("Time (UTC)")
     plt.ylabel("Counts / s" if normalise_rate else "Counts per bin")
     title_isos = " & ".join(iso_list)
     plt.title(f"{title_isos} Time Series Fit")
@@ -365,15 +364,8 @@ def plot_time_series(
         plt.legend(fontsize="small")
 
     ax = plt.gca()
-    locator = mdates.AutoDateLocator()
-    try:
-        formatter = mdates.ConciseDateFormatter(locator)
-    except AttributeError:  # older matplotlib
-        formatter = mdates.AutoDateFormatter(locator)
-    ax.xaxis.set_major_locator(locator)
-    ax.xaxis.set_major_formatter(formatter)
+    setup_time_axis(ax, centers_mpl)
     plt.gcf().autofmt_xdate()
-    ax.xaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
     targets = get_targets(config, out_png)
     for p in targets.values():
@@ -554,7 +546,6 @@ def plot_radon_activity_full(
     ax.set_xlabel("Time (UTC)")
     ax.set_ylabel("Rn-222 Activity (Bq)")
     ax.set_title("Extrapolated Radon Activity vs. Time")
-    ax.ticklabel_format(axis="y", style="plain")
     setup_time_axis(ax, times_mpl)
 
     if po214_activity is not None:
@@ -570,7 +561,6 @@ def plot_radon_activity_full(
         ax.legend(lines1 + lines2, labels1 + labels2, loc="best")
 
     plt.gcf().autofmt_xdate()
-    ax.yaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
     targets = get_targets(config, out_png)
     for p in targets.values():
@@ -606,7 +596,6 @@ def plot_equivalent_air(times, volumes, errors, conc, out_png, config=None):
 
     setup_time_axis(ax, times_mpl)
     fig.autofmt_xdate()
-    ax.yaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
     targets = get_targets(config, out_png)
     for p in targets.values():
@@ -687,10 +676,8 @@ def plot_radon_trend_full(times, activity, out_png, config=None, *, fit_valid=Tr
     ax.set_ylabel("Radon Activity (Bq)")
     ax.set_title("Radon Activity Trend")
 
-    ax.ticklabel_format(axis="y", style="plain")
     setup_time_axis(ax, times_mpl)
     fig.autofmt_xdate()
-    ax.yaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
 
     targets = get_targets(config, out_png)
@@ -710,10 +697,8 @@ def plot_radon_activity(ts_dict, outdir):
     ax.errorbar(times_mpl, y, yerr=e, fmt="o")
     ax.set_ylabel("Radon activity [Bq]")
     ax.set_xlabel("Time (UTC)")
-    ax.ticklabel_format(axis="y", style="plain")
     setup_time_axis(ax, times_mpl)
     fig.autofmt_xdate()
-    ax.yaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
     fig.savefig(outdir / "radon_activity.png", dpi=300)
     plt.close(fig)
@@ -731,10 +716,8 @@ def plot_radon_trend(ts_dict, outdir):
     ax.plot(times_mpl, np.polyval(coeff, times_mpl))
     ax.set_ylabel("Radon activity [Bq]")
     ax.set_xlabel("Time (UTC)")
-    ax.ticklabel_format(axis="y", style="plain")
     setup_time_axis(ax, times_mpl)
     fig.autofmt_xdate()
-    ax.yaxis.get_offset_text().set_visible(False)
     plt.tight_layout()
     fig.savefig(outdir / "radon_trend.png", dpi=300)
     plt.close(fig)

--- a/plot_utils/_time_utils.py
+++ b/plot_utils/_time_utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Iterable
 
 import matplotlib.dates as mdates
@@ -47,14 +47,16 @@ def to_mpl_times(times: Iterable) -> np.ndarray:
 
 
 def setup_time_axis(ax, times_mpl: np.ndarray):
-    """Apply UTC date labels and elapsed-hour secondary axis."""
-    locator = mdates.AutoDateLocator()
+    """Apply UTC date labels, elapsed-hour secondary axis, and plain y-scale."""
+    locator = mdates.AutoDateLocator(tz=timezone.utc)
     try:  # Concise formatter is available on newer Matplotlib
-        formatter = mdates.ConciseDateFormatter(locator)
+        formatter = mdates.ConciseDateFormatter(locator, tz=timezone.utc)
     except AttributeError:  # pragma: no cover - fallback for old MPL
-        formatter = mdates.AutoDateFormatter(locator)
+        formatter = mdates.AutoDateFormatter(locator, tz=timezone.utc)
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
+    ax.ticklabel_format(axis="y", style="plain")
+    ax.yaxis.get_offset_text().set_visible(False)
 
     base = times_mpl[0]
 

--- a/plot_utils/radon.py
+++ b/plot_utils/radon.py
@@ -19,10 +19,8 @@ def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None
     ax.errorbar(times_mpl, activity, yerr=errors, fmt="o")
     ax.set_ylabel("Rn-222 activity [Bq]")
     ax.set_xlabel("Time (UTC)")
-    ax.ticklabel_format(axis="y", style="plain")
     setup_time_axis(ax, times_mpl)
     fig.autofmt_xdate()
-    ax.yaxis.get_offset_text().set_visible(False)
     if out_png is not None:
         fig.savefig(out_png, dpi=300)
         plt.close(fig)
@@ -42,11 +40,9 @@ def plot_radon_trend(ts_dict, outdir: Path, out_png: str | Path | None = None) -
     ax.plot(times_mpl, np.polyval(coeff, times_mpl), label=f"slope={coeff[0]:.2e} Bq/s")
     ax.set_ylabel("Rn-222 activity [Bq]")
     ax.set_xlabel("Time (UTC)")
-    ax.ticklabel_format(axis="y", style="plain")
     ax.legend()
     setup_time_axis(ax, times_mpl)
     fig.autofmt_xdate()
-    ax.yaxis.get_offset_text().set_visible(False)
     if out_png is not None:
         fig.savefig(out_png, dpi=300)
         plt.close(fig)


### PR DESCRIPTION
## Summary
- centralize time normalization and axis formatting in plot utilities
- enforce UTC datetime handling with elapsed-hours secondary axis
- disable scientific offsets on time-series plots

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1599fc950832b9b4c2ea2f0a60292