### PR TITLE
Default spectral path is binned Poisson; unbinned is opt-in, and the chosen path is recorded

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -2960,6 +2960,8 @@ def main(argv=None):
         spec_dict = dict(spectrum_results.params)
         spec_dict["cov"] = spectrum_results.cov.tolist()
         spec_dict["ndf"] = spectrum_results.ndf
+        if spectrum_results.likelihood is not None:
+            spec_dict["likelihood"] = spectrum_results.likelihood
     elif isinstance(spectrum_results, dict):
         spec_dict = spectrum_results
     if peak_deviation:

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -430,6 +430,32 @@ def test_fit_spectrum_unbinned_runs():
     out = fit_spectrum(energies, priors, unbinned=True)
     assert "sigma0" in out.params
     assert "F" in out.params
+    assert out.likelihood == "unbinned"
+
+
+def test_fit_spectrum_records_default_branch():
+    rng = np.random.default_rng(7)
+    energies = np.concatenate([
+        rng.normal(5.3, 0.05, 150),
+        rng.normal(6.0, 0.05, 150),
+        rng.normal(7.7, 0.05, 150),
+    ])
+
+    priors = {
+        "sigma0": (0.05, 0.01),
+        "F": (0.0, 0.01),
+        "mu_Po210": (5.3, 0.1),
+        "S_Po210": (150, 15),
+        "mu_Po218": (6.0, 0.1),
+        "S_Po218": (150, 15),
+        "mu_Po214": (7.7, 0.1),
+        "S_Po214": (150, 15),
+        "b0": (0.0, 1.0),
+        "b1": (0.0, 1.0),
+    }
+
+    out = fit_spectrum(energies, priors)
+    assert out.likelihood == "binned_poisson"
 
 
 def test_fit_spectrum_unbinned_consistent():
@@ -457,6 +483,8 @@ def test_fit_spectrum_unbinned_consistent():
     out_unbinned = fit_spectrum(energies, priors, unbinned=True)
     diff = abs(out_hist.params["mu_Po210"] - out_unbinned.params["mu_Po210"])
     assert diff < 0.2
+    assert out_hist.likelihood == "binned_poisson"
+    assert out_unbinned.likelihood == "unbinned"
 
 
 def test_fit_spectrum_fixed_resolution():


### PR DESCRIPTION
## Summary
- Track the likelihood branch used in `FitResult` and expose it via `fit_spectrum`
- Default spectral fits to a binned Poisson negative log-likelihood
- Persist selected likelihood in `analyze.py` output
- Test default binned Poisson branch and unbinned branch switching

## Testing
- `pytest tests/test_fitting.py::test_fit_spectrum_records_default_branch tests/test_fitting.py::test_fit_spectrum_unbinned_runs tests/test_fitting.py::test_fit_spectrum_unbinned_consistent -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78d49cacc832b827e58aa91183da3