### PR TITLE
docs: document binned Poisson spectral fit

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ analysis:
 See [docs/analysis-modes.md](docs/analysis-modes.md) for brief rationale and definitions.
 
 ### Radon vs. progeny mode
+
 `--iso radon` (default) combines Po-218 & Po-214 counts via BLUE to yield the parent Rn-222 activity.
 `--iso po218` or `--iso po214` fits an individual progeny chain only (useful for diagnostics).
-
 
 The script exits with an error message if filtering removes all events at any stage
 (noise cut, burst filter, time-window selection or baseline subtraction).
@@ -110,7 +110,7 @@ The input file must be a comma-separated table with these columns:
 - `fBits` – status bits or flags
 - `timestamp` – event timestamp in seconds
   (either numeric Unix seconds or an ISO‑8601 string; parsed directly to
-  timezone-aware ``pandas.Timestamp`` values via `time_utils.parse_timestamp`)
+  timezone-aware `pandas.Timestamp` values via `time_utils.parse_timestamp`)
 - `adc` – raw ADC value
 - `fchannel` – acquisition channel
 
@@ -120,15 +120,12 @@ sample layout which also includes typical auxiliary fields such as
 `pressure` and `humidity`.
 
 When your CSV uses different header names you can specify them under
-the `columns` section of the configuration.  Provide a mapping from the
+the `columns` section of the configuration. Provide a mapping from the
 canonical names (`timestamp`, `adc`, etc.) to the actual column names in
 the file:
 
 ```yaml
-"columns": {
-    "timestamp": "ftimestamps",
-    "adc": "fadc_channels"
-}
+"columns": { "timestamp": "ftimestamps", "adc": "fadc_channels" }
 ```
 
 ## Output
@@ -146,8 +143,8 @@ The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--j
 - `efficiency.png` – bar chart of individual efficiencies and the BLUE result.
 - `eff_cov.png` – heatmap of the efficiency covariance matrix.
 - `radon_activity.png` – extrapolated radon activity over time.
- - `equivalent_air.png` – equivalent air volume plot when `--ambient-file` or
-   `--ambient-concentration` is provided.
+- `equivalent_air.png` – equivalent air volume plot when `--ambient-file` or
+  `--ambient-concentration` is provided.
 
 The `time_fit` routine still fits only Po‑214 and Po‑218.
 When `window_po210` is provided the Po‑210 events are extracted and a
@@ -155,9 +152,9 @@ time‑series histogram is produced without a decay fit. The `hl_po210`
 value controls only the model curve drawn in this plot.
 
 The time‐series model multiplies the decay rate by the detection efficiency
-internally.  Therefore the fitted `E_Po214` and `E_Po218` values correspond to
+internally. Therefore the fitted `E_Po214` and `E_Po218` values correspond to
 the physical decay rates in Bq (decays/s) before any detector volume correction.
-Do **not** divide these results by the efficiency again.  To obtain the
+Do **not** divide these results by the efficiency again. To obtain the
 concentration simply convert the fitted rate to Bq/m³ using `utils.cps_to_bq`.
 For example:
 
