### PR TITLE
docs: describe opt-in background and likelihood modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,24 @@ Key toggles in ``config.yaml`` include:
 - ``plotting.plot_save_formats`` – image formats to write
 - ``burst_filter.burst_mode`` – method for burst rejection
 
+### Opt-in background & extended likelihood
+
+These experimental modes are opt-in; the defaults remain a linear background with the current likelihood. Enable both via the command line:
+
+```bash
+python analyze.py --background-model loglin_unit --likelihood extended --input merged_data.csv
+```
+
+or in `config.yaml`:
+
+```yaml
+analysis:
+  background_model: loglin_unit
+  likelihood: extended
+```
+
+See [docs/analysis-modes.md](docs/analysis-modes.md) for rationale and definitions.
+
 `nominal_adc` under the `calibration` section sets the expected raw ADC
 centroids for Po‑210, Po‑218 and Po‑214 when using automatic calibration.
 If omitted, defaults of `{"Po210": 1250, "Po218": 1400, "Po214": 1800}`

--- a/docs/analysis-modes.md
+++ b/docs/analysis-modes.md
@@ -1,0 +1,6 @@
+# Opt-in analysis modes
+
+These experimental options model a log-linear background and use an extended Poisson likelihood. They are opt-in; the default analysis remains linear with the current likelihood.
+
+- `background_model: loglin_unit` — fits a unit-normalized log-linear background term.
+- `likelihood: extended` — treats the fit as an extended Poisson likelihood.


### PR DESCRIPTION
## Summary
- document experimental background and extended likelihood modes
- add standalone doc explaining background_model and extended likelihood flags

## Testing
- `pytest tests/test_feature_selectors.py tests/test_fitting.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2aacc09b0832ba613c6ce6801349a