### PR TITLE
Add guard against time axis aliases in plotting utilities

### DIFF
--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from color_schemes import COLOR_SCHEMES
 from constants import PO214, PO218, PO210, RN222
 from .paths import get_targets
-from ._time_utils import setup_time_axis, to_mpl_times
+from ._time_utils import guard_mpl_times, setup_time_axis
 
 # Half-life constants used for the time-series overlay [seconds]
 PO214_HALF_LIFE_S = PO214.half_life_s
@@ -253,7 +253,7 @@ def plot_time_series(
         edges = np.linspace(0, (t_end - t_start), n_bins + 1)
     centers = 0.5 * (edges[:-1] + edges[1:])
     centers_abs = t_start + centers
-    centers_mpl = to_mpl_times(centers_abs)
+    centers_mpl = guard_mpl_times(times=centers_abs)
     bin_widths = np.diff(edges)
 
     # Optional normalisation to counts / s (set in config)
@@ -535,7 +535,7 @@ def plot_radon_activity_full(
     When ``po214_activity`` is given it is overlaid for quality control
     on a secondary axis explicitly labelled as Po-214 activity.
     """
-    times_mpl = to_mpl_times(times)
+    times_mpl = guard_mpl_times(times=times)
     activity = np.asarray(activity, dtype=float)
     errors = np.asarray(errors, dtype=float)
 
@@ -581,7 +581,7 @@ def plot_equivalent_air(times, volumes, errors, conc, out_png, config=None):
         Ambient concentration label to include in the plot title. When ``None``
         the concentration is omitted from the title.
     """
-    times_mpl = to_mpl_times(times)
+    times_mpl = guard_mpl_times(times=times)
     volumes = np.asarray(volumes, dtype=float)
     errors = np.asarray(errors, dtype=float)
 
@@ -669,7 +669,7 @@ def plot_radon_trend_full(times, activity, out_png, config=None, *, fit_valid=Tr
     """Plot modeled radon activity trend without uncertainties."""
     if not fit_valid:
         return
-    times_mpl = to_mpl_times(times)
+    times_mpl = guard_mpl_times(times=times)
     activity = np.asarray(activity, dtype=float)
 
     fig, ax = plt.subplots(figsize=(8, 4))
@@ -696,7 +696,7 @@ def plot_radon_trend_full(times, activity, out_png, config=None, *, fit_valid=Tr
 def plot_radon_activity(ts_dict, outdir):
     """Simple wrapper to plot radon activity time series."""
     outdir = Path(outdir)
-    times_mpl = to_mpl_times(ts_dict["time"])
+    times_mpl = guard_mpl_times(times=ts_dict["time"])
     y = np.asarray(ts_dict["activity"], dtype=float)
     e = np.asarray(ts_dict["error"], dtype=float)
 
@@ -716,7 +716,7 @@ def plot_radon_activity(ts_dict, outdir):
 def plot_radon_trend(ts_dict, outdir):
     """Simple wrapper to plot a radon activity trend."""
     outdir = Path(outdir)
-    times_mpl = to_mpl_times(ts_dict["time"])
+    times_mpl = guard_mpl_times(times=ts_dict["time"])
     y = np.asarray(ts_dict["activity"], dtype=float)
     coeff = np.polyfit(times_mpl, y, 1)
 

--- a/plot_utils/_time_utils.py
+++ b/plot_utils/_time_utils.py
@@ -51,6 +51,26 @@ def to_mpl_times(times: Iterable) -> np.ndarray:
     return secs / 86400.0 + epoch
 
 
+def guard_mpl_times(*, times=None, times_mpl=None, times_dt=None) -> np.ndarray:
+    """Normalize time inputs and forbid stale aliases.
+
+    Exactly one of ``times`` or ``times_mpl`` must be supplied. The legacy
+    ``times_dt`` alias is rejected to avoid accidental reintroduction of the
+    old ``times_dt``/``times_mpl`` bug. The return value is always a NumPy
+    array of Matplotlib date numbers.
+    """
+
+    if times_dt is not None:
+        raise AssertionError("times_dt is deprecated; use 'times' or 'times_mpl'")
+
+    provided = (times is not None, times_mpl is not None)
+    if sum(provided) != 1:
+        raise ValueError("Provide exactly one of 'times' or 'times_mpl'")
+
+    arr = times_mpl if times_mpl is not None else to_mpl_times(times)
+    return np.asarray(arr, dtype=float)
+
+
 def setup_time_axis(ax, times_mpl: np.ndarray):
     """Apply UTC date labels and elapsed-hour secondary axis."""
     locator = mdates.AutoDateLocator()

--- a/plot_utils/radon.py
+++ b/plot_utils/radon.py
@@ -2,7 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from pathlib import Path
 
-from ._time_utils import setup_time_axis, to_mpl_times
+from ._time_utils import guard_mpl_times, setup_time_axis
 
 
 def _save(fig, outdir: Path, name: str) -> None:
@@ -12,7 +12,7 @@ def _save(fig, outdir: Path, name: str) -> None:
 
 
 def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None) -> None:
-    times_mpl = to_mpl_times(ts_dict["time"])
+    times_mpl = guard_mpl_times(times=ts_dict["time"])
     activity = np.asarray(ts_dict["activity"], dtype=float)
     errors = np.asarray(ts_dict["error"], dtype=float)
     fig, ax = plt.subplots()
@@ -31,7 +31,7 @@ def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None
 
 
 def plot_radon_trend(ts_dict, outdir: Path, out_png: str | Path | None = None) -> None:
-    times_mpl = to_mpl_times(ts_dict["time"])
+    times_mpl = guard_mpl_times(times=ts_dict["time"])
     activity = np.asarray(ts_dict["activity"], dtype=float)
     if times_mpl.size < 2:
         coeff = np.array([0.0, activity[0] if activity.size else 0.0])

--- a/plotting.py
+++ b/plotting.py
@@ -2,7 +2,7 @@ import matplotlib as _mpl
 _mpl.use("Agg")
 import matplotlib.pyplot as plt
 from pathlib import Path
-from plot_utils._time_utils import setup_time_axis, to_mpl_times
+from plot_utils._time_utils import guard_mpl_times, setup_time_axis
 
 __all__ = ["plot_radon_activity", "plot_radon_trend"]
 
@@ -19,7 +19,7 @@ def plot_radon_activity(ts, outdir):
     """
     outdir = Path(outdir)
     fig, ax = plt.subplots()
-    times_mpl = to_mpl_times(ts.time)
+    times_mpl = guard_mpl_times(times=ts.time)
     ax.errorbar(times_mpl, ts.activity, yerr=getattr(ts, "error", None), fmt="o")
     ax.set_ylabel("Radon activity [Bq]")
     ax.set_xlabel("Time (UTC)")
@@ -36,7 +36,7 @@ def plot_radon_trend(ts, outdir):
     """Plot radon activity trend without uncertainties."""
     outdir = Path(outdir)
     fig, ax = plt.subplots()
-    times_mpl = to_mpl_times(ts.time)
+    times_mpl = guard_mpl_times(times=ts.time)
     ax.plot(times_mpl, ts.activity, "o-")
     ax.set_ylabel("Radon activity [Bq]")
     ax.set_xlabel("Time (UTC)")

--- a/tests/test_mpl_time_guard.py
+++ b/tests/test_mpl_time_guard.py
@@ -1,0 +1,21 @@
+import numpy as np
+import pytest
+from plot_utils._time_utils import guard_mpl_times, to_mpl_times
+
+
+def test_guard_mpl_times_normalizes_inputs():
+    secs = [0, 3600]
+    expected = to_mpl_times(secs)
+    out_from_secs = guard_mpl_times(times=secs)
+    out_from_mpl = guard_mpl_times(times_mpl=expected)
+    np.testing.assert_allclose(out_from_secs, expected)
+    np.testing.assert_allclose(out_from_mpl, expected)
+
+
+def test_guard_mpl_times_rejects_aliases():
+    with pytest.raises(AssertionError):
+        guard_mpl_times(times_dt=[0, 1])
+    with pytest.raises(ValueError):
+        guard_mpl_times()
+    with pytest.raises(ValueError):
+        guard_mpl_times(times=[0], times_mpl=[1])


### PR DESCRIPTION
## Summary
- centralize time axis normalization with `guard_mpl_times`
- refactor plotting helpers to use the guard and prevent `times_dt` alias
- add tests verifying alias rejection

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a15fce78e4832b92e569328a3dbd8c