### PR TITLE
Document opt-in background and extended likelihood modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,25 @@ python analyze.py [--config config.yaml] --input merged_data.csv \
 `--iso po218` or `--iso po214` fits an individual progeny chain only (useful for diagnostics).
 
 
+### Opt-in background & extended likelihood
+
+These experimental analysis modes are opt-in; legacy linear background and current likelihood remain the defaults.
+
+```bash
+python analyze.py --background-model loglin_unit --likelihood extended --input merged_data.csv
+```
+
+Minimal `config.yaml`:
+
+```yaml
+analysis:
+  background_model: loglin_unit
+  likelihood: extended
+```
+
+See [analysis modes](docs/analysis-modes.md) for more details.
+
+
 The script exits with an error message if filtering removes all events at any stage
 (noise cut, burst filter, time-window selection or baseline subtraction).
 

--- a/docs/analysis-modes.md
+++ b/docs/analysis-modes.md
@@ -1,0 +1,17 @@
+# Experimental analysis modes
+
+Opt-in features allow testing a log-linear background model (`background_model: loglin_unit`) and an extended unbinned likelihood (`likelihood: extended`). These modes remain experimental and are disabled by default.
+
+The log-linear background fits a straight line in log space normalised to unit area, while the extended likelihood incorporates Poisson fluctuations in the total event count.
+
+Enable both via the CLI or in `config.yaml`:
+
+```bash
+python analyze.py --background-model loglin_unit --likelihood extended --input merged_data.csv
+```
+
+```yaml
+analysis:
+  background_model: loglin_unit
+  likelihood: extended
+```


### PR DESCRIPTION
## Summary
- Explain experimental background and extended likelihood modes in README
- Add dedicated `docs/analysis-modes.md` with rationale and examples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a2aacc09b0832ba613c6ce6801349a