### PR TITLE
Add diagnostics block to summary

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -77,6 +77,7 @@ from io_utils import (
     apply_burst_filter,
     Summary,
 )
+from reporting import build_diagnostics
 from utils import to_native
 from calibration import (
     derive_calibration_constants,
@@ -3084,6 +3085,10 @@ def main(argv=None):
             raise FileExistsError(f"Results folder already exists: {results_dir}")
 
     copy_config(results_dir, cfg, exist_ok=args.overwrite)
+    diagnostics = build_diagnostics(
+        summary, spectrum_results, time_fit_results, df_analysis, cfg
+    )
+    summary.diagnostics = diagnostics
     out_dir = Path(write_summary(results_dir, summary))
     out_dir.mkdir(parents=True, exist_ok=True)
 

--- a/io_utils.py
+++ b/io_utils.py
@@ -13,6 +13,7 @@ import pandas as pd
 from collections.abc import Mapping
 from typing import Any, Iterator
 from constants import load_nuclide_overrides
+# Diagnostics dataclass is used for default diagnostic structure
 from reporting import Diagnostics
 
 import numpy as np
@@ -89,7 +90,7 @@ class Summary(Mapping[str, Any]):
     cli_sha256: str | None = None
     cli_args: list[str] = field(default_factory=list)
     analysis: dict = field(default_factory=dict)
-    diagnostics: Diagnostics = field(default_factory=Diagnostics)
+    diagnostics: dict | None = None
 
     def __getitem__(self, key: str) -> Any:  # type: ignore[override]
         return getattr(self, key)

--- a/reporting.py
+++ b/reporting.py
@@ -23,8 +23,10 @@ class Diagnostics:
 
     spectral_fit_fit_valid: bool | None = None
     time_fit_po214_fit_valid: bool | None = None
+    time_fit_po218_fit_valid: bool | None = None
     n_events_loaded: int = 0
     n_events_discarded: int = 0
+    selected_analysis_modes: dict = field(default_factory=dict)
     warnings: List[str] = field(default_factory=list)
 
 
@@ -61,4 +63,67 @@ def get_captured_warnings() -> List[str]:
     return msgs
 
 
-__all__ = ["Diagnostics", "start_warning_capture", "get_captured_warnings"]
+def build_diagnostics(summary, spectrum_results, time_fit_results, df_analysis, cfg) -> dict:
+    """Construct a diagnostics dictionary for the analysis run."""
+
+    def _get(obj, key, default=None):
+        if hasattr(obj, key):
+            return getattr(obj, key)
+        if isinstance(obj, dict):
+            return obj.get(key, default)
+        return default
+
+    def _fit_valid(res):
+        if hasattr(res, "params"):
+            return bool(res.params.get("fit_valid", False))
+        if isinstance(res, dict):
+            return bool(res.get("fit_valid", False))
+        return False
+
+    noise_removed = _get(_get(summary, "noise_cut", {}), "removed_events", 0) or 0
+    burst_removed = _get(_get(summary, "burst_filter", {}), "removed_events", 0) or 0
+    n_loaded = int(len(df_analysis) + noise_removed + burst_removed)
+    diagnostics = {
+        "spectral_fit_fit_valid": _fit_valid(spectrum_results),
+        "time_fit_po214_fit_valid": _fit_valid(_get(time_fit_results, "Po214")),
+        "n_events_loaded": n_loaded,
+        "n_events_discarded": int(n_loaded - len(df_analysis)),
+        "selected_analysis_modes": {
+            "background_model": _get(cfg.get("analysis", {}), "background_model"),
+            "unbinned_likelihood": bool(
+                cfg.get("spectral_fit", {}).get("unbinned_likelihood", False)
+            ),
+            "spectrum_binning": {},
+        },
+        "warnings": get_captured_warnings(),
+    }
+
+    if _get(time_fit_results, "Po218") is not None:
+        diagnostics["time_fit_po218_fit_valid"] = _fit_valid(
+            _get(time_fit_results, "Po218")
+        )
+
+    bin_cfg = cfg.get("spectral_fit", {}).get("binning")
+    if bin_cfg is not None:
+        mode = str(bin_cfg.get("method", "adc")).lower()
+        width = (
+            bin_cfg.get("adc_bin_width")
+            if mode == "adc"
+            else bin_cfg.get("default_bins")
+        )
+    else:
+        mode = str(cfg.get("spectral_fit", {}).get("spectral_binning_mode", "adc")).lower()
+        width = (
+            cfg.get("spectral_fit", {}).get("adc_bin_width")
+            if mode == "adc"
+            else cfg.get("spectral_fit", {}).get("fd_hist_bins")
+        )
+    diagnostics["selected_analysis_modes"]["spectrum_binning"] = {
+        "mode": mode,
+        "width": width,
+    }
+
+    return diagnostics
+
+
+__all__ = ["Diagnostics", "start_warning_capture", "get_captured_warnings", "build_diagnostics"]

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -26,6 +26,7 @@ def test_diagnostics_written(tmp_path):
         "time_fit_po214_fit_valid",
         "n_events_loaded",
         "n_events_discarded",
+        "selected_analysis_modes",
         "warnings",
     }:
         assert key in diag
@@ -40,7 +41,9 @@ def test_minimal_diagnostics_inserted(tmp_path):
     assert data["diagnostics"] == {
         "spectral_fit_fit_valid": None,
         "time_fit_po214_fit_valid": None,
+        "time_fit_po218_fit_valid": None,
         "n_events_loaded": 0,
         "n_events_discarded": 0,
+        "selected_analysis_modes": {},
         "warnings": [],
     }

--- a/tests/test_summary_diagnostics.py
+++ b/tests/test_summary_diagnostics.py
@@ -1,0 +1,71 @@
+import json
+import sys
+from pathlib import Path
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import analyze
+
+
+def test_summary_diagnostics_block(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {
+            "method": "two-point",
+            "peak_prominence": 0.0,
+            "peak_width": 1,
+            "nominal_adc": {"Po210": 1238, "Po218": 1300, "Po214": 1800},
+            "peak_search_radius": 30,
+            "fit_window_adc": 20,
+            "use_emg": False,
+            "init_sigma_adc": 5.0,
+            "init_tau_adc": 1.0,
+            "sanity_tolerance_mev": 1.0,
+        },
+        "spectral_fit": {"do_spectral_fit": False},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": ["png"]},
+    }
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+
+    data_path = Path(__file__).resolve().parents[1] / "example_input.csv"
+
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(
+        analyze, "plot_time_series", lambda *a, **k: Path(k.get("out_png", tmp_path / "x.png")).touch()
+    )
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch())
+    monkeypatch.setattr(analyze, "plot_radon_activity", lambda *a, **k: Path(a[2]).touch())
+    monkeypatch.setattr(analyze, "plot_radon_trend", lambda *a, **k: Path(a[2]).touch())
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    analyze.main()
+
+    result_dir = next(tmp_path.iterdir())
+    summary_path = result_dir / "summary.json"
+    data = json.loads(summary_path.read_text())
+    diag = data.get("diagnostics")
+    assert diag is not None
+    for key in [
+        "spectral_fit_fit_valid",
+        "time_fit_po214_fit_valid",
+        "n_events_loaded",
+        "n_events_discarded",
+        "selected_analysis_modes",
+        "warnings",
+    ]:
+        assert key in diag


### PR DESCRIPTION
## Summary
- build comprehensive diagnostics including fit validity, event counts, analysis modes and warnings
- attach diagnostics to summaries during analysis
- add regression test for diagnostics block

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a799d800ac832ba89de4d5b47b6e43