### PR TITLE
Ensure diagnostics always present in summary output

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -616,6 +616,9 @@ def write_summary(
 
     sanitized = to_native(summary_dict)
 
+    if "diagnostics" not in sanitized or sanitized["diagnostics"] is None:
+        sanitized["diagnostics"] = to_native(Diagnostics())
+
     with open(summary_path, "w", encoding="utf-8") as f:
         json.dump(sanitized, f, indent=4)
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -29,3 +29,18 @@ def test_diagnostics_written(tmp_path):
         "warnings",
     }:
         assert key in diag
+
+
+def test_minimal_diagnostics_inserted(tmp_path):
+    results_dir = write_summary(tmp_path, {})
+    summary_path = Path(results_dir) / "summary.json"
+    data = json.loads(summary_path.read_text())
+
+    assert "diagnostics" in data
+    assert data["diagnostics"] == {
+        "spectral_fit_fit_valid": None,
+        "time_fit_po214_fit_valid": None,
+        "n_events_loaded": 0,
+        "n_events_discarded": 0,
+        "warnings": [],
+    }


### PR DESCRIPTION
## Summary
- Guarantee `summary.json` always includes a `diagnostics` block with default fields
- Add regression test covering default diagnostics insertion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a78d534b60832b999170dc5929bb9c