### PR TITLE
Add run diagnostics to analysis summary

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -77,6 +77,7 @@ from io_utils import (
     apply_burst_filter,
     Summary,
 )
+from reporting import build_diagnostics
 from utils import to_native
 from calibration import (
     derive_calibration_constants,
@@ -3075,6 +3076,14 @@ def main(argv=None):
     if weights is not None:
         summary.efficiency = summary.efficiency or {}
         summary.efficiency["blue_weights"] = list(weights)
+
+    summary.diagnostics = build_diagnostics(
+        summary,
+        spectrum_results,
+        time_fit_results,
+        df_analysis,
+        cfg,
+    )
 
     results_dir = Path(args.output_dir) / (args.job_id or now_str)
     if results_dir.exists():

--- a/io_utils.py
+++ b/io_utils.py
@@ -89,7 +89,7 @@ class Summary(Mapping[str, Any]):
     cli_sha256: str | None = None
     cli_args: list[str] = field(default_factory=list)
     analysis: dict = field(default_factory=dict)
-    diagnostics: Diagnostics = field(default_factory=Diagnostics)
+    diagnostics: dict | None = None
 
     def __getitem__(self, key: str) -> Any:  # type: ignore[override]
         return getattr(self, key)

--- a/reporting.py
+++ b/reporting.py
@@ -1,6 +1,7 @@
 import logging
 from dataclasses import dataclass, field
-from typing import List
+from typing import Any, Mapping, List
+import numpy as np
 
 
 @dataclass
@@ -13,19 +14,108 @@ class Diagnostics:
         Whether the spectral fit converged.
     time_fit_po214_fit_valid : bool | None
         Whether the Po214 time fit converged.
+    time_fit_po218_fit_valid : bool | None
+        Whether the Po218 time fit converged.
     n_events_loaded : int
         Total number of events loaded from file.
     n_events_discarded : int
         Number of events discarded by cuts.
+    selected_analysis_modes : dict
+        Summary of analysis mode selections.
     warnings : list[str]
         Collected log warning messages.
     """
 
     spectral_fit_fit_valid: bool | None = None
     time_fit_po214_fit_valid: bool | None = None
+    time_fit_po218_fit_valid: bool | None = None
     n_events_loaded: int = 0
     n_events_discarded: int = 0
+    selected_analysis_modes: dict = field(default_factory=dict)
     warnings: List[str] = field(default_factory=list)
+
+
+def _extract_fit_valid(obj: Any, iso: str | None = None) -> bool | None:
+    """Return fit validity flag from ``obj``."""
+    if obj is None:
+        return None
+    params: Mapping[str, Any]
+    if hasattr(obj, "params"):
+        params = getattr(obj, "params")  # type: ignore[assignment]
+    elif isinstance(obj, Mapping):
+        params = obj
+    else:
+        return None
+    if iso is not None:
+        key = f"fit_valid_{iso}"
+        if key in params:
+            return bool(params.get(key))
+    if "fit_valid" in params:
+        return bool(params.get("fit_valid"))
+    return None
+
+
+def _binning_info(df_analysis, cfg: Mapping[str, Any]) -> tuple[str, float | None]:
+    """Return (mode, width) for the spectral plot binning."""
+    spec_cfg = cfg.get("spectral_fit", {})
+    bin_cfg = spec_cfg.get("binning")
+    if bin_cfg is not None:
+        mode = str(bin_cfg.get("method", "adc")).lower()
+    else:
+        mode = str(spec_cfg.get("spectral_binning_mode", "adc")).lower()
+    width: float | None = None
+    if mode == "fd":
+        energies = df_analysis.get("energy_MeV")
+        if energies is not None:
+            arr = np.asarray(energies)
+            if arr.size > 0:
+                q25, q75 = np.percentile(arr, [25, 75])
+                iqr = q75 - q25
+                if iqr > 0:
+                    width = 2 * iqr / (arr.size ** (1 / 3))
+    else:
+        if bin_cfg is not None:
+            width = bin_cfg.get("adc_bin_width", spec_cfg.get("adc_bin_width", 1))
+        else:
+            width = spec_cfg.get("adc_bin_width", 1)
+    return mode, width
+
+
+def build_diagnostics(summary, spectrum_results, time_fit_results, df_analysis, cfg) -> dict:
+    """Construct a diagnostics dictionary for the current analysis run."""
+
+    n_loaded = len(df_analysis)
+    noise_removed = 0
+    burst_removed = 0
+    noise_cut = getattr(summary, "noise_cut", None)
+    if isinstance(noise_cut, Mapping):
+        noise_removed = int(noise_cut.get("removed_events", 0))
+    burst_filter = getattr(summary, "burst_filter", None)
+    if isinstance(burst_filter, Mapping):
+        burst_removed = int(burst_filter.get("removed_events", 0))
+    n_loaded += noise_removed + burst_removed
+    n_discarded = n_loaded - len(df_analysis)
+
+    mode, width = _binning_info(df_analysis, cfg)
+
+    diag = {
+        "spectral_fit_fit_valid": _extract_fit_valid(spectrum_results),
+        "time_fit_po214_fit_valid": _extract_fit_valid(time_fit_results.get("Po214"), "Po214"),
+        "time_fit_po218_fit_valid": _extract_fit_valid(time_fit_results.get("Po218"), "Po218"),
+        "n_events_loaded": int(n_loaded),
+        "n_events_discarded": int(n_discarded),
+        "selected_analysis_modes": {
+            "background_model": cfg.get("analysis", {}).get("background_model"),
+            "spectral_unbinned_likelihood": bool(
+                cfg.get("spectral_fit", {}).get("unbinned_likelihood", False)
+            ),
+            "binning_mode": mode,
+            "binning_width": width,
+        },
+        "warnings": get_captured_warnings(),
+    }
+
+    return diag
 
 
 class _WarningCapture(logging.Handler):
@@ -61,4 +151,9 @@ def get_captured_warnings() -> List[str]:
     return msgs
 
 
-__all__ = ["Diagnostics", "start_warning_capture", "get_captured_warnings"]
+__all__ = [
+    "Diagnostics",
+    "start_warning_capture",
+    "get_captured_warnings",
+    "build_diagnostics",
+]

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -2,18 +2,19 @@ import json
 from pathlib import Path
 
 from io_utils import Summary, write_summary
-from reporting import Diagnostics
 
 
 def test_diagnostics_written(tmp_path):
     summary = Summary()
-    summary.diagnostics = Diagnostics(
-        spectral_fit_fit_valid=True,
-        time_fit_po214_fit_valid=False,
-        n_events_loaded=10,
-        n_events_discarded=2,
-        warnings=["example"]
-    )
+    summary.diagnostics = {
+        "spectral_fit_fit_valid": True,
+        "time_fit_po214_fit_valid": False,
+        "time_fit_po218_fit_valid": None,
+        "n_events_loaded": 10,
+        "n_events_discarded": 2,
+        "selected_analysis_modes": {},
+        "warnings": ["example"],
+    }
 
     results_dir = write_summary(tmp_path, summary)
     summary_path = Path(results_dir) / "summary.json"
@@ -24,8 +25,10 @@ def test_diagnostics_written(tmp_path):
     for key in {
         "spectral_fit_fit_valid",
         "time_fit_po214_fit_valid",
+        "time_fit_po218_fit_valid",
         "n_events_loaded",
         "n_events_discarded",
+        "selected_analysis_modes",
         "warnings",
     }:
         assert key in diag
@@ -40,7 +43,9 @@ def test_minimal_diagnostics_inserted(tmp_path):
     assert data["diagnostics"] == {
         "spectral_fit_fit_valid": None,
         "time_fit_po214_fit_valid": None,
+        "time_fit_po218_fit_valid": None,
         "n_events_loaded": 0,
         "n_events_discarded": 0,
+        "selected_analysis_modes": {},
         "warnings": [],
     }

--- a/tests/test_summary_diagnostics.py
+++ b/tests/test_summary_diagnostics.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+import analyze
+
+
+def test_summary_contains_diagnostics(tmp_path, monkeypatch):
+    data_dir = Path(__file__).resolve().parent / "data" / "mini_run"
+    csv = data_dir / "run.csv"
+    cfg = data_dir / "config.yaml"
+
+    # avoid writing plot files during test
+    monkeypatch.setattr(plt, "savefig", lambda *a, **k: None)
+
+    analyze.main(["-i", str(csv), "-c", str(cfg), "-o", str(tmp_path)])
+
+    summary_files = list(tmp_path.glob("*/summary.json"))
+    assert len(summary_files) == 1
+
+    data = json.loads(summary_files[0].read_text())
+    diag = data.get("diagnostics")
+    assert diag is not None
+
+    for key in [
+        "spectral_fit_fit_valid",
+        "time_fit_po214_fit_valid",
+        "time_fit_po218_fit_valid",
+        "n_events_loaded",
+        "n_events_discarded",
+        "selected_analysis_modes",
+        "warnings",
+    ]:
+        assert key in diag
+


### PR DESCRIPTION
## Summary
- attach detailed diagnostics block to summary.json with fit validity, event counts, analysis modes, and warnings
- expose diagnostics field in `Summary` and compute it in the analysis pipeline
- add tests ensuring diagnostics are written and included in summaries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a799d800ac832ba89de4d5b47b6e43