### PR TITLE
Record spectral fit likelihood path

### DIFF
--- a/README.md
+++ b/README.md
@@ -885,6 +885,7 @@ print(summary)
 ## Spectral fit hardening and defaults
 
 The spectral fitting routine now uses a binned Poisson likelihood by default, providing improved numerical stability for large event counts. The legacy unbinned path remains available by setting `spectral_fit.unbinned_likelihood` to `true` in the configuration.
+The `summary.json` spectral section reports this via a new `likelihood_path` field.
 
 Example:
 

--- a/analyze.py
+++ b/analyze.py
@@ -2960,8 +2960,10 @@ def main(argv=None):
         spec_dict = dict(spectrum_results.params)
         spec_dict["cov"] = spectrum_results.cov.tolist()
         spec_dict["ndf"] = spectrum_results.ndf
+        spec_dict["likelihood_path"] = spectrum_results.params.get("likelihood_path")
     elif isinstance(spectrum_results, dict):
         spec_dict = spectrum_results
+        spec_dict["likelihood_path"] = spectrum_results.get("likelihood_path")
     if peak_deviation:
         spec_dict["peak_deviation"] = peak_deviation
 

--- a/fitting.py
+++ b/fitting.py
@@ -330,6 +330,7 @@ def fit_spectrum(
     if flags is None:
         flags = {}
     likelihood_mode = "unbinned" if unbinned else "binned_poisson"
+    likelihood_path = "unbinned_extended" if unbinned else "binned_poisson"
     if flags.get("fix_sigma_E"):
         flags.setdefault("fix_sigma0", True)
         flags.setdefault("fix_F", True)
@@ -610,6 +611,7 @@ def fit_spectrum(
             out["chi2"] = float(2 * m.fval)
             out["chi2_ndf"] = out["chi2"] / ndf if ndf != 0 else np.nan
             out["aic"] = float(2 * m.fval + 2 * k)
+            out["likelihood_path"] = likelihood_path
             return FitResult(
                 out,
                 cov,
@@ -684,6 +686,7 @@ def fit_spectrum(
             cov = np.zeros((len(param_order), len(param_order)))
             k = len(param_order)
             out["aic"] = float(2 * m.fval + 2 * k)
+            out["likelihood_path"] = likelihood_path
             return FitResult(
                 out,
                 cov,
@@ -746,6 +749,7 @@ def fit_spectrum(
             out["dF"] = 0.0
         k = len(param_order)
         out["aic"] = float(2 * m.fval + 2 * k)
+        out["likelihood_path"] = likelihood_path
         return FitResult(
             out,
             cov,
@@ -801,6 +805,7 @@ def fit_spectrum(
         out["dF"] = 0.0
 
     out["fit_valid"] = fit_valid
+    out["likelihood_path"] = likelihood_path
 
     model_counts = _model_binned(centers, *popt)
     with np.errstate(divide="ignore", invalid="ignore"):


### PR DESCRIPTION
## Summary
- Record whether spectrum fitting used the histogram or unbinned path via `likelihood_path`
- Expose the chosen likelihood path in analysis summaries
- Mention the new field in README documentation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a799d1cecc832b852f5fb117553247