### PR TITLE
Add selector zero-drift smoke tests

### DIFF
--- a/tests/test_feature_selectors.py
+++ b/tests/test_feature_selectors.py
@@ -1,28 +1,29 @@
 import numpy as np
 import pytest
 
+import likelihood_ext
 from fitting import fit_spectrum
 
 
-def _generate_energies(seed: int = 0):
+def _generate_energies(seed: int = 0, n: int = 20):
     rng = np.random.default_rng(seed)
     return np.concatenate([
-        rng.normal(5.3, 0.05, 200),
-        rng.normal(6.0, 0.05, 200),
-        rng.normal(7.7, 0.05, 200),
+        rng.normal(5.3, 0.05, n),
+        rng.normal(6.0, 0.05, n),
+        rng.normal(7.7, 0.05, n),
     ])
 
 
-def _base_priors():
+def _base_priors(n: int = 20):
     return {
         "sigma0": (0.05, 0.01),
         "F": (0.0, 0.01),
         "mu_Po210": (5.3, 0.1),
-        "S_Po210": (200, 20),
+        "S_Po210": (n, 5),
         "mu_Po218": (6.0, 0.1),
-        "S_Po218": (200, 20),
+        "S_Po218": (n, 5),
         "mu_Po214": (7.7, 0.1),
-        "S_Po214": (200, 20),
+        "S_Po214": (n, 5),
         "b0": (0.0, 1.0),
         "b1": (0.0, 1.0),
     }
@@ -37,7 +38,7 @@ def test_default_vs_explicit_linear_identical():
         assert res_linear.params[key] == pytest.approx(val)
 
 
-def test_explicit_extended_matches_default():
+def test_explicit_extended_matches_default(monkeypatch):
     energies = _generate_energies(1)
     priors = _base_priors()
     flags = {
@@ -48,8 +49,22 @@ def test_explicit_extended_matches_default():
         "fix_b1": True,
     }
     res_default = fit_spectrum(energies, priors, unbinned=True, flags=flags)
+
+    called = {"count": 0}
+    orig = likelihood_ext.neg_loglike_extended
+
+    def spy(*args, **kwargs):
+        called["count"] += 1
+        return orig(*args, **kwargs)
+
+    monkeypatch.setattr(likelihood_ext, "neg_loglike_extended", spy)
+
     flags_ext = dict(flags)
     flags_ext["likelihood"] = "extended"
     res_ext = fit_spectrum(energies, priors, unbinned=True, flags=flags_ext)
+
+    assert called["count"] > 0
     for key in ("mu_Po210", "mu_Po218", "mu_Po214"):
-        assert res_ext.params[key] == pytest.approx(res_default.params[key], rel=5e-2)
+        assert res_ext.params[key] == pytest.approx(
+            res_default.params[key], rel=5e-2
+        )


### PR DESCRIPTION
## Summary
- Add short-spectrum helper and priors for selector tests
- Verify `background_model=linear` matches default
- Ensure `likelihood=extended` path is exercised without changing results

## Testing
- `pytest tests/test_feature_selectors.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a15fb65d84832b851bf96ccd6ca011