@@ -168,34 +165,34 @@ from utils.time_utils import parse_timestamp
 t0 = parse_timestamp("2023-07-31T00:00:00Z")
 ```
 
-When using ``compute_radon_activity`` you should pass the fitted rates
+When using `compute_radon_activity` you should pass the fitted rates
 directly. They already represent activities in Bq and no additional
 division by the detection efficiency is required.
 
 The time-series fit checks whether the covariance matrix returned by
-Minuit is positive definite.  If not, a tiny diagonal jitter is added
-before repeating the check.  When even the jittered matrix fails this
-test the result still contains the fitted values but ``fit_valid`` is set
-to ``False``.  Passing ``strict=True`` (or ``--strict-covariance`` on the
-command line) instead raises a ``RuntimeError`` as soon as the matrix is
+Minuit is positive definite. If not, a tiny diagonal jitter is added
+before repeating the check. When even the jittered matrix fails this
+test the result still contains the fitted values but `fit_valid` is set
+to `False`. Passing `strict=True` (or `--strict-covariance` on the
+command line) instead raises a `RuntimeError` as soon as the matrix is
 found to be non-positive definite.
 
 ### Invalid fits
 
-When ``fit_valid`` is ``false`` the plotting routines omit fit overlays
+When `fit_valid` is `false` the plotting routines omit fit overlays
 and results are reported without extrapolating beyond the data.
 
 ## Configuration
 
-The parser is case sensitive, so all keys in ``config.yaml`` should be lowercase. Mixed-case names from older files remain supported for backward compatibility but are deprecated. If ``--config`` is not supplied, ``analyze.py`` automatically looks for a single ``config.yaml`` in the same directory as the script; additional configuration files are not supported.
+The parser is case sensitive, so all keys in `config.yaml` should be lowercase. Mixed-case names from older files remain supported for backward compatibility but are deprecated. If `--config` is not supplied, `analyze.py` automatically looks for a single `config.yaml` in the same directory as the script; additional configuration files are not supported.
 
-Key toggles in ``config.yaml`` include:
+Key toggles in `config.yaml` include:
 
-- ``spectral_fit.do_spectral_fit`` – enable or disable spectral fitting
-- ``time_fit.do_time_fit`` – run time-series fits
-- ``systematics.enable`` – evaluate systematic uncertainties
-- ``plotting.plot_save_formats`` – image formats to write
-- ``burst_filter.burst_mode`` – method for burst rejection
+- `spectral_fit.do_spectral_fit` – enable or disable spectral fitting
+- `time_fit.do_time_fit` – run time-series fits
+- `systematics.enable` – evaluate systematic uncertainties
+- `plotting.plot_save_formats` – image formats to write
+- `burst_filter.burst_mode` – method for burst rejection
 
 `nominal_adc` under the `calibration` section sets the expected raw ADC
 centroids for Po‑210, Po‑218 and Po‑214 when using automatic calibration.
@@ -203,10 +200,9 @@ If omitted, defaults of `{"Po210": 1250, "Po218": 1400, "Po214": 1800}`
 are used.
 
 `sanity_tolerance_mev` in the same section specifies how close the fitted
-peak energies must be to their known values.  The default of `0.5` MeV
+peak energies must be to their known values. The default of `0.5` MeV
 causes calibration to fail when any Po‑210, Po‑218 or Po‑214 centroid
 deviates by more than this amount.
-
 
 sigma_E_init — optional initial guess for the peak energy resolution (MeV).
 When present it is converted to an ADC width with the fixed calibration slope
@@ -214,19 +210,21 @@ and used only as the starting σ for the Po‑214 peak fit; it never replaces th
 fitted σ_E that is written to summary.json.
 
 calibration:
-  sigma_E_init: 0.015        # one value for all isotopes, in MeV
-  # or, per isotope:
-  sigma_E_init:
-    Po214: 0.012
-    Po218: 0.014
+sigma_E_init: 0.015 # one value for all isotopes, in MeV
+
+# or, per isotope:
+
+sigma_E_init:
+Po214: 0.012
+Po218: 0.014
 
 peak_widths — per‑isotope minimum widths (ADC channels) used when searching
-for peaks.  Isotopes not listed fall back to the global peak_width.
+for peaks. Isotopes not listed fall back to the global peak_width.
 
 calibration:
-  peak_width: 5              # global default
-  peak_widths:
-    Po214: 6                 # override for Po‑214 only
+peak_width: 5 # global default
+peak_widths:
+Po214: 6 # override for Po‑214 only
 
 slope_MeV_per_ch — fixes the linear calibration slope.
 
@@ -238,25 +236,26 @@ fit (Po‑210 & Po‑214) refines both slope and intercept.
 Po‑214 search entirely.
 
 calibration:
-  slope_MeV_per_ch: 0.00430
-  float_slope: true          # let the data refine it
-  # intercept_MeV: -0.12     # uncomment to skip Po‑214 search
+slope_MeV_per_ch: 0.00430
+float_slope: true # let the data refine it
+
+# intercept_MeV: -0.12 # uncomment to skip Po‑214 search
 
 CLI override: --calibration-slope VALUE always supersedes
 calibration.slope_MeV_per_ch.
-
 
 Per-isotope width thresholds may also be specified via `peak_widths` to
 override the global `peak_width` used during calibration. For example:
 
 ```yaml
 calibration:
