### PR TITLE
Module C: always include diagnostics in summary

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -615,6 +615,10 @@ def write_summary(
     summary_path = results_folder / "summary.json"
 
     sanitized = to_native(summary_dict)
+    # Ensure a diagnostics block is always present
+    diag = sanitized.get("diagnostics")
+    if not isinstance(diag, Mapping):
+        sanitized["diagnostics"] = to_native(Diagnostics())
 
     with open(summary_path, "w", encoding="utf-8") as f:
         json.dump(sanitized, f, indent=4)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from dataclasses import asdict
 
 from io_utils import Summary, write_summary
 from reporting import Diagnostics
@@ -29,3 +30,12 @@ def test_diagnostics_written(tmp_path):
         "warnings",
     }:
         assert key in diag
+
+
+def test_minimal_diagnostics_added(tmp_path):
+    # Summary dictionary without diagnostics should still get a diagnostics block
+    results_dir = write_summary(tmp_path, {})
+    summary_path = Path(results_dir) / "summary.json"
+    data = json.loads(summary_path.read_text())
+
+    assert data["diagnostics"] == asdict(Diagnostics())


### PR DESCRIPTION
## Summary
- guarantee a diagnostics block is present in `summary.json`
- test that minimal diagnostics are injected when none are provided

## Testing
- `pytest tests/test_reporting.py -q`
- `pytest tests/test_io_utils.py::test_write_summary_and_copy_config tests/test_io_utils.py::test_write_summary_with_nullable_integers tests/test_io_utils.py::test_write_summary_with_nan_values -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a78d534b60832b999170dc5929bb9c