### PR TITLE
Add diagnostics block to summary reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ the file:
 The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--job-id` is given the folder `<output_dir>/<job-id>/` is used instead. If `--output_dir` is omitted it defaults to `results`. If the folder already exists run with `--overwrite` to replace it. The directory includes:
 
 - `summary.json` – calibration and fit summary.
+- The file now includes a small `diagnostics` block with validation flags,
+  event counts and any collected warnings to quickly spot problems.
 - `config_used.json` – copy of the configuration used.
   Any timestamps overridden on the command line are written
   back to this file as ISO timestamps.

--- a/io_utils.py
+++ b/io_utils.py
@@ -88,6 +88,7 @@ class Summary(Mapping[str, Any]):
     cli_sha256: str | None = None
     cli_args: list[str] = field(default_factory=list)
     analysis: dict = field(default_factory=dict)
+    diagnostics: dict = field(default_factory=dict)
 
     def __getitem__(self, key: str) -> Any:  # type: ignore[override]
         return getattr(self, key)

--- a/reporting.py
+++ b/reporting.py
@@ -1,0 +1,77 @@
+"""Utility functions for writing summary diagnostics."""
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict, field
+from contextlib import contextmanager
+import logging
+from typing import Iterable, List, Dict, Any
+
+from io_utils import write_summary as _write_summary
+
+
+@dataclass
+class Diagnostics:
+    """Diagnostics block to be embedded in ``summary.json``."""
+
+    spectral_fit_fit_valid: bool = False
+    time_fit_po214_fit_valid: bool = False
+    n_events_loaded: int = 0
+    n_events_discarded: int = 0
+    warnings: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@contextmanager
+def capture_warnings() -> Iterable[List[str]]:
+    """Capture ``logging.WARNING`` level messages.
+
+    Examples
+    --------
+    >>> with capture_warnings() as w:
+    ...     logging.getLogger(__name__).warning("problem")
+    >>> w
+    ['problem']
+    """
+
+    records: List[str] = []
+
+    class _ListHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - trivial
+            if record.levelno >= logging.WARNING:
+                records.append(record.getMessage())
+
+    handler = _ListHandler()
+    root = logging.getLogger()
+    root.addHandler(handler)
+    try:
+        yield records
+    finally:
+        root.removeHandler(handler)
+
+
+def write_summary(summary: Dict[str, Any], output_dir: str, diagnostics: Diagnostics | Dict[str, Any], **kwargs) -> Any:
+    """Write a ``summary.json`` file including a diagnostics block.
+
+    Parameters
+    ----------
+    summary:
+        Base summary information.
+    output_dir:
+        Directory where ``summary.json`` should be created.
+    diagnostics:
+        Diagnostics information either as :class:`Diagnostics` or ``dict``.
+    **kwargs:
+        Additional keyword arguments passed through to
+        :func:`io_utils.write_summary`.
+    """
+
+    if isinstance(diagnostics, Diagnostics):
+        diag_dict = diagnostics.to_dict()
+    else:
+        diag_dict = dict(diagnostics)
+
+    summary = dict(summary)  # copy
+    summary["diagnostics"] = diag_dict
+    return _write_summary(output_dir, summary, **kwargs)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,26 @@
+import json
+from pathlib import Path
+
+import reporting
+
+
+def test_diagnostics_written(tmp_path):
+    diag = reporting.Diagnostics(
+        spectral_fit_fit_valid=True,
+        time_fit_po214_fit_valid=False,
+        n_events_loaded=10,
+        n_events_discarded=2,
+        warnings=["something"],
+    )
+    result_dir = reporting.write_summary({}, tmp_path, diag, timestamp="20000101T000000Z")
+    summary = json.loads((result_dir / "summary.json").read_text())
+    assert "diagnostics" in summary
+    block = summary["diagnostics"]
+    expected_keys = {
+        "spectral_fit_fit_valid",
+        "time_fit_po214_fit_valid",
+        "n_events_loaded",
+        "n_events_discarded",
+        "warnings",
+    }
+    assert expected_keys <= set(block)


### PR DESCRIPTION
## Summary
- add Diagnostics dataclass and helper to include validation flags and warning capture when writing summary.json
- extend Summary and README to mention new diagnostics block
- test that diagnostics keys are persisted in summary.json

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6757df974832bb2e214fd970d385a