### PR TITLE
Default spectral path is binned Poisson; unbinned is opt-in, and the chosen path is recorded

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -2960,6 +2960,8 @@ def main(argv=None):
         spec_dict = dict(spectrum_results.params)
         spec_dict["cov"] = spectrum_results.cov.tolist()
         spec_dict["ndf"] = spectrum_results.ndf
+        if spectrum_results.likelihood is not None:
+            spec_dict["likelihood"] = spectrum_results.likelihood
     elif isinstance(spectrum_results, dict):
         spec_dict = spectrum_results
     if peak_deviation:

--- a/fitting.py
+++ b/fitting.py
@@ -142,6 +142,7 @@ class FitResult:
     ndf: int
     param_index: dict[str, int] | None = None
     counts: int | None = None
+    likelihood: str | None = None
     _cov_df: pd.DataFrame | None = field(init=False, default=None, repr=False)
 
     def __post_init__(self):
@@ -608,7 +609,9 @@ def fit_spectrum(
             out["chi2"] = float(2 * m.fval)
             out["chi2_ndf"] = out["chi2"] / ndf if ndf != 0 else np.nan
             out["aic"] = float(2 * m.fval + 2 * k)
-            return FitResult(out, cov, int(ndf), param_index, counts=int(n_events))
+            return FitResult(
+                out, cov, int(ndf), param_index, counts=int(n_events), likelihood="binned_poisson"
+            )
 
         m.hesse()
         cov_raw = m.covariance
@@ -675,7 +678,9 @@ def fit_spectrum(
             cov = np.zeros((len(param_order), len(param_order)))
             k = len(param_order)
             out["aic"] = float(2 * m.fval + 2 * k)
-            return FitResult(out, cov, int(ndf), param_index, counts=int(n_events))
+            return FitResult(
+                out, cov, int(ndf), param_index, counts=int(n_events), likelihood="unbinned"
+            )
 
         m.hesse()
         cov_raw = m.covariance
@@ -730,7 +735,9 @@ def fit_spectrum(
             out["dF"] = 0.0
         k = len(param_order)
         out["aic"] = float(2 * m.fval + 2 * k)
-        return FitResult(out, cov, int(ndf), param_index, counts=int(n_events))
+        return FitResult(
+            out, cov, int(ndf), param_index, counts=int(n_events), likelihood="unbinned"
+        )
 
     g = np.ones(len(param_order))
     for i, name in enumerate(param_order):
@@ -791,7 +798,9 @@ def fit_spectrum(
     k = len(popt)
     out["aic"] = float(2 * nll_val + 2 * k)
     param_index = {name: i for i, name in enumerate(param_order)}
-    return FitResult(out, pcov, int(ndf), param_index, counts=int(n_events))
+    return FitResult(
+        out, pcov, int(ndf), param_index, counts=int(n_events), likelihood="binned_poisson"
+    )
 
 
 def _integral_model(E, N0, B, lam, eff, T):

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -430,6 +430,7 @@ def test_fit_spectrum_unbinned_runs():
     out = fit_spectrum(energies, priors, unbinned=True)
     assert "sigma0" in out.params
     assert "F" in out.params
+    assert out.likelihood == "unbinned"
 
 
 def test_fit_spectrum_unbinned_consistent():
@@ -457,6 +458,34 @@ def test_fit_spectrum_unbinned_consistent():
     out_unbinned = fit_spectrum(energies, priors, unbinned=True)
     diff = abs(out_hist.params["mu_Po210"] - out_unbinned.params["mu_Po210"])
     assert diff < 0.2
+
+
+def test_fit_spectrum_records_path():
+    rng = np.random.default_rng(123)
+    energies = np.concatenate([
+        rng.normal(5.3, 0.05, 100),
+        rng.normal(6.0, 0.05, 100),
+        rng.normal(7.7, 0.05, 100),
+    ])
+
+    priors = {
+        "sigma0": (0.05, 0.01),
+        "F": (0.0, 0.01),
+        "mu_Po210": (5.3, 0.1),
+        "S_Po210": (100, 10),
+        "mu_Po218": (6.0, 0.1),
+        "S_Po218": (100, 10),
+        "mu_Po214": (7.7, 0.1),
+        "S_Po214": (100, 10),
+        "b0": (0.0, 1.0),
+        "b1": (0.0, 1.0),
+    }
+
+    out_binned = fit_spectrum(energies, priors)
+    assert out_binned.likelihood == "binned_poisson"
+
+    out_unbinned = fit_spectrum(energies, priors, unbinned=True)
+    assert out_unbinned.likelihood == "unbinned"
 
 
 def test_fit_spectrum_fixed_resolution():


### PR DESCRIPTION
## Summary
- track which spectral likelihood branch runs via a new `likelihood` field on `FitResult`
- default binned spectrum path records `binned_poisson` while unbinned mode records `unbinned`
- surface the chosen likelihood in the summary JSON and add tests for both paths

## Testing
- `pytest tests/test_fitting.py::test_fit_spectrum_unbinned_runs tests/test_fitting.py::test_fit_spectrum_records_path -q`
- `pytest tests/test_cov_entry.py -q`
- `pytest tests/test_fitting.py::test_fit_spectrum_unbinned_consistent -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78d49cacc832b827e58aa91183da3