### PR TITLE
Add diagnostics block to summary output

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ the file:
 
 The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--job-id` is given the folder `<output_dir>/<job-id>/` is used instead. If `--output_dir` is omitted it defaults to `results`. If the folder already exists run with `--overwrite` to replace it. The directory includes:
 
-- `summary.json` – calibration and fit summary.
+- `summary.json` – calibration and fit summary with run diagnostics.
 - `config_used.json` – copy of the configuration used.
   Any timestamps overridden on the command line are written
   back to this file as ISO timestamps.

--- a/io_utils.py
+++ b/io_utils.py
@@ -13,6 +13,7 @@ import pandas as pd
 from collections.abc import Mapping
 from typing import Any, Iterator
 from constants import load_nuclide_overrides
+from reporting import Diagnostics
 
 import numpy as np
 from utils import to_native
@@ -88,6 +89,7 @@ class Summary(Mapping[str, Any]):
     cli_sha256: str | None = None
     cli_args: list[str] = field(default_factory=list)
     analysis: dict = field(default_factory=dict)
+    diagnostics: Diagnostics = field(default_factory=Diagnostics)
 
     def __getitem__(self, key: str) -> Any:  # type: ignore[override]
         return getattr(self, key)

--- a/reporting.py
+++ b/reporting.py
@@ -1,0 +1,64 @@
+import logging
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class Diagnostics:
+    """Container for lightweight run diagnostics.
+
+    Parameters
+    ----------
+    spectral_fit_fit_valid : bool | None
+        Whether the spectral fit converged.
+    time_fit_po214_fit_valid : bool | None
+        Whether the Po214 time fit converged.
+    n_events_loaded : int
+        Total number of events loaded from file.
+    n_events_discarded : int
+        Number of events discarded by cuts.
+    warnings : list[str]
+        Collected log warning messages.
+    """
+
+    spectral_fit_fit_valid: bool | None = None
+    time_fit_po214_fit_valid: bool | None = None
+    n_events_loaded: int = 0
+    n_events_discarded: int = 0
+    warnings: List[str] = field(default_factory=list)
+
+
+class _WarningCapture(logging.Handler):
+    """Logging handler that stores warning messages."""
+
+    def __init__(self):
+        super().__init__(level=logging.WARNING)
+        self.messages: List[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - simple
+        self.messages.append(record.getMessage())
+
+
+_warning_handler: _WarningCapture | None = None
+
+
+def start_warning_capture() -> None:
+    """Begin collecting warning messages from the root logger."""
+    global _warning_handler
+    if _warning_handler is None:
+        _warning_handler = _WarningCapture()
+        logging.getLogger().addHandler(_warning_handler)
+
+
+def get_captured_warnings() -> List[str]:
+    """Return and clear captured warning messages."""
+    global _warning_handler
+    if _warning_handler is None:
+        return []
+    logging.getLogger().removeHandler(_warning_handler)
+    msgs = list(_warning_handler.messages)
+    _warning_handler = None
+    return msgs
+
+
+__all__ = ["Diagnostics", "start_warning_capture", "get_captured_warnings"]

--- a/results/summary.json
+++ b/results/summary.json
@@ -2,5 +2,12 @@
   "radon": {
     "Rn_activity_Bq": 0.0,
     "stat_unc_Bq": 0.1
+  },
+  "diagnostics": {
+    "spectral_fit_fit_valid": true,
+    "time_fit_po214_fit_valid": true,
+    "n_events_loaded": 0,
+    "n_events_discarded": 0,
+    "warnings": []
   }
 }

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+
+from io_utils import Summary, write_summary
+from reporting import Diagnostics
+
+
+def test_diagnostics_written(tmp_path):
+    summary = Summary()
+    summary.diagnostics = Diagnostics(
+        spectral_fit_fit_valid=True,
+        time_fit_po214_fit_valid=False,
+        n_events_loaded=10,
+        n_events_discarded=2,
+        warnings=["example"]
+    )
+
+    results_dir = write_summary(tmp_path, summary)
+    summary_path = Path(results_dir) / "summary.json"
+    data = json.loads(summary_path.read_text())
+
+    assert "diagnostics" in data
+    diag = data["diagnostics"]
+    for key in {
+        "spectral_fit_fit_valid",
+        "time_fit_po214_fit_valid",
+        "n_events_loaded",
+        "n_events_discarded",
+        "warnings",
+    }:
+        assert key in diag


### PR DESCRIPTION
## Summary
- add `Diagnostics` dataclass and helper functions to capture warnings
- record diagnostics block in `Summary` and sample `summary.json`
- document diagnostics block and test for expected keys

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6757df974832bb2e214fd970d385a