### PR TITLE
Record spectral likelihood path in spectrum results

### DIFF
--- a/README.md
+++ b/README.md
@@ -886,6 +886,8 @@ print(summary)
 
 The spectral fitting routine now uses a binned Poisson likelihood by default, providing improved numerical stability for large event counts. The legacy unbinned path remains available by setting `spectral_fit.unbinned_likelihood` to `true` in the configuration.
 
+The `summary.json` output records the chosen mode under `spectral_fit.likelihood_path`.
+
 Example:
 
 ```bash

--- a/analyze.py
+++ b/analyze.py
@@ -2960,8 +2960,10 @@ def main(argv=None):
         spec_dict = dict(spectrum_results.params)
         spec_dict["cov"] = spectrum_results.cov.tolist()
         spec_dict["ndf"] = spectrum_results.ndf
+        spec_dict["likelihood_path"] = spectrum_results.params.get("likelihood_path")
     elif isinstance(spectrum_results, dict):
         spec_dict = spectrum_results
+        spec_dict["likelihood_path"] = spectrum_results.get("likelihood_path")
     if peak_deviation:
         spec_dict["peak_deviation"] = peak_deviation
 

--- a/fitting.py
+++ b/fitting.py
@@ -330,6 +330,7 @@ def fit_spectrum(
     if flags is None:
         flags = {}
     likelihood_mode = "unbinned" if unbinned else "binned_poisson"
+    likelihood_path = likelihood_mode
     if flags.get("fix_sigma_E"):
         flags.setdefault("fix_sigma0", True)
         flags.setdefault("fix_F", True)
@@ -391,6 +392,11 @@ def fit_spectrum(
 
     if "S_bkg" in priors or background_model == "loglin_unit":
         flags.setdefault("likelihood", "extended")
+
+    if unbinned and flags.get("likelihood") == "extended":
+        likelihood_path = "unbinned_extended"
+    else:
+        likelihood_path = likelihood_mode
 
     from feature_selectors import select_background_factory, select_neg_loglike
 
@@ -610,6 +616,7 @@ def fit_spectrum(
             out["chi2"] = float(2 * m.fval)
             out["chi2_ndf"] = out["chi2"] / ndf if ndf != 0 else np.nan
             out["aic"] = float(2 * m.fval + 2 * k)
+            out["likelihood_path"] = likelihood_path
             return FitResult(
                 out,
                 cov,
@@ -684,6 +691,7 @@ def fit_spectrum(
             cov = np.zeros((len(param_order), len(param_order)))
             k = len(param_order)
             out["aic"] = float(2 * m.fval + 2 * k)
+            out["likelihood_path"] = likelihood_path
             return FitResult(
                 out,
                 cov,
@@ -746,6 +754,7 @@ def fit_spectrum(
             out["dF"] = 0.0
         k = len(param_order)
         out["aic"] = float(2 * m.fval + 2 * k)
+        out["likelihood_path"] = likelihood_path
         return FitResult(
             out,
             cov,
@@ -813,6 +822,7 @@ def fit_spectrum(
     out["nll"] = float(nll_val)
     k = len(popt)
     out["aic"] = float(2 * nll_val + 2 * k)
+    out["likelihood_path"] = likelihood_path
     param_index = {name: i for i, name in enumerate(param_order)}
     return FitResult(
         out,

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -431,6 +431,7 @@ def test_fit_spectrum_unbinned_runs():
     assert "sigma0" in out.params
     assert "F" in out.params
     assert out.likelihood == "unbinned"
+    assert out.params.get("likelihood_path") == "unbinned"
 
 
 def test_fit_spectrum_records_binned_default():
@@ -456,6 +457,7 @@ def test_fit_spectrum_records_binned_default():
 
     out = fit_spectrum(energies, priors)
     assert out.likelihood == "binned_poisson"
+    assert out.params.get("likelihood_path") == "binned_poisson"
 
 
 def test_fit_spectrum_unbinned_consistent():


### PR DESCRIPTION
## Summary
- track which spectral likelihood (binned Poisson vs. unbinned) was used by embedding a `likelihood_path` entry in `FitResult.params`
- include `likelihood_path` in the `spectral_fit` section of `summary.json`
- document the new field and test both binned and unbinned paths

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a799d1cecc832b852f5fb117553247