### PR TITLE
Default spectral path is binned Poisson; unbinned is opt-in, and the chosen path is recorded

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ fit.  Important keys include:
 - `peak_search_cwt_widths` – list of widths for wavelet peak detection
   when `peak_search_method` is `"cwt"`.
 - `unbinned_likelihood` – when `true` use an extended unbinned likelihood
-  instead of the default χ² fit to histogrammed data.
+  instead of the default binned Poisson fit to histogrammed data.
 - `emg_left` evaluations are wrapped in `np.errstate` and passed through
   `np.nan_to_num` for stability so that NaN or infinite values never
   reach `curve_fit`.

--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -1,5 +1,5 @@
-import numpy as np
 import analyze
+import numpy as np
 from fitting import FitResult, FitParams
 
 
@@ -33,3 +33,26 @@ def test_analysis_flags_threaded(monkeypatch):
 
     assert captured["background_model"] == "loglin_unit"
     assert captured["likelihood"] == "extended"
+
+
+def test_unbinned_likelihood_switch(monkeypatch):
+    calls = []
+
+    def fake_fit_spectrum(*args, **kwargs):
+        calls.append(kwargs.get("unbinned", False))
+        method = "unbinned" if kwargs.get("unbinned", False) else "binned"
+        return FitResult(FitParams({}), None, 0, method=method)
+
+    monkeypatch.setattr(analyze, "fit_spectrum", fake_fit_spectrum)
+
+    energies = np.array([5.3, 6.0, 7.7])
+    priors = {}
+    cfg = {"calibration": {"known_energies": {"Po210": 5.3, "Po218": 6.0, "Po214": 7.7}}}
+
+    res, _ = analyze._spectral_fit_with_check(energies, priors, {}, cfg, unbinned=True)
+    assert calls[-1] is True
+    assert res.method == "unbinned"
+
+    res2, _ = analyze._spectral_fit_with_check(energies, priors, {}, cfg)
+    assert calls[-1] is False
+    assert res2.method == "binned"

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -430,6 +430,32 @@ def test_fit_spectrum_unbinned_runs():
     out = fit_spectrum(energies, priors, unbinned=True)
     assert "sigma0" in out.params
     assert "F" in out.params
+    assert out.method == "unbinned"
+
+
+def test_fit_spectrum_records_binned_mode():
+    rng = np.random.default_rng(6)
+    energies = np.concatenate([
+        rng.normal(5.3, 0.05, 150),
+        rng.normal(6.0, 0.05, 150),
+        rng.normal(7.7, 0.05, 150),
+    ])
+
+    priors = {
+        "sigma0": (0.05, 0.01),
+        "F": (0.0, 0.01),
+        "mu_Po210": (5.3, 0.1),
+        "S_Po210": (150, 15),
+        "mu_Po218": (6.0, 0.1),
+        "S_Po218": (150, 15),
+        "mu_Po214": (7.7, 0.1),
+        "S_Po214": (150, 15),
+        "b0": (0.0, 1.0),
+        "b1": (0.0, 1.0),
+    }
+
+    out = fit_spectrum(energies, priors)
+    assert out.method == "binned"
 
 
 def test_fit_spectrum_unbinned_consistent():
@@ -455,6 +481,8 @@ def test_fit_spectrum_unbinned_consistent():
 
     out_hist = fit_spectrum(energies, priors)
     out_unbinned = fit_spectrum(energies, priors, unbinned=True)
+    assert out_hist.method == "binned"
+    assert out_unbinned.method == "unbinned"
     diff = abs(out_hist.params["mu_Po210"] - out_unbinned.params["mu_Po210"])
     assert diff < 0.2
 


### PR DESCRIPTION
## Summary
- expose which spectral likelihood branch runs and default to binned Poisson
- support opt-in unbinned likelihood and document the default
- add tests to exercise and assert both binned and unbinned paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78d49cacc832b827e58aa91183da3