### PR TITLE
MODULE B — Make binned Poisson the observable default and test both branches

### DIFF
--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -430,6 +430,32 @@ def test_fit_spectrum_unbinned_runs():
     out = fit_spectrum(energies, priors, unbinned=True)
     assert "sigma0" in out.params
     assert "F" in out.params
+    assert out.likelihood == "unbinned"
+
+
+def test_fit_spectrum_records_binned_default():
+    rng = np.random.default_rng(17)
+    energies = np.concatenate([
+        rng.normal(5.3, 0.05, 100),
+        rng.normal(6.0, 0.05, 100),
+        rng.normal(7.7, 0.05, 100),
+    ])
+
+    priors = {
+        "sigma0": (0.05, 0.01),
+        "F": (0.0, 0.01),
+        "mu_Po210": (5.3, 0.1),
+        "S_Po210": (100, 10),
+        "mu_Po218": (6.0, 0.1),
+        "S_Po218": (100, 10),
+        "mu_Po214": (7.7, 0.1),
+        "S_Po214": (100, 10),
+        "b0": (0.0, 1.0),
+        "b1": (0.0, 1.0),
+    }
+
+    out = fit_spectrum(energies, priors)
+    assert out.likelihood == "binned_poisson"
 
 
 def test_fit_spectrum_unbinned_consistent():


### PR DESCRIPTION
## Summary
- Extend `FitResult` with a `likelihood` field and have `fit_spectrum` record whether the binned Poisson or unbinned path was used.
- Default spectrum fit now reports `binned_poisson`; switching to unbinned sets `unbinned`.
- Add tests covering both branches and verifying the recorded likelihood.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78d49cacc832b827e58aa91183da3