### PR TITLE
docs: explain opt-in background and extended likelihood

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,22 @@ Key toggles in ``config.yaml`` include:
 - ``plotting.plot_save_formats`` – image formats to write
 - ``burst_filter.burst_mode`` – method for burst rejection
 
+### Opt-in background & extended likelihood
+
+These experimental modes are opt-in; the defaults remain the legacy linear background and current likelihood.
+
+```bash
+python analyze.py --background-model loglin_unit --likelihood extended ...
+```
+
+```yaml
+analysis:
+  background_model: loglin_unit
+  likelihood: extended
+```
+
+See [docs/analysis-modes.md](docs/analysis-modes.md) for background and likelihood details.
+
 `nominal_adc` under the `calibration` section sets the expected raw ADC
 centroids for Po‑210, Po‑218 and Po‑214 when using automatic calibration.
 If omitted, defaults of `{"Po210": 1250, "Po218": 1400, "Po214": 1800}`

--- a/docs/analysis-modes.md
+++ b/docs/analysis-modes.md
@@ -1,0 +1,8 @@
+# Experimental analysis modes
+
+These opt-in options explore new models while keeping defaults unchanged.
+
+- **background_model** `loglin_unit`: log-linear shape normalized to unit area for smooth backgrounds.
+- **likelihood** `extended`: extended unbinned likelihood that incorporates the observed event count.
+
+Enable them only when evaluating advanced background or statistical treatments.


### PR DESCRIPTION
## Summary
- document experimental background model and extended likelihood usage in README
- add dedicated docs page describing background_model and extended likelihood

## Testing
- `pytest` (partial: interrupted after ~25 tests)
- `pytest tests/test_feature_selectors.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2aacc09b0832ba613c6ce6801349a