### PR TITLE
Always attach a minimal diagnostics dictionary to the run summary

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -616,6 +616,10 @@ def write_summary(
 
     sanitized = to_native(summary_dict)
 
+    # Ensure a diagnostics block is always present
+    if not isinstance(sanitized.get("diagnostics"), dict):
+        sanitized["diagnostics"] = to_native(Diagnostics())
+
     with open(summary_path, "w", encoding="utf-8") as f:
         json.dump(sanitized, f, indent=4)
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from io_utils import Summary, write_summary
 from reporting import Diagnostics
+from utils import to_native
 
 
 def test_diagnostics_written(tmp_path):
@@ -29,3 +30,10 @@ def test_diagnostics_written(tmp_path):
         "warnings",
     }:
         assert key in diag
+
+
+def test_diagnostics_default_written(tmp_path):
+    results_dir = write_summary(tmp_path, {})
+    summary_path = Path(results_dir) / "summary.json"
+    data = json.loads(summary_path.read_text())
+    assert data["diagnostics"] == to_native(Diagnostics())


### PR DESCRIPTION
## Summary
- Ensure `write_summary` always includes a diagnostics block, creating an empty one when absent
- Add test verifying default diagnostics are written for summaries without diagnostics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a78d534b60832b999170dc5929bb9c