-    peak_width: 5
-    peak_widths:
-        Po210: 5
-        Po218: 5
-        Po214: 6
+  peak_width: 5
+  peak_widths:
+    Po210: 5
+    Po218: 5
+    Po214: 6
 ```
+
 Any isotope omitted from `peak_widths` falls back to the global setting.
 
 `slope_MeV_per_ch` fixes the linear calibration slope:
@@ -270,10 +269,9 @@ Any isotope omitted from `peak_widths` falls back to the global setting.
 - The command-line option `--calibration-slope` overrides this value from the
   CLI.
 
-
-`noise_cutoff` defines a pedestal noise threshold in ADC.  Events with raw
-ADC values at or below this threshold are removed before any fits.  The
-default is `400`.  Set it to `null` to skip the cut entirely.  The
+`noise_cutoff` defines a pedestal noise threshold in ADC. Events with raw
+ADC values at or below this threshold are removed before any fits. The
+default is `400`. Set it to `null` to skip the cut entirely. The
 `analyze.py` pipeline applies this filter right after loading the event
 CSV.
 
@@ -305,80 +303,91 @@ When the cut is applied the analysis logs how many events were removed. This
 count also appears in `summary.json` under `noise_cut.removed_events`.
 
 `analysis_start_time` in the optional `analysis` section sets the global
-time origin for decay fitting and time-series plots.  Provide an
+time origin for decay fitting and time-series plots. Provide an
 ISO‑8601 string such as `"2023-07-31T00:00:00Z"` or the corresponding
-numeric Unix seconds.  When omitted the first event timestamp is used.
-
+numeric Unix seconds. When omitted the first event timestamp is used.
 
 All other time-related fields (`analysis_end_time`, `spike_start_time`,
 `spike_end_time`, `spike_periods`, `run_periods`, `radon_interval` and
 `baseline.range`) likewise accept absolute timestamps in ISO 8601
-format or numeric seconds.  All of these values are parsed with
+format or numeric seconds. All of these values are parsed with
 `time_utils.parse_timestamp` so the same formats apply everywhere.
 
 `analysis_end_time` may be specified to stop processing after the given
-timestamp.  `spike_start_time` discards all events after its value,
-while `spike_end_time` discards all events before its value.  When both
+timestamp. `spike_start_time` discards all events after its value,
+while `spike_end_time` discards all events before its value. When both
 are provided events between them are removed. `spike_periods` holds a
-list of `[start, end]` pairs where events are excluded entirely.  All of
+list of `[start, end]` pairs where events are excluded entirely. All of
 these accept either ISO‑8601 strings or numeric seconds and can also be
 set with the corresponding CLI options.
 `run_periods` specifies the intervals of valid data to keep after spike
-filtering.  Events falling outside all provided periods are discarded.
+filtering. Events falling outside all provided periods are discarded.
 `radon_interval` sets two timestamps used to compute the change in radon
 activity between them.
 
 `ambient_concentration` may also be specified here to record the ambient
-radon concentration in Bq/L used for the equivalent air plot.  The
-command-line option `--ambient-concentration` overrides this value.  The
-default configuration sets this key to `null`.  The template
+radon concentration in Bq/L used for the equivalent air plot. The
+command-line option `--ambient-concentration` overrides this value. The
+default configuration sets this key to `null`. The template
 `config.yaml` therefore includes
+
 ```yaml
 "ambient_concentration": null
 ```
+
 under the `analysis` section.
 
 Example snippet:
 
 ```yaml
-"analysis": {
+"analysis":
+  {
     "analysis_start_time": "2023-07-31T00:00:00Z",
     "analysis_end_time": "2024-02-01T06:00:00Z",
     "spike_start_time": null,
     "spike_end_time": "2023-07-31T00:10:00Z",
     "spike_periods": [["2023-11-12T00:00:00Z", "2023-11-13T12:00:00Z"]],
-    "run_periods": [["2023-09-28T00:00:00Z", "2023-10-28T23:59:59Z"], ["2024-01-05T00:00:00Z", "2024-01-10T23:59:59Z"]],
+    "run_periods":
+      [
+        ["2023-09-28T00:00:00Z", "2023-10-28T23:59:59Z"],
+        ["2024-01-05T00:00:00Z", "2024-01-10T23:59:59Z"],
+      ],
     "radon_interval": ["2024-01-05T06:00:00Z", "2024-01-06T18:00:00Z"],
-    "ambient_concentration": 0.02
-}
+    "ambient_concentration": 0.02,
+  }
 ```
 
 When present the value is also written to `summary.json` under the
 `analysis` section:
 
 ```yaml
