### PR TITLE
Add stable log(exp(x)-1) helper and tests

### DIFF
--- a/math_utils.py
+++ b/math_utils.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+
+def log_expm1_stable(x):
+    """Return ``log(exp(x) - 1)`` in a numerically stable way.
+
+    For large positive ``x`` values ``np.expm1(x)`` will overflow. In this
+    regime we instead compute ``x + log1p(-exp(-x))`` which is algebraically
+    equivalent but avoids overflow. For smaller values ``np.log(np.expm1(x))``
+    provides accurate results.
+
+    Parameters
+    ----------
+    x : array_like
+        Input value or array of values.
+
+    Returns
+    -------
+    numpy.ndarray or float
+        The element-wise ``log(exp(x) - 1)``.
+    """
+    x_arr = np.asarray(x, dtype=float)
+    threshold = np.log(np.finfo(float).max)
+
+    # ``np.where`` evaluates both branches so we must explicitly mask to avoid
+    # calling ``np.expm1`` on large values which would overflow.  Working on the
+    # masked arrays keeps the implementation vectorised while preventing
+    # spurious runtime warnings.
+    res = np.empty_like(x_arr)
+    mask = x_arr < threshold
+    res[mask] = np.log(np.expm1(x_arr[mask]))
+    res[~mask] = x_arr[~mask] + np.log1p(-np.exp(-x_arr[~mask]))
+    return res

--- a/tests/test_math_utils.py
+++ b/tests/test_math_utils.py
@@ -1,0 +1,22 @@
+import numpy as np
+import sys
+from pathlib import Path
+
+# Add repository root to path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from math_utils import log_expm1_stable
+
+
+def test_log_expm1_stable_agrees_with_numpy():
+    vals = np.array([1e-10, 1e-5, 1.0, 20.0, 700.0])
+    expected = np.log(np.expm1(vals))
+    out = log_expm1_stable(vals)
+    assert np.allclose(out, expected)
+
+
+def test_log_expm1_stable_monotonic_large_inputs():
+    a = log_expm1_stable(800.0)
+    b = log_expm1_stable(1000.0)
+    assert np.isfinite(a) and np.isfinite(b)
+    assert b > a


### PR DESCRIPTION
## Summary
- Implement `log_expm1_stable` to compute `log(exp(x)-1)` without overflow for large x
- Add tests validating numerical agreement with NumPy and monotonicity for huge inputs

## Testing
- `pytest -q tests/test_math_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a67c7ead5c832ba6f4fb91aaff7d15