### PR TITLE
Add runtime guardrails for optional spectral models

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -678,8 +678,8 @@ def parse_args(argv=None):
     p = argparse.ArgumentParser(
         description="Full Radon Monitor Analysis Pipeline",
         epilog=(
-            "See the README for details on opt-in spectral flags such as "
-            "background_model=loglin_unit and likelihood=extended."
+            "See the README's Opt-in section for details on experimental spectral flags "
+            "such as background_model=loglin_unit and likelihood=extended."
         ),
     )
     default_cfg = Path(__file__).resolve().with_name("config.yaml")

--- a/likelihood_ext.py
+++ b/likelihood_ext.py
@@ -52,20 +52,18 @@ def neg_loglike_extended(
 
     if background_model == "loglin_unit":
         required = {"S_bkg", "b0", "b1"}
-        missing = required - params.keys()
+        missing = [k for k in required if k not in params]
         if missing:
-            got = sorted(params.keys())
             raise ValueError(
-                "background_model=loglin_unit requires params {S_bkg, b0, b1}; got: "
-                f"{got}"
+                "background_model=loglin_unit missing params: "
+                + ", ".join(sorted(missing))
             )
 
     missing_areas = [k for k in area_keys if k not in params]
     if missing_areas:
-        got = sorted(params.keys())
-        needed = ", ".join(area_keys)
         raise ValueError(
-            f"likelihood=extended requires params {{{needed}}}; got: {got}"
+            "likelihood=extended missing params: "
+            + ", ".join(sorted(missing_areas))
         )
 
     lam = np.clip(intensity_fn(E, params), clip, np.inf)

--- a/tests/test_feature_selectors.py
+++ b/tests/test_feature_selectors.py
@@ -2,7 +2,9 @@ import numpy as np
 import pytest
 
 import likelihood_ext
+from feature_selectors import select_background_factory
 from fitting import fit_spectrum
+from types import SimpleNamespace
 
 
 def _generate_energies(seed: int = 0, n: int = 20):
@@ -68,3 +70,14 @@ def test_explicit_extended_matches_default(monkeypatch):
         assert res_ext.params[key] == pytest.approx(
             res_default.params[key], rel=5e-2
         )
+
+
+def test_loglin_unit_missing_params():
+    opts = SimpleNamespace(background_model="loglin_unit")
+    bkg = select_background_factory(opts, 0.0, 1.0)
+    with pytest.raises(ValueError) as exc:
+        bkg([0.0], {})
+    assert (
+        str(exc.value)
+        == "background_model=loglin_unit missing params: S_bkg, b0, b1"
+    )

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -144,25 +144,25 @@ def test_loglin_unit_bootstraps_background():
 
 
 def test_extended_likelihood_missing_area_key():
-    from likelihood_ext import neg_loglike_extended
+    from types import SimpleNamespace
+    from feature_selectors import select_neg_loglike
 
     E = np.array([1.0, 2.0, 3.0])
+
     def intensity(E_vals, params):
         return np.ones_like(E_vals)
 
     params = {"area": 0.0}
+    neg_loglike = select_neg_loglike(SimpleNamespace(likelihood="extended"))
     with pytest.raises(ValueError) as exc:
-        neg_loglike_extended(
+        neg_loglike(
             E,
             intensity,
             params,
             area_keys=("area", "missing"),
             background_model=None,
         )
-    assert (
-        str(exc.value)
-        == "likelihood=extended requires params {area, missing}; got: ['area']"
-    )
+    assert str(exc.value) == "likelihood=extended missing params: missing"
 
 
 def test_fit_spectrum_fixed_parameter_bounds():


### PR DESCRIPTION
## Summary
- validate required parameters when opting into `background_model=loglin_unit`
- ensure `likelihood=extended` checks for required area keys
- mention README Opt-in section in CLI help

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a2aadb6540832b94ec29e5392379b0