### PR TITLE
Enforce two-pass time fit and baseline checks on the main path, and set plotting to fixed bins for reproducibility

### DIFF
--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -212,7 +212,12 @@ def plot_time_series(
             config.get("time_bin_mode", "fixed"),
         )
     ).lower()
-    if bin_mode in ("fd", "auto"):
+    if bin_mode == "auto":
+        # ``auto`` previously invoked the Freedman–Diaconis rule which can
+        # yield run-to-run differences.  Map it to ``fixed`` for
+        # reproducibility.
+        bin_mode = "fixed"
+    if bin_mode == "fd":
         # Freedman Diaconis rule on the entire time range:
         data = times_rel[(times_rel >= 0) & (times_rel <= (t_end - t_start))]
         if len(data) < 2:
@@ -247,10 +252,10 @@ def plot_time_series(
     # ------------------------------------------------------------------
     # Build equally-spaced edges so delta t is identical for each bin
     # ------------------------------------------------------------------
-    if bin_mode not in ("fd", "auto"):
-        edges = np.arange(0, (n_bins + 1) * dt, dt, dtype=float)
-    else:
+    if bin_mode == "fd":
         edges = np.linspace(0, (t_end - t_start), n_bins + 1)
+    else:
+        edges = np.arange(0, (n_bins + 1) * dt, dt, dtype=float)
     centers = 0.5 * (edges[:-1] + edges[1:])
     centers_abs = t_start + centers
     centers_mpl = guard_mpl_times(times=centers_abs)

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -122,18 +122,18 @@ def test_plot_time_series_invalid_fit_po218_skips_model(tmp_path, monkeypatch):
     assert not calls
 
 
-def test_plot_time_series_auto_fd(tmp_path):
+def test_plot_time_series_fd(tmp_path):
     # 100 uniform events over 5 seconds
     times = 1000.0 + np.linspace(0, 5, 100)
     energies = np.full(100, 7.7)
     cfg = basic_config()
     cfg.update({
-        "plot_time_binning_mode": "AUTO",
+        "plot_time_binning_mode": "FD",
         "dump_time_series_json": True,
     })
-    out_png = tmp_path / "ts_auto.png"
+    out_png = tmp_path / "ts_fd.png"
     plot_time_series(times, energies, None, 1000.0, 1005.0, cfg, str(out_png))
-    js = out_png.with_name("ts_auto_ts.json")
+    js = out_png.with_name("ts_fd_ts.json")
     assert out_png.exists() and js.exists()
 
     import json
@@ -1028,7 +1028,7 @@ def test_plot_time_series_datetime64(tmp_path):
     )
     energies = np.array([7.7, 7.8, 7.7])
     cfg = basic_config()
-    cfg.update({"plot_time_binning_mode": "auto", "time_bins_fallback": 1})
+    cfg.update({"plot_time_binning_mode": "fd", "time_bins_fallback": 1})
     out_png = tmp_path / "ts_dt.png"
 
     plot_time_series(

--- a/tests/test_two_pass_time_fit_baseline_validation.py
+++ b/tests/test_two_pass_time_fit_baseline_validation.py
@@ -1,0 +1,163 @@
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+from calibration import CalibrationResult
+from fitting import FitResult, FitParams
+
+
+def _write_cfg(tmp_path, cfg):
+    cfg_path = tmp_path / "cfg.yaml"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+    return cfg_path
+
+
+def _write_data(tmp_path, df):
+    data_path = tmp_path / "data.csv"
+    df.to_csv(data_path, index=False)
+    return data_path
+
+
+def _patch_common(monkeypatch):
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
+    monkeypatch.setattr(analyze, "derive_calibration_constants", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock)
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch())
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "apply_burst_filter", lambda df, cfg, mode="rate": (df, 0))
+    monkeypatch.setattr(analyze, "copy_config", lambda *a, **k: None)
+
+
+def test_analyze_uses_two_pass_time_fit(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": True,
+            "window_po214": [7, 9],
+            "hl_po214": [1.0, 0.0],
+            "eff_po214": [1.0, 0.0],
+            "flags": {},
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = _write_cfg(tmp_path, cfg)
+
+    df = pd.DataFrame(
+        {
+            "fUniqueID": [1],
+            "fBits": [0],
+            "timestamp": [pd.Timestamp(1.0, unit="s", tz="UTC")],
+            "adc": [8],
+            "fchannel": [1],
+        }
+    )
+    data_path = _write_data(tmp_path, df)
+
+    _patch_common(monkeypatch)
+
+    called = {}
+
+    def fake_two_pass(*args, **kwargs):
+        called["ok"] = True
+        return FitResult(FitParams({}), np.zeros((0, 0)), 0)
+
+    def fail_fit(*args, **kwargs):
+        raise AssertionError("fit_time_series should not be called directly")
+
+    monkeypatch.setattr(analyze, "two_pass_time_fit", fake_two_pass)
+    monkeypatch.setattr(analyze, "fit_time_series", fail_fit)
+
+    def fake_write(out_dir, summary, timestamp=None):
+        d = Path(out_dir) / (timestamp or "x")
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    monkeypatch.setattr(analyze, "write_summary", fake_write)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    assert called.get("ok")
+
+
+def test_baseline_validation_fails_fast(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "analysis": {"analysis_start_time": 0, "analysis_end_time": 10},
+        "baseline": {"range": [20, 30], "monitor_volume_l": 605.0, "sample_volume_l": 0.0},
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {
+            "do_time_fit": True,
+            "window_po214": [7, 9],
+            "hl_po214": [1.0, 0.0],
+            "eff_po214": [1.0, 0.0],
+            "flags": {},
+        },
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = _write_cfg(tmp_path, cfg)
+
+    df = pd.DataFrame(
+        {
+            "fUniqueID": [1],
+            "fBits": [0],
+            "timestamp": [pd.Timestamp(1.0, unit="s", tz="UTC")],
+            "adc": [8],
+            "fchannel": [1],
+        }
+    )
+    data_path = _write_data(tmp_path, df)
+
+    _patch_common(monkeypatch)
+
+    def fail_two_pass(*args, **kwargs):
+        raise AssertionError("two_pass_time_fit should not be called")
+
+    monkeypatch.setattr(analyze, "two_pass_time_fit", fail_two_pass)
+    monkeypatch.setattr(
+        analyze.baseline,
+        "subtract",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("baseline subtraction should not run")),
+    )
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    with pytest.raises(ValueError):
+        analyze.main()


### PR DESCRIPTION
## Summary
- Map `plot_time_binning_mode=auto` to fixed-width bins for reproducible time-series plots
- Add regression tests ensuring two-pass time fitting is used and that baseline windows are validated early
- Update plot utilities tests for explicit Freedman–Diaconis selection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78fb04d94832b82585921765c6535