### PR TITLE
refactor: centralize time-axis handling

### DIFF
--- a/plotting.py
+++ b/plotting.py
@@ -1,10 +1,9 @@
 import matplotlib as _mpl
 _mpl.use("Agg")
 import matplotlib.pyplot as plt
-import matplotlib.dates as mdates
-import matplotlib.ticker as mticker
-from datetime import datetime
 from pathlib import Path
+
+from plot_utils._time_utils import setup_time_axis, to_mpl_times
 
 __all__ = ["plot_radon_activity", "plot_radon_trend"]
 
@@ -21,37 +20,14 @@ def plot_radon_activity(ts, outdir):
     """
     outdir = Path(outdir)
     fig, ax = plt.subplots()
-    times = [datetime.utcfromtimestamp(t) for t in ts.time]
-    times_dt = mdates.date2num(times)
-    ax.errorbar(times_dt, ts.activity, yerr=getattr(ts, "error", None), fmt="o")
+    times_mpl = to_mpl_times(ts.time)
+    ax.errorbar(times_mpl, ts.activity, yerr=getattr(ts, "error", None), fmt="o")
     ax.set_ylabel("Radon activity [Bq]")
     ax.set_xlabel("Time (UTC)")
     ax.ticklabel_format(axis="y", style="plain")
-
-    locator = mdates.AutoDateLocator()
-    try:
-        formatter = mdates.ConciseDateFormatter(locator)
-    except AttributeError:
-        formatter = mdates.AutoDateFormatter(locator)
-    ax.xaxis.set_major_locator(locator)
-    ax.xaxis.set_major_formatter(formatter)
-
-    base_dt = times_dt[0]
-
-    def _to_hours(x):
-        return (x - base_dt) * 24.0
-
-    def _to_dates(x):
-        return base_dt + x / 24.0
-
-    secax = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
-    secax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda x, pos=None: f"{x:g}"))
-    secax.set_xlabel("Elapsed Time (h)")
-
-    ax.xaxis.get_offset_text().set_visible(False)
-    ax.yaxis.get_offset_text().set_visible(False)
-    secax.xaxis.get_offset_text().set_visible(False)
+    setup_time_axis(ax, times_mpl)
     fig.autofmt_xdate()
+    ax.yaxis.get_offset_text().set_visible(False)
     fig.tight_layout()
     fig.savefig(outdir / "radon_activity.png", dpi=300)
     plt.close(fig)
@@ -61,37 +37,14 @@ def plot_radon_trend(ts, outdir):
     """Plot radon activity trend without uncertainties."""
     outdir = Path(outdir)
     fig, ax = plt.subplots()
-    times = [datetime.utcfromtimestamp(t) for t in ts.time]
-    times_dt = mdates.date2num(times)
-    ax.plot(times_dt, ts.activity, "o-")
+    times_mpl = to_mpl_times(ts.time)
+    ax.plot(times_mpl, ts.activity, "o-")
     ax.set_ylabel("Radon activity [Bq]")
     ax.set_xlabel("Time (UTC)")
     ax.ticklabel_format(axis="y", style="plain")
-
-    locator = mdates.AutoDateLocator()
-    try:
-        formatter = mdates.ConciseDateFormatter(locator)
-    except AttributeError:
-        formatter = mdates.AutoDateFormatter(locator)
-    ax.xaxis.set_major_locator(locator)
-    ax.xaxis.set_major_formatter(formatter)
-
-    base_dt = times_dt[0]
-
-    def _to_hours(x):
-        return (x - base_dt) * 24.0
-
-    def _to_dates(x):
-        return base_dt + x / 24.0
-
-    secax = ax.secondary_xaxis("top", functions=(_to_hours, _to_dates))
-    secax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda x, pos=None: f"{x:g}"))
-    secax.set_xlabel("Elapsed Time (h)")
-
-    ax.xaxis.get_offset_text().set_visible(False)
-    ax.yaxis.get_offset_text().set_visible(False)
-    secax.xaxis.get_offset_text().set_visible(False)
+    setup_time_axis(ax, times_mpl)
     fig.autofmt_xdate()
+    ax.yaxis.get_offset_text().set_visible(False)
     fig.tight_layout()
     fig.savefig(outdir / "radon_trend.png", dpi=300)
     plt.close(fig)


### PR DESCRIPTION
## Summary
- Refactor `plotting.py` to use shared time-axis utilities
- Normalize time inputs once and enforce UTC/elapsed-hour axes
- Remove redundant conversions and disable y-axis offsets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1599fc950832b9b4c2ea2f0a60292