-"analysis": {
+"analysis":
+  {
     "analysis_start_time": "2023-07-31T00:00:00Z",
     "analysis_end_time": "2024-02-01T06:00:00Z",
     "spike_start_time": null,
     "spike_end_time": "2023-07-31T00:10:00Z",
     "spike_periods": [["2023-11-12T00:00:00Z", "2023-11-13T12:00:00Z"]],
-    "run_periods": [["2023-09-28T00:00:00Z", "2023-10-28T23:59:59Z"], ["2024-01-05T00:00:00Z", "2024-01-10T23:59:59Z"]],
+    "run_periods":
+      [
+        ["2023-09-28T00:00:00Z", "2023-10-28T23:59:59Z"],
+        ["2024-01-05T00:00:00Z", "2024-01-10T23:59:59Z"],
+      ],
     "radon_interval": ["2024-01-05T06:00:00Z", "2024-01-06T18:00:00Z"],
-    "ambient_concentration": 0.02
-}
+    "ambient_concentration": 0.02,
+  }
 ```
 
 `--ambient-file` may be supplied instead to account for a
-time-dependent background.  The option expects a two-column text file
+time-dependent background. The option expects a two-column text file
 containing absolute timestamps (in seconds) and the corresponding
-ambient concentration in Bq/L.  These values are linearly interpolated
+ambient concentration in Bq/L. These values are linearly interpolated
 to the radon-activity timestamps and override any constant value when
 calling `plot_equivalent_air`.
 
-`burst_filter` controls removal of short high-rate clusters.  The
+`burst_filter` controls removal of short high-rate clusters. The
 `burst_mode` key selects the default strategy which can be overridden by
-the command-line option `--burst-mode`.  `none` disables the filter,
+the command-line option `--burst-mode`. `none` disables the filter,
 `micro` applies a short sliding-window veto defined by
 `micro_window_size_s` and `micro_count_threshold`, `rate` uses the
 rolling-median threshold (`burst_window_size_s`, `rolling_median_window`,
@@ -388,19 +397,20 @@ rate veto.
 Example snippet:
 
 ```yaml
-"burst_filter": {
+"burst_filter":
+  {
     "burst_mode": "rate",
     "burst_window_size_s": 60,
     "rolling_median_window": 5,
     "burst_multiplier": 5,
     "micro_window_size_s": 1,
-    "micro_count_threshold": 3
-}
+    "micro_count_threshold": 3,
+  }
 ```
 
 `time_bins_fallback` under the `plotting` section sets the number of histogram
 bins to use when the automatic [Freedman–Diaconis rule](https://en.wikipedia.org/wiki/Freedman%E2%80%93Diaconis_rule) fails,
-typically due to zero IQR.  The default is `1`.
+typically due to zero IQR. The default is `1`.
 
 The CLI options `--plot-time-binning-mode` (deprecated alias
 `--time-bin-mode`) and `--plot-time-bin-width` override
@@ -424,7 +434,7 @@ The half-lives used in the decay fit can also be changed with
 
 When the spectrum is binned in raw ADC channels (`"spectral_binning_mode": "adc"`),
 the bin edges are internally converted to energy using the calibration
-`slope_MeV_per_ch` (MeV per channel) and intercept before plotting.  This ensures `spectrum.png`
+`slope_MeV_per_ch` (MeV per channel) and intercept before plotting. This ensures `spectrum.png`
 reflects the calibrated energy scale regardless of binning mode.
 
 Custom `bin_edges` arrays may be supplied when calling the spectral fitting or
@@ -432,7 +442,7 @@ plotting routines. The edges can have variable widths but must be strictly
 increasing.
 
 The `spectral_fit` section provides priors for the unbinned likelihood
-fit.  Important keys include:
+fit. Important keys include:
 
 - `fd_hist_bins` – number of histogram bins to use when the automatic [Freedman–Diaconis rule](https://en.wikipedia.org/wiki/Freedman%E2%80%93Diaconis_rule) fails.
 - `mu_sigma` – uncertainty applied to peak centroids.
@@ -443,15 +453,15 @@ fit.  Important keys include:
   continuum terms.
 - `tau_{iso}_prior_mean` and `tau_{iso}_prior_sigma` – mean and
   uncertainty for the exponential tail constant of each isotope when
-  `use_emg` enables that tail.  Use a strictly positive prior mean (e.g.
-  ``0.005``) to prevent numerical overflow when the tail constant
+  `use_emg` enables that tail. Use a strictly positive prior mean (e.g.
+  `0.005`) to prevent numerical overflow when the tail constant
   approaches zero.
 - `use_emg` – mapping of isotopes to boolean flags selecting an
-  exponentially modified Gaussian tail.  If omitted Po‑210 defaults to
+  exponentially modified Gaussian tail. If omitted Po‑210 defaults to
   `true` while Po‑218 and Po‑214 default to `false`.
 - `mu_bounds` – optional lower/upper limits for each peak centroid.
   Set for example `{"Po218": [5.9, 6.2]}` to keep the Po‑218 fit from
-  drifting into the Po‑210 region.  Centroid guesses found during peak
+  drifting into the Po‑210 region. Centroid guesses found during peak
   search are clamped to this range before the fit starts.
 - `sigma_E_prior_source` – one-sigma width of the prior on the common
   energy resolution parameter. When omitted the uncertainty from the
@@ -475,44 +485,44 @@ fit.  Important keys include:
 Example snippet:
 
 ```yaml
