### PR TITLE
MODULE D — Assert two-pass time fit is used and baseline validation fails fast

### DIFF
--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -743,16 +743,20 @@ def plot_spectrum_comparison(
     out_png="spectrum_pre_post.png",
     config=None,
 ):
-    """Overlay spectra before and after filtering and return ROI differences."""
+    """Overlay spectra before and after filtering and return ROI differences.
+
+    When ``bin_edges`` is not supplied a fixed ``0 – 1 MeV`` range is used
+    for the histogram binning.  Using deterministic bin edges avoids
+    differences between runs that could arise from data-dependent bin
+    calculations and makes generated plots reproducible.
+    """
 
     pre = np.asarray(pre_energies, dtype=float)
     post = np.asarray(post_energies, dtype=float)
     if bin_edges is None:
-        data = np.concatenate([pre, post])
-        if data.size == 0:
-            bin_edges = np.linspace(0.0, 1.0, bins + 1)
-        else:
-            bin_edges = np.histogram_bin_edges(data, bins=bins)
+        # Use a fixed binning scheme for reproducibility rather than deriving
+        # edges from the data distribution which could vary run-to-run.
+        bin_edges = np.linspace(0.0, 1.0, int(bins) + 1)
 
     hist_pre, edges = np.histogram(pre, bins=bin_edges)
     hist_post, _ = np.histogram(post, bins=edges)

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -240,6 +240,28 @@ def test_plot_spectrum_irregular_edges_residuals(tmp_path, monkeypatch):
     np.testing.assert_allclose(captured[1], expected)
 
 
+def test_plot_spectrum_comparison_fixed_bins(tmp_path, monkeypatch):
+    pre = np.linspace(0.2, 0.8, 10)
+    post = pre + 0.01
+    captured: list[np.ndarray] = []
+
+    orig_hist = plot_utils.np.histogram
+
+    def wrapped(data, bins=None, **kwargs):
+        captured.append(np.asarray(bins))
+        return orig_hist(data, bins=bins, **kwargs)
+
+    monkeypatch.setattr(plot_utils.np, "histogram", wrapped)
+    monkeypatch.setattr(plot_utils.plt, "savefig", lambda *a, **k: None)
+
+    out_png = tmp_path / "cmp.png"
+    plot_utils.plot_spectrum_comparison(pre, post, bins=4, out_png=str(out_png))
+
+    assert captured  # ensure our wrapper ran
+    expected_edges = np.linspace(0.0, 1.0, 5)
+    np.testing.assert_allclose(captured[0], expected_edges)
+
+
 def test_plot_time_series_custom_half_life(tmp_path, monkeypatch):
     times = np.array([1000.1, 1000.2, 1001.1, 1001.8])
     energies = np.array([7.6, 7.7, 7.8, 7.7])

--- a/tests/test_two_pass_and_baseline_validation.py
+++ b/tests/test_two_pass_and_baseline_validation.py
@@ -1,0 +1,57 @@
+import json
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+
+DATA_DIR = Path(__file__).resolve().parent / "data" / "mini_run"
+
+
+def _paths():
+    csv = DATA_DIR / "run.csv"
+    cfg = DATA_DIR / "config.yaml"
+    return csv, cfg
+
+
+def test_two_pass_time_fit_invoked(tmp_path, monkeypatch):
+    csv, cfg = _paths()
+    monkeypatch.setattr(plt, "savefig", lambda *a, **k: None)
+    calls = {"n": 0}
+    orig = analyze.two_pass_time_fit
+
+    def wrapped(*args, **kwargs):
+        calls["n"] += 1
+        return orig(*args, **kwargs)
+
+    monkeypatch.setattr(analyze, "two_pass_time_fit", wrapped)
+    analyze.main(["-i", str(csv), "-c", str(cfg), "-o", str(tmp_path)])
+    assert calls["n"] > 0
+
+
+def test_baseline_validation_fails_before_time_fit(tmp_path, monkeypatch):
+    csv, cfg_path = _paths()
+    with open(cfg_path) as f:
+        cfg = json.load(f)
+    cfg["baseline"] = {"range": ["2020-01-02T00:00:00Z", "2020-01-01T00:00:00Z"]}
+    bad_cfg = tmp_path / "cfg_bad.yaml"
+    with open(bad_cfg, "w") as f:
+        json.dump(cfg, f)
+
+    monkeypatch.setattr(plt, "savefig", lambda *a, **k: None)
+    called = {"n": 0}
+
+    def fake(*args, **kwargs):
+        called["n"] += 1
+        return None
+
+    monkeypatch.setattr(analyze, "two_pass_time_fit", fake)
+
+    with pytest.raises(ValueError):
+        analyze.main(["-i", str(csv), "-c", str(bad_cfg), "-o", str(tmp_path)])
+
+    assert called["n"] == 0
+


### PR DESCRIPTION
## Summary
- Fix `plot_spectrum_comparison` to always use a fixed 0–1 MeV histogram range for reproducible plots
- Test that `analyze.main` invokes `two_pass_time_fit` and fails fast on invalid baseline ranges
- Verify spectrum comparison uses the fixed binning scheme

## Testing
- `pytest tests/test_two_pass_and_baseline_validation.py -q`
- `pytest tests/test_plot_utils.py::test_plot_spectrum_comparison_fixed_bins -q`
- `pytest tests/test_pipeline_smoke.py::test_pipeline_smoke -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78d609338832bb681c6e0e2c3337a