### PR TITLE
Use fixed hourly time bins by default

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -162,8 +162,8 @@ systematics:
   adc_drift_params: null
 plotting:
   plot_spectrum_binsize_adc: 1
-  plot_time_binning_mode: auto
-  plot_time_bin_width_s: 21600
+  plot_time_binning_mode: fixed
+  plot_time_bin_width_s: 3600
   plot_time_normalise_rate: true
   time_bins_fallback: 1
   plot_save_formats:

--- a/tests/test_timefit_and_baseline.py
+++ b/tests/test_timefit_and_baseline.py
@@ -1,0 +1,30 @@
+import numpy as np
+import plot_utils
+from plot_utils import plot_time_series
+
+
+def test_default_fixed_time_bins(tmp_path, monkeypatch):
+    times = np.array([100.0, 3700.0, 7400.0])
+    energies = np.full_like(times, 5.3)
+    cfg = {
+        "window_po210": [5.2, 5.4],
+        "eff_po210": [1.0],
+        "plot_time_style": "lines",
+    }
+
+    captured = {}
+
+    def fake_plot(x, y, *args, **kwargs):
+        if kwargs.get("label") == "Data Po210":
+            captured["n_bins"] = len(x)
+        return type("obj", (), {})()
+
+    monkeypatch.setattr(plot_utils.plt, "plot", fake_plot)
+    monkeypatch.setattr(plot_utils.plt, "savefig", lambda *a, **k: None)
+
+    t_start = 0.0
+    t_end = 7500.0
+    plot_time_series(times, energies, None, t_start, t_end, cfg, str(tmp_path / "ts.png"))
+
+    expected_bins = int(np.floor((t_end - t_start) / 3600))
+    assert captured.get("n_bins") == expected_bins


### PR DESCRIPTION
## Summary
- default to fixed one-hour time bins in the main configuration
- add regression test ensuring bin count matches the expected number of hours

## Testing
- `pytest tests/test_timefit_and_baseline.py tests/test_analyze_config_merge.py::test_time_bin_cli tests/test_analyze_config_merge.py::test_time_bin_override_logs tests/test_time_bin_mode_conflict.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a799dfdd2c832bbe312e5303e4b3c1