### PR TITLE
feat: default binned spectral likelihood and stable expm1

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ fit.  Important keys include:
 - `peak_search_cwt_widths` – list of widths for wavelet peak detection
   when `peak_search_method` is `"cwt"`.
 - `unbinned_likelihood` – when `true` use an extended unbinned likelihood
-  instead of the default χ² fit to histogrammed data.
+  instead of the default binned Poisson likelihood.
 - `emg_left` evaluations are wrapped in `np.errstate` and passed through
   `np.nan_to_num` for stability so that NaN or infinite values never
   reach `curve_fit`.
@@ -880,5 +880,17 @@ run_results = [
 
 summary = fit_hierarchical_runs(run_results)
 print(summary)
+```
+
+## Spectral fit hardening and defaults
+
+The spectral fitting routine now defaults to a binned Poisson likelihood
+for improved numerical stability. Set `spectral_fit.unbinned_likelihood`
+to `true` in your configuration to restore the previous unbinned path.
+
+Example command line:
+
+```bash
+python analyze.py --input path/to/merged_output.csv
 ```
 

--- a/config.yaml
+++ b/config.yaml
@@ -72,7 +72,7 @@ calibration:
 spectral_fit:
   do_spectral_fit: true
   spectral_binning_mode: adc
-  adc_bin_width: 1
+  adc_bin_width: 2
   fd_hist_bins: 400
   mu_sigma: 0.02
   amp_prior_scale: 5.0
@@ -102,8 +102,8 @@ spectral_fit:
   peak_search_method: prominence
   peak_search_cwt_widths: null
   refit_aic_threshold: 2.0
-  use_plot_bins_for_fit: false
-  unbinned_likelihood: true
+  use_plot_bins_for_fit: true
+  unbinned_likelihood: false
   flags:
     fix_sigma0: false  # allow the width to float
     sigma0_prior:

--- a/math_utils.py
+++ b/math_utils.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+
+def log_expm1_stable(y: np.ndarray) -> np.ndarray:
+    """Return ``log(expm1(y))`` with improved stability.
+
+    Parameters
+    ----------
+    y : np.ndarray
+        Input array of finite values.
+
+    Returns
+    -------
+    np.ndarray
+        Element-wise ``log(expm1(y))`` computed in a numerically stable way.
+    """
+    y = np.asarray(y, dtype=float)
+    out = np.empty_like(y)
+    mask = y > 0
+    # For positive values use y + log1p(-exp(-y)) to avoid overflow
+    out[mask] = y[mask] + np.log1p(-np.exp(-y[mask]))
+    # For non-positive values use log(expm1(y)) with argument clamped away from zero
+    tiny = np.finfo(y.dtype).tiny
+    expm1_vals = np.expm1(y[~mask])
+    expm1_vals = np.clip(expm1_vals, tiny, None)
+    out[~mask] = np.log(expm1_vals)
+    return out

--- a/tests/test_math_utils.py
+++ b/tests/test_math_utils.py
@@ -1,0 +1,22 @@
+import numpy as np
+from math_utils import log_expm1_stable
+
+
+def test_log_expm1_stable_matches_numpy():
+    y = np.array([-50.0, -1e-6, 0.0, 1e-6, 1.0, 10.0])
+    expected = np.empty_like(y)
+    mask = y > 0
+    expected[mask] = y[mask] + np.log1p(-np.exp(-y[mask]))
+    expm1_vals = np.expm1(y[~mask])
+    tiny = np.finfo(float).tiny
+    expm1_vals = np.clip(expm1_vals, tiny, None)
+    expected[~mask] = np.log(expm1_vals)
+    actual = log_expm1_stable(y)
+    assert np.allclose(actual, expected, rtol=1e-12, atol=0)
+
+
+def test_log_expm1_stable_large_values():
+    vals = np.array([800.0, 1000.0])
+    out = log_expm1_stable(vals)
+    assert np.isfinite(out).all()
+    assert out[1] > out[0]


### PR DESCRIPTION
## Summary
- add `log_expm1_stable` to avoid overflow
- switch spectral fits to binned Poisson likelihood by default
- expose configuration defaults for binned fits and document changes

## Testing
- `pytest -q`
- `python analyze.py --input example_input.csv`

------
https://chatgpt.com/codex/tasks/task_e_68a67b099fb0832bb3356d5804ef6821