-"spectral_fit": {
+"spectral_fit":
+  {
     "bkg_mode": "manual",
     "b0_prior": [0.0, 1.0],
     "b1_prior": [0.0, 1.0],
     "mu_sigma": 0.05,
     "amp_prior_scale": 1.0,
-    "unbinned_likelihood": false
-}
+    "unbinned_likelihood": false,
+  }
 ```
 
 `dump_time_series_json` under `plotting` saves a `*_ts.json` file
 containing the binned time-series data when set to `true`.
 
-
 `adc_drift_rate` under `systematics` applies a linear time-dependent
-shift to the raw ADC values before calibration.  The value is in ADC
-counts per second and defaults to `0.0` (no correction).  When the rate
+shift to the raw ADC values before calibration. The value is in ADC
+counts per second and defaults to `0.0` (no correction). When the rate
 is non-zero `analyze.py` applies the shift using
 `apply_linear_adc_shift` and stores the value in `summary.json` under
-`adc_drift_rate`.  More complex drift corrections can be configured via
-`adc_drift_mode` and `adc_drift_params`.  Supported modes are
+`adc_drift_rate`. More complex drift corrections can be configured via
+`adc_drift_mode` and `adc_drift_params`. Supported modes are
 `"linear"`, `"quadratic"` and `"piecewise"`; the last two require
 additional parameters as documented in `systematics.apply_linear_adc_shift`.
 
 `sigma_E_frac`, `tail_fraction` and `energy_shift_keV` provide the
-magnitude of systematic shifts applied during the scan.  The first two
+magnitude of systematic shifts applied during the scan. The first two
 are interpreted fractionally relative to the current parameter values,
 while `energy_shift_keV` is an absolute shift supplied in keV.
 Values with this suffix are automatically converted to MeV.
 Each entry is optional and only affects the scan when present.
 
 `plot_time_style` chooses how the histogram is drawn in the time-series
-plot.  Use `"steps"` (default) for a stepped histogram or `"lines"` to
-connect bin centers with straight lines.  The line style is useful when
+plot. Use `"steps"` (default) for a stepped histogram or `"lines"` to
+connect bin centers with straight lines. The line style is useful when
 overlaying multiple isotopes so one does not obscure the other.
 
 `overlay_isotopes` under `plotting` keeps both isotope windows intact
-when invoking `plot_time_series`.  When set to `true` the analysis does
+when invoking `plot_time_series`. When set to `true` the analysis does
 not clear the other window, allowing Po‑214 and Po‑218 to be plotted
 together on a single overlay.
 Specifying `window_po210` (and optional `eff_po210`) adds a Po‑210
@@ -523,28 +533,25 @@ fit results for Po‑210 are available.
 Available options are `"default"`, `"colorblind"` and `"grayscale"`.
 The command line option `--palette NAME` overrides the configuration.
 
-
 `plot_time_normalise_rate` controls how the y-axis is scaled in the
-time-series plot.  With the default `true` the histogram is normalised to
-counts per second.  Set it to `false` to show the raw counts per bin.
+time-series plot. With the default `true` the histogram is normalised to
+counts per second. Set it to `false` to show the raw counts per bin.
 
 Example snippet:
 
 ```yaml
