### PR TITLE
Add time-axis alias guard for plot utilities

### DIFF
--- a/plot_utils/_time_utils.py
+++ b/plot_utils/_time_utils.py
@@ -10,6 +10,27 @@ import matplotlib.ticker as mticker
 import numpy as np
 
 
+def guard_time_alias(namespace: dict) -> None:
+    """Raise ``AssertionError`` if stale time aliases are present.
+
+    Parameters
+    ----------
+    namespace : dict
+        Mapping of variable names to objects, typically ``locals()``.
+
+    Notes
+    -----
+    This helper prevents accidental use of deprecated ``times_dt`` or
+    ``times_mpl`` aliases that previously caused plotting bugs.
+    """
+
+    forbidden = {"times_dt", "times_mpl"}
+    overlap = forbidden.intersection(namespace)
+    if overlap:
+        names = ", ".join(sorted(overlap))
+        raise AssertionError(f"unexpected time alias: {names}")
+
+
 def to_mpl_times(times: Iterable) -> np.ndarray:
     """Convert an array-like of times to Matplotlib date numbers.
 
@@ -51,7 +72,7 @@ def to_mpl_times(times: Iterable) -> np.ndarray:
     return secs / 86400.0 + epoch
 
 
-def setup_time_axis(ax, times_mpl: np.ndarray):
+def setup_time_axis(ax, times: np.ndarray):
     """Apply UTC date labels and elapsed-hour secondary axis."""
     locator = mdates.AutoDateLocator()
     try:  # Concise formatter is available on newer Matplotlib
@@ -61,7 +82,7 @@ def setup_time_axis(ax, times_mpl: np.ndarray):
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
 
-    base = times_mpl[0]
+    base = times[0]
 
     def _to_hours(x):
         return (x - base) * 24.0

--- a/plot_utils/radon.py
+++ b/plot_utils/radon.py
@@ -2,7 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from pathlib import Path
 
-from ._time_utils import setup_time_axis, to_mpl_times
+from ._time_utils import guard_time_alias, setup_time_axis, to_mpl_times
 
 
 def _save(fig, outdir: Path, name: str) -> None:
@@ -12,15 +12,16 @@ def _save(fig, outdir: Path, name: str) -> None:
 
 
 def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None) -> None:
-    times_mpl = to_mpl_times(ts_dict["time"])
+    guard_time_alias(locals())
+    times = to_mpl_times(ts_dict["time"])
     activity = np.asarray(ts_dict["activity"], dtype=float)
     errors = np.asarray(ts_dict["error"], dtype=float)
     fig, ax = plt.subplots()
-    ax.errorbar(times_mpl, activity, yerr=errors, fmt="o")
+    ax.errorbar(times, activity, yerr=errors, fmt="o")
     ax.set_ylabel("Rn-222 activity [Bq]")
     ax.set_xlabel("Time (UTC)")
     ax.ticklabel_format(axis="y", style="plain")
-    setup_time_axis(ax, times_mpl)
+    setup_time_axis(ax, times)
     fig.autofmt_xdate()
     ax.yaxis.get_offset_text().set_visible(False)
     if out_png is not None:
@@ -31,20 +32,21 @@ def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None
 
 
 def plot_radon_trend(ts_dict, outdir: Path, out_png: str | Path | None = None) -> None:
-    times_mpl = to_mpl_times(ts_dict["time"])
+    guard_time_alias(locals())
+    times = to_mpl_times(ts_dict["time"])
     activity = np.asarray(ts_dict["activity"], dtype=float)
-    if times_mpl.size < 2:
+    if times.size < 2:
         coeff = np.array([0.0, activity[0] if activity.size else 0.0])
     else:
-        coeff = np.polyfit(times_mpl, activity, 1)
+        coeff = np.polyfit(times, activity, 1)
     fig, ax = plt.subplots()
-    ax.plot(times_mpl, activity, "o")
-    ax.plot(times_mpl, np.polyval(coeff, times_mpl), label=f"slope={coeff[0]:.2e} Bq/s")
+    ax.plot(times, activity, "o")
+    ax.plot(times, np.polyval(coeff, times), label=f"slope={coeff[0]:.2e} Bq/s")
     ax.set_ylabel("Rn-222 activity [Bq]")
     ax.set_xlabel("Time (UTC)")
     ax.ticklabel_format(axis="y", style="plain")
     ax.legend()
-    setup_time_axis(ax, times_mpl)
+    setup_time_axis(ax, times)
     fig.autofmt_xdate()
     ax.yaxis.get_offset_text().set_visible(False)
     if out_png is not None:

--- a/plotting.py
+++ b/plotting.py
@@ -2,7 +2,7 @@ import matplotlib as _mpl
 _mpl.use("Agg")
 import matplotlib.pyplot as plt
 from pathlib import Path
-from plot_utils._time_utils import setup_time_axis, to_mpl_times
+from plot_utils._time_utils import guard_time_alias, setup_time_axis, to_mpl_times
 
 __all__ = ["plot_radon_activity", "plot_radon_trend"]
 
@@ -18,13 +18,14 @@ def plot_radon_activity(ts, outdir):
         Output directory where ``radon_activity.png`` will be saved.
     """
     outdir = Path(outdir)
+    guard_time_alias(locals())
     fig, ax = plt.subplots()
-    times_mpl = to_mpl_times(ts.time)
-    ax.errorbar(times_mpl, ts.activity, yerr=getattr(ts, "error", None), fmt="o")
+    times = to_mpl_times(ts.time)
+    ax.errorbar(times, ts.activity, yerr=getattr(ts, "error", None), fmt="o")
     ax.set_ylabel("Radon activity [Bq]")
     ax.set_xlabel("Time (UTC)")
     ax.ticklabel_format(axis="y", style="plain")
-    setup_time_axis(ax, times_mpl)
+    setup_time_axis(ax, times)
     fig.autofmt_xdate()
     ax.yaxis.get_offset_text().set_visible(False)
     fig.tight_layout()
@@ -36,12 +37,13 @@ def plot_radon_trend(ts, outdir):
     """Plot radon activity trend without uncertainties."""
     outdir = Path(outdir)
     fig, ax = plt.subplots()
-    times_mpl = to_mpl_times(ts.time)
-    ax.plot(times_mpl, ts.activity, "o-")
+    guard_time_alias(locals())
+    times = to_mpl_times(ts.time)
+    ax.plot(times, ts.activity, "o-")
     ax.set_ylabel("Radon activity [Bq]")
     ax.set_xlabel("Time (UTC)")
     ax.ticklabel_format(axis="y", style="plain")
-    setup_time_axis(ax, times_mpl)
+    setup_time_axis(ax, times)
     fig.autofmt_xdate()
     ax.yaxis.get_offset_text().set_visible(False)
     fig.tight_layout()


### PR DESCRIPTION
## Summary
- add `guard_time_alias` helper that rejects stale `times_dt`/`times_mpl` aliases
- normalize time inputs at start of plotting helpers and update to canonical `times`
- rename `setup_time_axis` argument to `times` and apply guard across plot utilities

## Testing
- `pytest` *(fails: KeyboardInterrupt after ~10 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a15fce78e4832b92e569328a3dbd8c