### PR TITLE
Record spectral likelihood path

### DIFF
--- a/README.md
+++ b/README.md
@@ -885,6 +885,7 @@ print(summary)
 ## Spectral fit hardening and defaults
 
 The spectral fitting routine now uses a binned Poisson likelihood by default, providing improved numerical stability for large event counts. The legacy unbinned path remains available by setting `spectral_fit.unbinned_likelihood` to `true` in the configuration.
+The resulting `summary.json` now records this choice under `spectral_fit.likelihood_path`.
 
 Example:
 

--- a/analyze.py
+++ b/analyze.py
@@ -2960,6 +2960,7 @@ def main(argv=None):
         spec_dict = dict(spectrum_results.params)
         spec_dict["cov"] = spectrum_results.cov.tolist()
         spec_dict["ndf"] = spectrum_results.ndf
+        spec_dict["likelihood_path"] = spectrum_results.params.get("likelihood_path")
     elif isinstance(spectrum_results, dict):
         spec_dict = spectrum_results
     if peak_deviation:

--- a/fitting.py
+++ b/fitting.py
@@ -610,6 +610,7 @@ def fit_spectrum(
             out["chi2"] = float(2 * m.fval)
             out["chi2_ndf"] = out["chi2"] / ndf if ndf != 0 else np.nan
             out["aic"] = float(2 * m.fval + 2 * k)
+            out["likelihood_path"] = likelihood_mode
             return FitResult(
                 out,
                 cov,
@@ -684,6 +685,7 @@ def fit_spectrum(
             cov = np.zeros((len(param_order), len(param_order)))
             k = len(param_order)
             out["aic"] = float(2 * m.fval + 2 * k)
+            out["likelihood_path"] = likelihood_mode
             return FitResult(
                 out,
                 cov,
@@ -746,6 +748,7 @@ def fit_spectrum(
             out["dF"] = 0.0
         k = len(param_order)
         out["aic"] = float(2 * m.fval + 2 * k)
+        out["likelihood_path"] = likelihood_mode
         return FitResult(
             out,
             cov,
@@ -814,6 +817,7 @@ def fit_spectrum(
     k = len(popt)
     out["aic"] = float(2 * nll_val + 2 * k)
     param_index = {name: i for i, name in enumerate(param_order)}
+    out["likelihood_path"] = likelihood_mode
     return FitResult(
         out,
         pcov,


### PR DESCRIPTION
## Summary
- embed `likelihood_path` in spectral FitResult to note whether the binned Poisson or unbinned likelihood was used
- propagate `likelihood_path` into the summary output
- document the new `likelihood_path` field in the README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a799d1cecc832b852f5fb117553247