### PR TITLE
Add diagnostics block to summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ the file:
 
 The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--job-id` is given the folder `<output_dir>/<job-id>/` is used instead. If `--output_dir` is omitted it defaults to `results`. If the folder already exists run with `--overwrite` to replace it. The directory includes:
 
-- `summary.json` – calibration and fit summary.
+- `summary.json` – calibration and fit summary including a diagnostics block.
 - `config_used.json` – copy of the configuration used.
   Any timestamps overridden on the command line are written
   back to this file as ISO timestamps.

--- a/io_utils.py
+++ b/io_utils.py
@@ -13,6 +13,7 @@ import pandas as pd
 from collections.abc import Mapping
 from typing import Any, Iterator
 from constants import load_nuclide_overrides
+from reporting import Diagnostics
 
 import numpy as np
 from utils import to_native
@@ -88,6 +89,7 @@ class Summary(Mapping[str, Any]):
     cli_sha256: str | None = None
     cli_args: list[str] = field(default_factory=list)
     analysis: dict = field(default_factory=dict)
+    diagnostics: Diagnostics = field(default_factory=Diagnostics)
 
     def __getitem__(self, key: str) -> Any:  # type: ignore[override]
         return getattr(self, key)

--- a/reporting.py
+++ b/reporting.py
@@ -1,0 +1,64 @@
+"""Utilities for collecting diagnostics information during analysis."""
+
+from dataclasses import dataclass, field
+import logging
+from typing import Mapping, Any
+
+
+@dataclass
+class Diagnostics:
+    """Minimal diagnostics written to ``summary.json``.
+
+    Attributes
+    ----------
+    spectral_fit_fit_valid : bool
+        ``True`` when the spectral fit converged with a valid covariance.
+    time_fit_po214_fit_valid : bool
+        Validity flag for the Po214 time-series fit.
+    n_events_loaded : int
+        Number of events loaded from input files.
+    n_events_discarded : int
+        Number of events discarded by cuts and filters.
+    warnings : list[str]
+        Collected warning messages emitted during processing.
+    """
+
+    spectral_fit_fit_valid: bool = False
+    time_fit_po214_fit_valid: bool = False
+    n_events_loaded: int = 0
+    n_events_discarded: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+
+class WarningCollector(logging.Handler):
+    """Logging handler that captures warning-level log messages."""
+
+    def __init__(self) -> None:  # pragma: no cover - trivial
+        super().__init__(level=logging.WARNING)
+        self.warnings: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - trivial
+        self.warnings.append(record.getMessage())
+
+
+def build_diagnostics(
+    summary: Mapping[str, Any],
+    *,
+    n_events_loaded: int = 0,
+    n_events_discarded: int = 0,
+    warning_collector: "WarningCollector | None" = None,
+) -> Diagnostics:
+    """Create a :class:`Diagnostics` instance from summary information."""
+
+    spectral_ok = bool(summary.get("spectral_fit", {}).get("fit_valid", False))
+    time_ok = bool(
+        summary.get("time_fit", {}).get("Po214", {}).get("fit_valid", False)
+    )
+    warnings = list(warning_collector.warnings) if warning_collector else []
+    return Diagnostics(
+        spectral_fit_fit_valid=spectral_ok,
+        time_fit_po214_fit_valid=time_ok,
+        n_events_loaded=int(n_events_loaded),
+        n_events_discarded=int(n_events_discarded),
+        warnings=warnings,
+    )

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+from io_utils import Summary, write_summary
+from reporting import Diagnostics
+
+
+def test_summary_includes_diagnostics(tmp_path):
+    diag = Diagnostics(
+        spectral_fit_fit_valid=True,
+        time_fit_po214_fit_valid=False,
+        n_events_loaded=10,
+        n_events_discarded=2,
+        warnings=["w"],
+    )
+    summary = Summary(diagnostics=diag)
+    results = write_summary(tmp_path, summary, "20000101T000000Z")
+    data = json.load(open(Path(results) / "summary.json"))
+    assert set(data["diagnostics"]) == {
+        "spectral_fit_fit_valid",
+        "time_fit_po214_fit_valid",
+        "n_events_loaded",
+        "n_events_discarded",
+        "warnings",
+    }


### PR DESCRIPTION
## Summary
- capture key analysis health metrics in new `diagnostics` dataclass
- include diagnostics in written summaries and document usage
- add regression test for diagnostics block in `summary.json`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6757df974832bb2e214fd970d385a