### PR TITLE
Add summary diagnostics block and tests

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -85,6 +85,7 @@ from calibration import (
 )
 
 from fitting import fit_spectrum, fit_time_series, FitResult, FitParams
+from reporting import build_diagnostics, start_warning_capture
 
 from constants import (
     DEFAULT_NOISE_CUTOFF,
@@ -1014,6 +1015,8 @@ def main(argv=None):
         requirements_sha256 = "unknown"
 
     args = parse_args(argv)
+
+    start_warning_capture()
 
     if args.reproduce:
         rep_path = Path(args.reproduce)
@@ -3075,6 +3078,10 @@ def main(argv=None):
     if weights is not None:
         summary.efficiency = summary.efficiency or {}
         summary.efficiency["blue_weights"] = list(weights)
+
+    summary.diagnostics = build_diagnostics(
+        summary, spectrum_results, time_fit_results, df_analysis, cfg
+    )
 
     results_dir = Path(args.output_dir) / (args.job_id or now_str)
     if results_dir.exists():

--- a/io_utils.py
+++ b/io_utils.py
@@ -13,12 +13,12 @@ import pandas as pd
 from collections.abc import Mapping
 from typing import Any, Iterator
 from constants import load_nuclide_overrides
-from reporting import Diagnostics
 
 import numpy as np
 from utils import to_native
 from utils.time_utils import parse_timestamp, to_epoch_seconds, tz_convert_utc
 import jsonschema
+from reporting import DEFAULT_DIAGNOSTICS
 
 
 def extract_time_series_events(events, cfg):
@@ -89,7 +89,7 @@ class Summary(Mapping[str, Any]):
     cli_sha256: str | None = None
     cli_args: list[str] = field(default_factory=list)
     analysis: dict = field(default_factory=dict)
-    diagnostics: Diagnostics = field(default_factory=Diagnostics)
+    diagnostics: dict | None = None
 
     def __getitem__(self, key: str) -> Any:  # type: ignore[override]
         return getattr(self, key)
@@ -617,7 +617,7 @@ def write_summary(
     sanitized = to_native(summary_dict)
 
     if "diagnostics" not in sanitized or sanitized["diagnostics"] is None:
-        sanitized["diagnostics"] = to_native(Diagnostics())
+        sanitized["diagnostics"] = to_native(DEFAULT_DIAGNOSTICS)
 
     with open(summary_path, "w", encoding="utf-8") as f:
         json.dump(sanitized, f, indent=4)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -2,18 +2,20 @@ import json
 from pathlib import Path
 
 from io_utils import Summary, write_summary
-from reporting import Diagnostics
+from reporting import DEFAULT_DIAGNOSTICS
 
 
 def test_diagnostics_written(tmp_path):
     summary = Summary()
-    summary.diagnostics = Diagnostics(
-        spectral_fit_fit_valid=True,
-        time_fit_po214_fit_valid=False,
-        n_events_loaded=10,
-        n_events_discarded=2,
-        warnings=["example"]
-    )
+    summary.diagnostics = {
+        "spectral_fit_fit_valid": True,
+        "time_fit_po214_fit_valid": False,
+        "time_fit_po218_fit_valid": None,
+        "n_events_loaded": 10,
+        "n_events_discarded": 2,
+        "selected_analysis_modes": {},
+        "warnings": ["example"],
+    }
 
     results_dir = write_summary(tmp_path, summary)
     summary_path = Path(results_dir) / "summary.json"
@@ -24,8 +26,10 @@ def test_diagnostics_written(tmp_path):
     for key in {
         "spectral_fit_fit_valid",
         "time_fit_po214_fit_valid",
+        "time_fit_po218_fit_valid",
         "n_events_loaded",
         "n_events_discarded",
+        "selected_analysis_modes",
         "warnings",
     }:
         assert key in diag
@@ -37,10 +41,4 @@ def test_minimal_diagnostics_inserted(tmp_path):
     data = json.loads(summary_path.read_text())
 
     assert "diagnostics" in data
-    assert data["diagnostics"] == {
-        "spectral_fit_fit_valid": None,
-        "time_fit_po214_fit_valid": None,
-        "n_events_loaded": 0,
-        "n_events_discarded": 0,
-        "warnings": [],
-    }
+    assert data["diagnostics"] == DEFAULT_DIAGNOSTICS

--- a/tests/test_summary_diagnostics.py
+++ b/tests/test_summary_diagnostics.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+import analyze
+
+
+def test_summary_diagnostics(tmp_path, monkeypatch):
+    data_dir = Path(__file__).resolve().parent / "data" / "mini_run"
+    csv = data_dir / "run.csv"
+    cfg = data_dir / "config.yaml"
+
+    monkeypatch.setattr(plt, "savefig", lambda *a, **k: None)
+
+    analyze.main(["-i", str(csv), "-c", str(cfg), "-o", str(tmp_path)])
+
+    summary_files = list(tmp_path.glob("*/summary.json"))
+    assert len(summary_files) == 1
+    data = json.loads(summary_files[0].read_text())
+    assert "diagnostics" in data
+    diag = data["diagnostics"]
+    for key in [
+        "spectral_fit_fit_valid",
+        "time_fit_po214_fit_valid",
+        "time_fit_po218_fit_valid",
+        "n_events_loaded",
+        "n_events_discarded",
+        "selected_analysis_modes",
+        "warnings",
+    ]:
+        assert key in diag


### PR DESCRIPTION
## Summary
- Build a diagnostics dictionary capturing fit validity, event counts, selected modes and warnings
- Attach diagnostics to summary output and provide defaults when missing
- Test that summary.json always includes the diagnostics block

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a799d800ac832ba89de4d5b47b6e43