### PR TITLE
feat: expose chosen spectral likelihood path

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ the file:
 The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--job-id` is given the folder `<output_dir>/<job-id>/` is used instead. If `--output_dir` is omitted it defaults to `results`. If the folder already exists run with `--overwrite` to replace it. The directory includes:
 
 - `summary.json` – calibration and fit summary with run diagnostics.
+- The spectral results in `summary.json` include a `likelihood_path` field
+  indicating whether `binned_poisson` or `unbinned` likelihood was used.
 - `config_used.json` – copy of the configuration used.
   Any timestamps overridden on the command line are written
   back to this file as ISO timestamps.

--- a/analyze.py
+++ b/analyze.py
@@ -2960,8 +2960,10 @@ def main(argv=None):
         spec_dict = dict(spectrum_results.params)
         spec_dict["cov"] = spectrum_results.cov.tolist()
         spec_dict["ndf"] = spectrum_results.ndf
+        spec_dict["likelihood_path"] = spectrum_results.params.get("likelihood_path")
     elif isinstance(spectrum_results, dict):
         spec_dict = spectrum_results
+        spec_dict["likelihood_path"] = spectrum_results.get("likelihood_path")
     if peak_deviation:
         spec_dict["peak_deviation"] = peak_deviation
 

--- a/fitting.py
+++ b/fitting.py
@@ -610,6 +610,7 @@ def fit_spectrum(
             out["chi2"] = float(2 * m.fval)
             out["chi2_ndf"] = out["chi2"] / ndf if ndf != 0 else np.nan
             out["aic"] = float(2 * m.fval + 2 * k)
+            out["likelihood_path"] = "binned_poisson"
             return FitResult(
                 out,
                 cov,
@@ -684,6 +685,7 @@ def fit_spectrum(
             cov = np.zeros((len(param_order), len(param_order)))
             k = len(param_order)
             out["aic"] = float(2 * m.fval + 2 * k)
+            out["likelihood_path"] = "unbinned"
             return FitResult(
                 out,
                 cov,
@@ -746,6 +748,7 @@ def fit_spectrum(
             out["dF"] = 0.0
         k = len(param_order)
         out["aic"] = float(2 * m.fval + 2 * k)
+        out["likelihood_path"] = "unbinned"
         return FitResult(
             out,
             cov,
@@ -814,6 +817,7 @@ def fit_spectrum(
     k = len(popt)
     out["aic"] = float(2 * nll_val + 2 * k)
     param_index = {name: i for i, name in enumerate(param_order)}
+    out["likelihood_path"] = "binned_poisson"
     return FitResult(
         out,
         pcov,

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -431,6 +431,7 @@ def test_fit_spectrum_unbinned_runs():
     assert "sigma0" in out.params
     assert "F" in out.params
     assert out.likelihood == "unbinned"
+    assert out.params["likelihood_path"] == "unbinned"
 
 
 def test_fit_spectrum_records_binned_default():
@@ -456,6 +457,7 @@ def test_fit_spectrum_records_binned_default():
 
     out = fit_spectrum(energies, priors)
     assert out.likelihood == "binned_poisson"
+    assert out.params["likelihood_path"] == "binned_poisson"
 
 
 def test_fit_spectrum_unbinned_consistent():


### PR DESCRIPTION
## Summary
- record `likelihood_path` in spectral fit results for both binned and unbinned modes
- propagate chosen likelihood path into analysis summary
- document `likelihood_path` field and test coverage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a799d1cecc832b852f5fb117553247