-"plotting": {
-    "plot_time_normalise_rate": false
-}
+"plotting": { "plot_time_normalise_rate": false }
 ```
 
 `plot_time_series` can also display uncertainty bands around the model
-curves.  Pass arrays of propagated errors via the optional
-`model_errors` argument.  When running `analyze.py` these arrays are
+curves. Pass arrays of propagated errors via the optional
+`model_errors` argument. When running `analyze.py` these arrays are
 derived from the fitted parameters (`corrected_sigma`) so shaded +/-1 sigma
 regions appear alongside the dashed model lines.
 
 `plot_time_series` takes its half-life values from the `time_fit` section.
 Specify custom values using the keys `hl_po214`, `hl_po218` and `hl_po210`.
-When these keys are omitted or set to ``null`` the values fall back to the
+When these keys are omitted or set to `null` the values fall back to the
 physical half-lives of 1.64×10⁻⁴ s, 186 s and 1.1956×10⁷ s respectively.
 These custom half-lives control the
 decay model drawn over the time-series histogram.
@@ -555,12 +562,11 @@ them to the radon half-life (~3.8 days) to match the slowly varying
 radon activity.
 
 `sig_n0_po214` and `sig_n0_po218` set the uncertainty on the prior for the
-initial activity `N0` when no baseline range is provided.  Without a baseline,
+initial activity `N0` when no baseline range is provided. Without a baseline,
 the fit applies a Gaussian prior `(0, sig_n0_{iso.lower()})` so `N0` may vary
-rather than being fixed to zero.  Use the lower-case `sig_n0_{iso}` keys; the
-legacy `sig_N0_{iso}` form is still accepted for backward compatibility.  The default width is `1.0` if not
+rather than being fixed to zero. Use the lower-case `sig_n0_{iso}` keys; the
+legacy `sig_N0_{iso}` form is still accepted for backward compatibility. The default width is `1.0` if not
 specified in the configuration.
-
 
 `settling_time_s` was removed from the `time_fit` section and is no
 longer needed. The CLI option `--settle-s` may be used instead to
@@ -569,20 +575,21 @@ discard the first seconds of data before the decay fit.
 ### Fitting Long Time Scales
 
 When the data covers months or more, the short half-lives of Po‑218 and
-Po‑214 no longer matter.  You may set `hl_po214` and `hl_po218` to the
+Po‑214 no longer matter. You may set `hl_po214` and `hl_po218` to the
 radon half-life (330350.4 s ≈3.8 days) so the fit tracks the slowly varying
 radon concentration.
 
 Example snippet:
 
 ```yaml
-"time_fit": {
+"time_fit":
+  {
     "hl_po214": 328320,
     "hl_po218": 328320,
     "hl_po210": 11923200,
     "sig_n0_po214": 1.0,
-    "sig_n0_po218": 1.0
-}
+    "sig_n0_po218": 1.0,
+  }
 ```
 
 These half-life values may also be set on the command line with
@@ -603,7 +610,7 @@ an assay. Configuration must define these keys under `baseline`:
 Events collected during the baseline period are counted in the selected
 isotope windows. The counts for each isotope are converted into a decay
 rate in Bq by dividing by the baseline live time and the corresponding
-detection efficiency.  Each rate is scaled by the dilution factor
+detection efficiency. Each rate is scaled by the dilution factor
 `monitor_volume_l / (monitor_volume_l + sample_volume_l)` before being
 subtracted from the fitted radon decay rate of the assay. The multiplicative
 scale factors for Po-214, Po-218, Po-210 and electronic noise are stored in
@@ -615,22 +622,22 @@ The `--baseline-mode` option selects the background removal strategy.
 Valid modes are `none`, `electronics`, `radon` and `all` (default).
 
 Baseline subtraction for each isotope is handled by
-``radon.baseline.subtract_baseline_rate`` which combines the fitted rate
-with the raw baseline counts.  Internally it uses
-``radon.baseline.subtract_baseline_counts`` so that the propagated uncertainty reflects
-the unweighted event statistics of the analysis window. ``baseline_utils``
+`radon.baseline.subtract_baseline_rate` which combines the fitted rate
+with the raw baseline counts. Internally it uses
+`radon.baseline.subtract_baseline_counts` so that the propagated uncertainty reflects
+the unweighted event statistics of the analysis window. `baseline_utils`
 re-exports these helpers for backward compatibility.
-
 
 Example snippet:
 
 ```yaml
