### PR TITLE
Set spectral fit to default to binned likelihood and wider ADC bins

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,10 +464,13 @@ fit.  Important keys include:
   `"prominence"` applies `find_peaks` with the `peak_search_prominence` and
   `peak_search_width_adc` thresholds. `"cwt"` uses
   `find_peaks_cwt` with widths from `peak_search_cwt_widths`.
-- `peak_search_cwt_widths` – list of widths for wavelet peak detection
-  when `peak_search_method` is `"cwt"`.
-- `unbinned_likelihood` – when `true` use an extended unbinned likelihood
-  instead of the default χ² fit to histogrammed data.
+  - `peak_search_cwt_widths` – list of widths for wavelet peak detection
+    when `peak_search_method` is `"cwt"`.
+  - `adc_bin_width` – histogram bin width in ADC channels; default `2`.
+  - `use_plot_bins_for_fit` – when `true` use the plotting bin width for the
+    spectral fit; default `true`.
+  - `unbinned_likelihood` – when `true` use an extended unbinned likelihood
+    instead of the default χ² fit to histogrammed data; default `false`.
 - `emg_left` evaluations are wrapped in `np.errstate` and passed through
   `np.nan_to_num` for stability so that NaN or infinite values never
   reach `curve_fit`.

--- a/config.yaml
+++ b/config.yaml
@@ -72,7 +72,7 @@ calibration:
 spectral_fit:
   do_spectral_fit: true
   spectral_binning_mode: adc
-  adc_bin_width: 1
+  adc_bin_width: 2
   fd_hist_bins: 400
   mu_sigma: 0.02
   amp_prior_scale: 5.0
@@ -102,8 +102,8 @@ spectral_fit:
   peak_search_method: prominence
   peak_search_cwt_widths: null
   refit_aic_threshold: 2.0
-  use_plot_bins_for_fit: false
-  unbinned_likelihood: true
+  use_plot_bins_for_fit: true
+  unbinned_likelihood: false
   flags:
     fix_sigma0: false  # allow the width to float
     sigma0_prior:

--- a/examples/config_fixed_slope.json
+++ b/examples/config_fixed_slope.json
@@ -49,7 +49,7 @@
     "spectral_fit": {
         "do_spectral_fit": true,
         "spectral_binning_mode": "adc",
-        "adc_bin_width": 1,
+        "adc_bin_width": 2,
         "fd_hist_bins": 400,
         "mu_sigma": 0.05,
         "amp_prior_scale": 1.0,
@@ -73,7 +73,7 @@
         "peak_search_width_adc": 3,
         "peak_search_method": "prominence",
         "peak_search_cwt_widths": null,
-        "use_plot_bins_for_fit": false,
+        "use_plot_bins_for_fit": true,
         "unbinned_likelihood": false,
         "mu_bounds": {
             "Po210": null,


### PR DESCRIPTION
## Summary
- default spectral fit bin width increased to 2 ADC channels
- fit now uses plotting bins and χ² likelihood by default
- document new defaults in README and example config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a67c80a1f8832b9f07cd466c846824