### PR TITLE
Standardize time axis utilities

### DIFF
--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -8,7 +8,6 @@ import matplotlib as _mpl
 
 _mpl.use("Agg")
 import matplotlib.pyplot as plt
-import matplotlib.dates as mdates
 import math
 from datetime import datetime
 from pathlib import Path
@@ -254,7 +253,7 @@ def plot_time_series(
         edges = np.linspace(0, (t_end - t_start), n_bins + 1)
     centers = 0.5 * (edges[:-1] + edges[1:])
     centers_abs = t_start + centers
-    centers_dt = mdates.date2num([datetime.utcfromtimestamp(t) for t in centers_abs])
+    centers_mpl = to_mpl_times(centers_abs)
     bin_widths = np.diff(edges)
 
     # Optional normalisation to counts / s (set in config)
@@ -288,7 +287,7 @@ def plot_time_series(
         style = str(config.get("plot_time_style", "steps")).lower()
         if style == "lines":
             plt.plot(
-                centers_dt,
+                centers_mpl,
                 counts_iso,
                 marker="o",
                 linestyle="-",
@@ -297,7 +296,7 @@ def plot_time_series(
             )
         else:
             plt.step(
-                centers_dt,
+                centers_mpl,
                 counts_iso,
                 where="mid",
                 color=colors[iso],
@@ -334,7 +333,7 @@ def plot_time_series(
             # Convert rate (counts/s) to expected counts per bin if not normalising
             model_counts = r_rel if normalise_rate else r_rel * bin_widths
             plt.plot(
-                centers_dt,
+                centers_mpl,
                 model_counts,
                 color=colors[iso],
                 lw=2,
@@ -346,7 +345,7 @@ def plot_time_series(
                 if err.size == model_counts.size:
                     kw = {"step": "mid"} if style != "lines" else {}
                     plt.fill_between(
-                        centers_dt,
+                        centers_mpl,
                         model_counts - err,
                         model_counts + err,
                         color=colors[iso],
@@ -356,7 +355,7 @@ def plot_time_series(
                 else:
                     raise ValueError("model_errors array length mismatch")
 
-    plt.xlabel("Time")
+    plt.xlabel("Time (UTC)")
     plt.ylabel("Counts / s" if normalise_rate else "Counts per bin")
     title_isos = " & ".join(iso_list)
     plt.title(f"{title_isos} Time Series Fit")
@@ -365,15 +364,10 @@ def plot_time_series(
         plt.legend(fontsize="small")
 
     ax = plt.gca()
-    locator = mdates.AutoDateLocator()
-    try:
-        formatter = mdates.ConciseDateFormatter(locator)
-    except AttributeError:  # older matplotlib
-        formatter = mdates.AutoDateFormatter(locator)
-    ax.xaxis.set_major_locator(locator)
-    ax.xaxis.set_major_formatter(formatter)
+    setup_time_axis(ax, centers_mpl)
     plt.gcf().autofmt_xdate()
-    ax.xaxis.get_offset_text().set_visible(False)
+    ax.yaxis.get_offset_text().set_visible(False)
+    ax.ticklabel_format(axis="y", style="plain")
     plt.tight_layout()
     targets = get_targets(config, out_png)
     for p in targets.values():

--- a/plot_utils/_time_utils.py
+++ b/plot_utils/_time_utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Iterable
 
 import matplotlib.dates as mdates
@@ -17,7 +17,8 @@ def to_mpl_times(times: Iterable) -> np.ndarray:
     ----------
     times : Iterable
         Sequence of epoch seconds, :class:`numpy.datetime64`, or
-        :class:`datetime.datetime` objects.
+        :class:`datetime.datetime` objects. Naive datetimes are interpreted
+        as UTC.
 
     Returns
     -------
@@ -32,6 +33,10 @@ def to_mpl_times(times: Iterable) -> np.ndarray:
         secs_list: list[float] = []
         for t in arr:
             if isinstance(t, datetime):
+                if t.tzinfo is None:
+                    t = t.replace(tzinfo=timezone.utc)
+                else:
+                    t = t.astimezone(timezone.utc)
                 secs_list.append(t.timestamp())
             elif isinstance(t, np.datetime64):
                 secs_list.append(float(t.astype("datetime64[s]").astype(np.int64)))

--- a/plotting.py
+++ b/plotting.py
@@ -1,10 +1,8 @@
 import matplotlib as _mpl
 _mpl.use("Agg")
 import matplotlib.pyplot as plt
-import matplotlib.dates as mdates
-import matplotlib.ticker as mticker
-from datetime import datetime
 from pathlib import Path
+from plot_utils._time_utils import setup_time_axis, to_mpl_times
 
 __all__ = ["plot_radon_activity", "plot_radon_trend"]
 
@@ -21,37 +19,14 @@ def plot_radon_activity(ts, outdir):
     """
     outdir = Path(outdir)
     fig, ax = plt.subplots()
-    times = [datetime.utcfromtimestamp(t) for t in ts.time]
-    times_dt = mdates.date2num(times)
-    ax.errorbar(times_dt, ts.activity, yerr=getattr(ts, "error", None), fmt="o")
+    times_mpl = to_mpl_times(ts.time)
+    ax.errorbar(times_mpl, ts.activity, yerr=getattr(ts, "error", None), fmt="o")
     ax.set_ylabel("Radon activity [Bq]")
     ax.set_xlabel("Time (UTC)")
     ax.ticklabel_format(axis="y", style="plain")
-
-    locator = mdates.AutoDateLocator()
-    try:
-        formatter = mdates.ConciseDateFormatter(locator)
-    except AttributeError:
-        formatter = mdates.AutoDateFormatter(locator)
-    ax.xaxis.set_major_locator(locator)
-    ax.xaxis.set_major_formatter(formatter)
-
-    base_dt = times_dt[0]
-
-    def _to_hours(x):
-        return (x - base_dt) * 24.0
-
-    def _to_dates(x):
-        return base_dt + x / 24.0
-
-    secax = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
-    secax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda x, pos=None: f"{x:g}"))
-    secax.set_xlabel("Elapsed Time (h)")
-
-    ax.xaxis.get_offset_text().set_visible(False)
-    ax.yaxis.get_offset_text().set_visible(False)
-    secax.xaxis.get_offset_text().set_visible(False)
+    setup_time_axis(ax, times_mpl)
     fig.autofmt_xdate()
+    ax.yaxis.get_offset_text().set_visible(False)
     fig.tight_layout()
     fig.savefig(outdir / "radon_activity.png", dpi=300)
     plt.close(fig)
@@ -61,37 +36,14 @@ def plot_radon_trend(ts, outdir):
     """Plot radon activity trend without uncertainties."""
     outdir = Path(outdir)
     fig, ax = plt.subplots()
-    times = [datetime.utcfromtimestamp(t) for t in ts.time]
-    times_dt = mdates.date2num(times)
-    ax.plot(times_dt, ts.activity, "o-")
+    times_mpl = to_mpl_times(ts.time)
+    ax.plot(times_mpl, ts.activity, "o-")
     ax.set_ylabel("Radon activity [Bq]")
     ax.set_xlabel("Time (UTC)")
     ax.ticklabel_format(axis="y", style="plain")
-
-    locator = mdates.AutoDateLocator()
-    try:
-        formatter = mdates.ConciseDateFormatter(locator)
-    except AttributeError:
-        formatter = mdates.AutoDateFormatter(locator)
-    ax.xaxis.set_major_locator(locator)
-    ax.xaxis.set_major_formatter(formatter)
-
-    base_dt = times_dt[0]
-
-    def _to_hours(x):
-        return (x - base_dt) * 24.0
-
-    def _to_dates(x):
-        return base_dt + x / 24.0
-
-    secax = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
-    secax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda x, pos=None: f"{x:g}"))
-    secax.set_xlabel("Elapsed Time (h)")
-
-    ax.xaxis.get_offset_text().set_visible(False)
-    ax.yaxis.get_offset_text().set_visible(False)
-    secax.xaxis.get_offset_text().set_visible(False)
+    setup_time_axis(ax, times_mpl)
     fig.autofmt_xdate()
+    ax.yaxis.get_offset_text().set_visible(False)
     fig.tight_layout()
     fig.savefig(outdir / "radon_trend.png", dpi=300)
     plt.close(fig)

--- a/tests/test_to_mpl_times.py
+++ b/tests/test_to_mpl_times.py
@@ -1,0 +1,14 @@
+from datetime import datetime, timezone
+import numpy as np
+from plot_utils._time_utils import to_mpl_times
+
+
+def test_to_mpl_times_various_inputs():
+    secs = [0, 3600]
+    expected = to_mpl_times(secs)
+    dt64 = np.array(secs, dtype="datetime64[s]")
+    naive = [datetime.utcfromtimestamp(s) for s in secs]
+    aware = [datetime.fromtimestamp(s, timezone.utc) for s in secs]
+    np.testing.assert_allclose(to_mpl_times(dt64), expected)
+    np.testing.assert_allclose(to_mpl_times(naive), expected)
+    np.testing.assert_allclose(to_mpl_times(aware), expected)


### PR DESCRIPTION
## Summary
- unify Matplotlib time conversions and axis setup for time-series helpers
- ensure datetimes are normalized to UTC and elapsed hours
- add tests for to_mpl_times accepting multiple input types

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1599fc950832b9b4c2ea2f0a60292