-"baseline": {
+"baseline":
+  {
     "range": ["2023-07-01T00:00:00Z", "2023-07-03T00:00:00Z"],
     "monitor_volume_l": 10.0,
     "sample_volume_l": 5.0,
-    "isotopes_to_subtract": ["Po214", "Po218"]
-}
+    "isotopes_to_subtract": ["Po214", "Po218"],
+  }
 ```
 
 Command line usage:
@@ -671,24 +678,24 @@ python analyze.py --config assay.yaml --input assay.csv --output_dir results \
 
 ### Baseline Subtraction Details
 
-Baseline subtraction relies on ``radon.baseline.subtract_baseline_counts``.
+Baseline subtraction relies on `radon.baseline.subtract_baseline_counts`.
 This helper expects the raw event counts from the analysis window, the
 corresponding live time, the number of counts observed during the baseline
-interval and its live time, together with the detection efficiency.  The
-function validates that the live times and efficiency are positive.  It
+interval and its live time, together with the detection efficiency. The
+function validates that the live times and efficiency are positive. It
 scales the baseline counts by the live‑time ratio before subtracting them
 and returns the corrected rate and its statistical uncertainty which
 includes contributions from both count sets.
 
-`summary.json` records these values under the ``baseline`` key:
+`summary.json` records these values under the `baseline` key:
 
-- ``analysis_counts`` – unweighted counts for each isotope in the analysis
+- `analysis_counts` – unweighted counts for each isotope in the analysis
   window.
-- ``rate_Bq`` and ``rate_unc_Bq`` – baseline decay rates and associated
+- `rate_Bq` and `rate_unc_Bq` – baseline decay rates and associated
   uncertainties.
-- ``dilution_factor`` – scale factor applied before subtracting the
+- `dilution_factor` – scale factor applied before subtracting the
   baseline rates from the fit.
-- ``corrected_rate_Bq`` and ``corrected_sigma_Bq`` – baseline-subtracted
+- `corrected_rate_Bq` and `corrected_sigma_Bq` – baseline-subtracted
   rates from the time-series fit and their uncertainties.
 
 ### Baseline Noise Cut
@@ -701,9 +708,7 @@ is specified, `analyze.py` forwards `calibration.noise_cutoff` as this value.
 Example configuration to tighten the cut (set it to `null` to disable):
 
 ```yaml
-"calibration": {
-    "noise_cutoff": 300
-}
+"calibration": { "noise_cutoff": 300 }
 ```
 
 ## Utility Conversions
@@ -726,13 +731,13 @@ centroids. Time parsing utilities are available from `utils.time_utils`:
   always yields a UTC `pandas.Timestamp`.
 - `to_epoch_seconds(ts_or_str)` from `utils.time_utils` converts these inputs to
   Unix seconds.
-- `baseline_utils.baseline_period_before_data(end, start)` returns ``True`` if
-  the baseline interval ends before the data window begins.  Both inputs may be
+- `baseline_utils.baseline_period_before_data(end, start)` returns `True` if
+  the baseline interval ends before the data window begins. Both inputs may be
   naïve or timezone-aware and are compared in UTC to avoid subtle mismatches.
 
 - `find_adc_bin_peaks(adc_values, expected, window=50, prominence=0.0, width=None, method="prominence")`
   histogramises the raw ADC spectrum, searches for maxima near each expected
-  centroid and returns a `{peak: adc_centroid}` mapping in ADC units.  Set
+  centroid and returns a `{peak: adc_centroid}` mapping in ADC units. Set
   `method="cwt"` to use wavelet-based peak detection via `find_peaks_cwt`.
 
 You can invoke these from the command line:
@@ -745,7 +750,7 @@ python utils.py 0.5 --to bq --volume_liters 10
 ## CalibrationResult Usage
 
 `calibration.CalibrationResult` stores the energy calibration
-parameters.  Use `predict()` to convert ADC values to MeV and
+parameters. Use `predict()` to convert ADC values to MeV and
 `uncertainty()` to propagate the 1-sigma error:
 
 ```python
@@ -764,11 +769,11 @@ sigmas = cal.uncertainty([1500, 1700])
 ## Radon Activity Output
 
 After the decay fits a weighted average of the Po‑218 and Po‑214 rates is
-converted to an instantaneous radon activity.  The result is written to
+converted to an instantaneous radon activity. The result is written to
 `summary.json` under `radon_results` together with the corresponding
 concentration (per liter) and the total amount of radon contained in the
