### PR TITLE
Ensure diagnostics block in summary

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -616,6 +616,18 @@ def write_summary(
 
     sanitized = to_native(summary_dict)
 
+    # Ensure a diagnostics block is always present in the summary.  Some
+    # callers may provide a plain mapping without the ``diagnostics`` key;
+    # others may supply a partial dictionary.  Attach a minimal set of
+    # diagnostics fields in these cases so downstream consumers can rely on
+    # their existence.
+    diag_defaults = to_native(Diagnostics())
+    if not isinstance(sanitized.get("diagnostics"), dict):
+        sanitized["diagnostics"] = diag_defaults
+    else:
+        for k, v in diag_defaults.items():
+            sanitized["diagnostics"].setdefault(k, v)
+
     with open(summary_path, "w", encoding="utf-8") as f:
         json.dump(sanitized, f, indent=4)
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from io_utils import Summary, write_summary
 from reporting import Diagnostics
+from dataclasses import asdict
 
 
 def test_diagnostics_written(tmp_path):
@@ -29,3 +30,12 @@ def test_diagnostics_written(tmp_path):
         "warnings",
     }:
         assert key in diag
+
+
+def test_missing_diagnostics_are_injected(tmp_path):
+    results_dir = write_summary(tmp_path, {})
+    summary_path = Path(results_dir) / "summary.json"
+    data = json.loads(summary_path.read_text())
+
+    assert "diagnostics" in data
+    assert data["diagnostics"] == asdict(Diagnostics())


### PR DESCRIPTION
## Summary
- Always include a diagnostics section when writing `summary.json`
- Add regression test confirming missing diagnostics are injected

## Testing
- `python -m pytest tests/test_reporting.py -q`
- `python -m pytest tests/test_io_utils.py::test_write_summary_and_copy_config tests/test_io_utils.py::test_write_summary_with_nullable_integers tests/test_io_utils.py::test_write_summary_with_nan_values -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78d534b60832b999170dc5929bb9c