### PR TITLE
Add diagnostics block to summary.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ the file:
 
 The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--job-id` is given the folder `<output_dir>/<job-id>/` is used instead. If `--output_dir` is omitted it defaults to `results`. If the folder already exists run with `--overwrite` to replace it. The directory includes:
 
-- `summary.json` – calibration and fit summary.
+- `summary.json` – calibration and fit summary. Includes a `diagnostics`
+  block with fit validity flags and event counts.
 - `config_used.json` – copy of the configuration used.
   Any timestamps overridden on the command line are written
   back to this file as ISO timestamps.

--- a/io_utils.py
+++ b/io_utils.py
@@ -18,6 +18,7 @@ import numpy as np
 from utils import to_native
 from utils.time_utils import parse_timestamp, to_epoch_seconds, tz_convert_utc
 import jsonschema
+from reporting import diagnostics_block
 
 
 def extract_time_series_events(events, cfg):
@@ -88,6 +89,7 @@ class Summary(Mapping[str, Any]):
     cli_sha256: str | None = None
     cli_args: list[str] = field(default_factory=list)
     analysis: dict = field(default_factory=dict)
+    diagnostics: dict = field(default_factory=dict)
 
     def __getitem__(self, key: str) -> Any:  # type: ignore[override]
         return getattr(self, key)
@@ -613,6 +615,11 @@ def write_summary(
     summary_path = results_folder / "summary.json"
 
     sanitized = to_native(summary_dict)
+    diag = sanitized.get("diagnostics")
+    if isinstance(diag, Mapping):
+        sanitized["diagnostics"] = diagnostics_block(**diag)
+    else:
+        sanitized["diagnostics"] = diagnostics_block()
 
     with open(summary_path, "w", encoding="utf-8") as f:
         json.dump(sanitized, f, indent=4)

--- a/reporting.py
+++ b/reporting.py
@@ -1,0 +1,34 @@
+"""Helpers for generating reporting information such as diagnostics blocks."""
+from __future__ import annotations
+
+from typing import Any
+import logging
+
+
+def diagnostics_block(**kwargs: Any) -> dict[str, Any]:
+    """Return a diagnostics block with standard fields.
+
+    Parameters are optional; missing fields are filled with defaults. Unknown
+    keys are ignored to keep the interface forward compatible.
+    """
+    return {
+        "spectral_fit_fit_valid": bool(kwargs.get("spectral_fit_fit_valid", False)),
+        "time_fit_po214_fit_valid": bool(
+            kwargs.get("time_fit_po214_fit_valid", False)
+        ),
+        "n_events_loaded": int(kwargs.get("n_events_loaded", 0)),
+        "n_events_discarded": int(kwargs.get("n_events_discarded", 0)),
+        "warnings": list(kwargs.get("warnings", [])),
+    }
+
+
+class WarningCaptureHandler(logging.Handler):
+    """Logging handler that collects warning messages."""
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.WARNING)
+        self.messages: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - simple
+        if record.levelno >= logging.WARNING:
+            self.messages.append(record.getMessage())

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,26 @@
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from io_utils import Summary, write_summary
+from reporting import diagnostics_block
+
+
+def test_diagnostics_written(tmp_path):
+    summary = Summary(diagnostics=diagnostics_block(
+        spectral_fit_fit_valid=True,
+        time_fit_po214_fit_valid=False,
+        n_events_loaded=10,
+        n_events_discarded=2,
+        warnings=["warn"],
+    ))
+    result_dir = write_summary(tmp_path, summary)
+    data = json.loads((Path(result_dir) / "summary.json").read_text())
+    diag = data.get("diagnostics", {})
+    assert diag["spectral_fit_fit_valid"] is True
+    assert diag["time_fit_po214_fit_valid"] is False
+    assert diag["n_events_loaded"] == 10
+    assert diag["n_events_discarded"] == 2
+    assert diag["warnings"] == ["warn"]


### PR DESCRIPTION
## Summary
- add `diagnostics` block helpers for summary output
- extend `Summary` dataclass and writer to ensure diagnostics section is present
- note diagnostics block in README and test its creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6757df974832bb2e214fd970d385a