-sample volume.  The file `radon_activity.png` visualises this
-activity versus time.  When either `--ambient-file` or
+sample volume. The file `radon_activity.png` visualises this
+activity versus time. When either `--ambient-file` or
 `--ambient-concentration` is supplied an additional plot
 `equivalent_air.png` shows the volume of ambient air containing the same
 activity.
@@ -777,7 +782,7 @@ ambient concentration data are available, `equivalent_air_po214.png`
 shows the equivalent air volume derived from this Po‑214 activity.
 
 If the combined activity of Po‑214 and Po‑218 is negative the pipeline
-aborts by default after clamping the result to zero.  Passing
+aborts by default after clamping the result to zero. Passing
 `--allow-negative-activity` preserves the negative value and processing
 continues.
 
@@ -793,20 +798,26 @@ for a particular run.
 
 `efficiency.py` implements helpers to derive efficiencies from spike,
 assay or decay data and combines multiple estimates using the BLUE
-method.  Each entry may be a single dictionary or a list of dictionaries
-which will be combined.  When the configuration file provides an
+method. Each entry may be a single dictionary or a list of dictionaries
+which will be combined. When the configuration file provides an
 `efficiency` section with entries such as:
 
 ```yaml
-"efficiency": {
-    "spike": [
-        {"counts": 1000, "activity_bq": 50, "live_time_s": 3600, "enabled": true}
-    ],
-    "assay": [
-        {"rate_cps": 0.8, "reference_bq": 2.0}
-    ]
-}
+"efficiency":
+  {
+    "spike":
+      [
+        {
+          "counts": 1000,
+          "activity_bq": 50,
+          "live_time_s": 3600,
+          "enabled": true,
+        },
+      ],
+    "assay": [{ "rate_cps": 0.8, "reference_bq": 2.0 }],
+  }
 ```
+
 Each spike entry may include an `enabled` flag (defaulting to `true`) to
 control whether the spike information contributes to the combined
 efficiency. `activity_bq` is the spike activity expressed in decays per
@@ -816,18 +827,18 @@ second (Bq).
 `summary.json` under the `efficiency` key.
 
 The helper `blue_combine.py` exposes a small wrapper so the combination
-can be used independently via ``from blue_combine import BLUE``.
+can be used independently via `from blue_combine import BLUE`.
 
 The option `--efficiency-json PATH` may be supplied on the command line to
 load the efficiency section from a separate file instead of embedding it
-directly in the main configuration.  Similarly `--systematics-json PATH`
+directly in the main configuration. Similarly `--systematics-json PATH`
 overrides the `systematics` section.
-
 
 ## Running Tests
 
 Install the required packages from `requirements.txt` before running the tests.
 You can do this directly or via the provided helper script:
+
 ```bash
 pip install -r requirements.txt   # or: bash scripts/setup_tests.sh
 pytest -v
@@ -856,7 +867,6 @@ grep -R "\<_seconds(" -n
 These patterns catch leftover calls without flagging legitimate
 `datetime.timedelta.total_seconds()` usage.
 
-
 ## Hierarchical Analysis
 
 Use `hierarchical.py` to perform Bayesian hierarchical inference across multiple runs. The function `fit_hierarchical_runs` pools measurements of the half-life and calibration constants. It returns posterior means, standard deviations and 95% credible intervals for the global parameters. Running `analyze.py` with `--hierarchical-summary result.json` collects the half-life and calibration outputs from all `summary.json` files under the chosen output directory and writes the combined fit to `result.json`.
@@ -882,3 +892,20 @@ summary = fit_hierarchical_runs(run_results)
 print(summary)
 ```
 
+## Spectral fit hardening and defaults
+
+The spectral fit now uses a binned Poisson likelihood by default for more
+robust handling of sparse spectra. The legacy extended unbinned likelihood
+remains available but must be explicitly enabled.
+
+Key configuration options:
+
+- `unbinned_likelihood` – set to `true` to use the extended unbinned likelihood.
+- `adc_bin_width` – ADC channel width used when constructing the fit histogram.
+- `use_plot_bins_for_fit` – reuse plot binning for the likelihood fit.
+
+Example CLI invocation (binned fit is used by default):
+
+```bash
+python analyze.py --input merged_data.csv
+```


### PR DESCRIPTION
## Summary
- document default binned Poisson spectral fit
- list new spectral fit configuration keys
- show example CLI call

## Testing
- `npx prettier -w README.md`
- `npx --yes markdownlint-cli README.md` (warnings: line length, heading)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a67c7f6fa0832b843f0c0f1390239e