### PR TITLE
feat: expose background and likelihood flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ python analyze.py [--config config.yaml] --input merged_data.csv \
     [--settle-s SEC] [--debug] [--seed SEED] \
     [--ambient-file amb.txt (time conc)] [--ambient-concentration 0.1] \
     [--burst-mode rate] \
+    [--background-model linear|loglin_unit] [--likelihood current|extended] \
     [--plot-time-binning-mode fixed --plot-time-bin-width 3600] [--dump-time-series-json] \
     [--timezone UTC|EST|PST] \
     [--hierarchical-summary OUT.json]

--- a/analyze.py
+++ b/analyze.py
@@ -2006,6 +2006,13 @@ def main(argv=None):
 
         # Flags controlling the spectral fit
         spec_flags = cfg["spectral_fit"].get("flags", {}).copy()
+        analysis_opts = cfg.get("analysis", {})
+        bkg_choice = analysis_opts.get("background_model")
+        like_choice = analysis_opts.get("likelihood")
+        if bkg_choice is not None:
+            spec_flags.setdefault("background_model", bkg_choice)
+        if like_choice is not None:
+            spec_flags.setdefault("likelihood", like_choice)
         if float_sigma_E and spec_flags.get("fix_sigma0"):
             raise ValueError(
                 "Configuration error: cannot float energy resolution while fixing sigma0"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,3 +11,7 @@ def test_cli_help():
         text=True,
     )
     assert result.returncode == 0
+    assert "--background-model" in result.stdout
+    assert "{linear,loglin_unit}" in result.stdout
+    assert "--likelihood" in result.stdout
+    assert "{current,extended}" in result.stdout

--- a/tests/test_cli_likelihood_extended.py
+++ b/tests/test_cli_likelihood_extended.py
@@ -1,0 +1,98 @@
+import yaml
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+import likelihood_ext
+from fitting import FitResult, FitParams
+from feature_selectors import select_neg_loglike
+from calibration import CalibrationResult
+
+
+def test_cli_likelihood_extended(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {
+            "do_spectral_fit": True,
+            "expected_peaks": {"Po210": 7600},
+            "mu_sigma": 0.1,
+            "amp_prior_scale": 1.0,
+            "bkg_mode": "manual",
+            "b0_prior": [0.0, 1.0],
+            "b1_prior": [0.0, 1.0],
+            "flags": {},
+        },
+        "time_fit": {"do_time_fit": False, "flags": {}},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.yaml"
+    with open(cfg_path, "w") as f:
+        yaml.safe_dump(cfg, f)
+
+    df = pd.DataFrame(
+        {
+            "fUniqueID": [1],
+            "fBits": [0],
+            "timestamp": [pd.Timestamp(0, unit="s", tz="UTC")],
+            "adc": [7600],
+            "fchannel": [1],
+        }
+    )
+    data_path = tmp_path / "run.csv"
+    df.to_csv(data_path, index=False)
+
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants",
+        lambda *a, **k: CalibrationResult(
+            coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0
+        ),
+    )
+    monkeypatch.setattr(
+        analyze,
+        "derive_calibration_constants_auto",
+        lambda *a, **k: CalibrationResult(
+            coeffs=[0.0, 1.0], cov=np.zeros((2, 2)), peaks={}, sigma_E=1.0, sigma_E_error=0.0
+        ),
+    )
+    monkeypatch.setattr(analyze, "apply_calibration", lambda adc, a, c, quadratic_coeff=None: np.asarray(adc))
+    monkeypatch.setattr(analyze, "find_adc_bin_peaks", lambda *a, **k: {"Po210": 7600})
+    monkeypatch.setattr(analyze, "fit_time_series", lambda *a, **k: FitResult(FitParams({}), np.zeros((0, 0)), 0))
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "apply_burst_filter", lambda df, cfg, mode="rate": (df, 0))
+
+    called = {"extended": False}
+
+    def fake_fit_spectrum(energies, priors, flags=None, **kwargs):
+        opts = SimpleNamespace(**(flags or {}))
+        neg_ll = select_neg_loglike(opts)
+        neg_ll(np.array([1.0]), lambda E, p: np.ones_like(E), {"area": 1.0}, area_keys=("area",))
+        called["extended"] = neg_ll is likelihood_ext.neg_loglike_extended
+        return FitResult(FitParams({"fit_valid": True}), np.zeros((0, 0)), 0)
+
+    monkeypatch.setattr(analyze, "fit_spectrum", fake_fit_spectrum)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+        "--likelihood",
+        "extended",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert called["extended"] is True


### PR DESCRIPTION
## Summary
- add `--background-model` and `--likelihood` CLI options
- route analysis config flags into spectral fit selectors
- test new flags and extended likelihood path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2aac3cd78832bb4584f6a4dd95154