### PR TITLE
docs: document opt-in analysis modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,26 @@ python analyze.py [--config config.yaml] --input merged_data.csv \
     [--hierarchical-summary OUT.json]
 ```
 
+### Opt-in background & extended likelihood
+
+These analysis modes are experimental and opt-in. Defaults remain the legacy linear background and the current unextended likelihood.
+
+CLI example:
+
+```bash
+python analyze.py --input merged_data.csv --background-model loglin_unit --likelihood extended
+```
+
+Minimal `config.yaml` snippet:
+
+```yaml
+analysis:
+  background_model: loglin_unit
+  likelihood: extended
+```
+
+See [docs/analysis-modes.md](docs/analysis-modes.md) for brief rationale and definitions.
+
 ### Radon vs. progeny mode
 `--iso radon` (default) combines Po-218 & Po-214 counts via BLUE to yield the parent Rn-222 activity.
 `--iso po218` or `--iso po214` fits an individual progeny chain only (useful for diagnostics).

--- a/docs/analysis-modes.md
+++ b/docs/analysis-modes.md
@@ -1,0 +1,8 @@
+# Experimental analysis modes
+
+These opt-in features let interested users test alternate background and likelihood formulations while keeping the default linear background and unextended likelihood unchanged.
+
+- **loglin_unit background** – uses a unit-area log-linear shape scaled by a positive `S_bkg` parameter.
+- **extended likelihood** – includes the Poisson term for the expected event count.
+
+Enable them from the CLI or configuration; see the README for examples.


### PR DESCRIPTION
## Summary
- explain how to enable experimental background and extended likelihood modes
- add brief doc page with rationale and definitions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2aacc09b0832ba613c6ce6801349a