### PR TITLE
Add guardrails for opt-in background and likelihood options

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -678,8 +678,8 @@ def parse_args(argv=None):
     p = argparse.ArgumentParser(
         description="Full Radon Monitor Analysis Pipeline",
         epilog=(
-            "See the README for details on opt-in spectral flags such as "
-            "background_model=loglin_unit and likelihood=extended."
+            "See the README's Opt-in section for details on experimental flags "
+            "such as background_model=loglin_unit and likelihood=extended."
         ),
     )
     default_cfg = Path(__file__).resolve().with_name("config.yaml")

--- a/feature_selectors.py
+++ b/feature_selectors.py
@@ -38,8 +38,16 @@ def select_background_factory(opts: Any, Emin: float, Emax: float) -> Callable:
         from fitting import make_linear_bkg
 
         shape = make_linear_bkg(Emin, Emax)
+        required = {"S_bkg", "b0", "b1"}
 
         def bkg(E, params):
+            missing = required - params.keys()
+            if missing:
+                got = sorted(params.keys())
+                raise ValueError(
+                    "background_model=loglin_unit requires params {S_bkg, b0, b1}; got: "
+                    f"{got}"
+                )
             val = shape(E, params["b0"], params["b1"])
             return softplus(params["S_bkg"]) * val
 
@@ -52,9 +60,34 @@ def select_neg_loglike(opts: Any) -> Callable:
     """Return the negative log-likelihood function based on ``opts``."""
 
     if getattr(opts, "likelihood", "") == "extended":
-        from likelihood_ext import neg_loglike_extended
+        from likelihood_ext import neg_loglike_extended as _neg_loglike_extended
 
-        return neg_loglike_extended
+        def neg_loglike(
+            E: Sequence[float],
+            intensity_fn: Callable[[Sequence[float], Mapping[str, float]], np.ndarray],
+            params: Mapping[str, float],
+            *,
+            area_keys: Sequence[str],
+            clip: float = 1e-300,
+            background_model: str | None = None,
+        ) -> float:
+            missing = [k for k in area_keys if k not in params]
+            if missing:
+                got = sorted(params.keys())
+                needed = ", ".join(area_keys)
+                raise ValueError(
+                    f"likelihood=extended requires params {{{needed}}}; got: {got}"
+                )
+            return _neg_loglike_extended(
+                E,
+                intensity_fn,
+                params,
+                area_keys=area_keys,
+                clip=clip,
+                background_model=background_model,
+            )
+
+        return neg_loglike
 
     def neg_loglike_current(
         E: Sequence[float],


### PR DESCRIPTION
## Summary
- validate required parameters when opting into `loglin_unit` background model
- check area keys when using opt-in `extended` likelihood
- mention README Opt-in section in CLI help

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2aadb6540832b94ec29e5392379b0