### PR TITLE
Use fixed hour time bins by default

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -162,8 +162,8 @@ systematics:
   adc_drift_params: null
 plotting:
   plot_spectrum_binsize_adc: 1
-  plot_time_binning_mode: auto
-  plot_time_bin_width_s: 21600
+  plot_time_binning_mode: fixed
+  plot_time_bin_width_s: 3600
   plot_time_normalise_rate: true
   time_bins_fallback: 1
   plot_save_formats:

--- a/tests/test_timefit_and_baseline.py
+++ b/tests/test_timefit_and_baseline.py
@@ -1,0 +1,25 @@
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import analyze
+
+
+def test_default_time_bin_count():
+    root = Path(__file__).resolve().parents[1]
+    with open(root / "config.yaml", "r") as f:
+        cfg = yaml.safe_load(f)
+    plot_cfg = cfg.get("plotting", {})
+
+    t_start = 0.0
+    t_end = 5 * 3600 + 123.0
+    times = np.linspace(t_start, t_end, num=10)
+
+    centers, _ = analyze._ts_bin_centers_widths(times, plot_cfg, t_start, t_end)
+    expected = math.floor((t_end - t_start) / plot_cfg["plot_time_bin_width_s"])
+    assert len(centers) == expected
+


### PR DESCRIPTION
## Summary
- default to fixed 1-hour time bins in config
- add regression test for default time bin count

## Testing
- `pytest tests/test_timefit_and_baseline.py -q`
- `pytest tests/test_time_bin_mode_conflict.py tests/test_analyze_config_merge.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a799dfdd2c832bbe312e5303e4b3c1