### PR TITLE
Add diagnostics block to analysis summary

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -95,6 +95,7 @@ from constants import (
     DEFAULT_ADC_CENTROIDS,
     DEFAULT_KNOWN_ENERGIES,
 )
+from reporting import start_warning_capture, build_diagnostics
 
 NUCLIDES = {
     "Po210": PO210,
@@ -1013,6 +1014,7 @@ def main(argv=None):
     except Exception:
         requirements_sha256 = "unknown"
 
+    start_warning_capture()
     args = parse_args(argv)
 
     if args.reproduce:
@@ -3084,6 +3086,8 @@ def main(argv=None):
             raise FileExistsError(f"Results folder already exists: {results_dir}")
 
     copy_config(results_dir, cfg, exist_ok=args.overwrite)
+    diagnostics = build_diagnostics(summary, spectrum_results, time_fit_results, df_analysis, cfg)
+    summary.diagnostics = diagnostics
     out_dir = Path(write_summary(results_dir, summary))
     out_dir.mkdir(parents=True, exist_ok=True)
 

--- a/io_utils.py
+++ b/io_utils.py
@@ -13,7 +13,7 @@ import pandas as pd
 from collections.abc import Mapping
 from typing import Any, Iterator
 from constants import load_nuclide_overrides
-from reporting import Diagnostics
+from reporting import default_diagnostics
 
 import numpy as np
 from utils import to_native
@@ -89,7 +89,7 @@ class Summary(Mapping[str, Any]):
     cli_sha256: str | None = None
     cli_args: list[str] = field(default_factory=list)
     analysis: dict = field(default_factory=dict)
-    diagnostics: Diagnostics = field(default_factory=Diagnostics)
+    diagnostics: dict | None = None
 
     def __getitem__(self, key: str) -> Any:  # type: ignore[override]
         return getattr(self, key)
@@ -617,7 +617,7 @@ def write_summary(
     sanitized = to_native(summary_dict)
 
     if "diagnostics" not in sanitized or sanitized["diagnostics"] is None:
-        sanitized["diagnostics"] = to_native(Diagnostics())
+        sanitized["diagnostics"] = default_diagnostics()
 
     with open(summary_path, "w", encoding="utf-8") as f:
         json.dump(sanitized, f, indent=4)

--- a/reporting.py
+++ b/reporting.py
@@ -1,30 +1,18 @@
 import logging
-from dataclasses import dataclass, field
-from typing import List
+from dataclasses import dataclass, field, asdict
+from typing import List, Mapping, Any
 
 
 @dataclass
 class Diagnostics:
-    """Container for lightweight run diagnostics.
-
-    Parameters
-    ----------
-    spectral_fit_fit_valid : bool | None
-        Whether the spectral fit converged.
-    time_fit_po214_fit_valid : bool | None
-        Whether the Po214 time fit converged.
-    n_events_loaded : int
-        Total number of events loaded from file.
-    n_events_discarded : int
-        Number of events discarded by cuts.
-    warnings : list[str]
-        Collected log warning messages.
-    """
+    """Container for lightweight run diagnostics."""
 
     spectral_fit_fit_valid: bool | None = None
     time_fit_po214_fit_valid: bool | None = None
+    time_fit_po218_fit_valid: bool | None = None
     n_events_loaded: int = 0
     n_events_discarded: int = 0
+    selected_analysis_modes: dict = field(default_factory=dict)
     warnings: List[str] = field(default_factory=list)
 
 
@@ -61,4 +49,64 @@ def get_captured_warnings() -> List[str]:
     return msgs
 
 
-__all__ = ["Diagnostics", "start_warning_capture", "get_captured_warnings"]
+def default_diagnostics() -> dict:
+    """Return a diagnostics dictionary with default values."""
+    return asdict(Diagnostics())
+
+
+def _fit_valid(fit: Any) -> bool | None:
+    """Extract the ``fit_valid`` flag from a fit result object."""
+    try:
+        from fitting import FitResult  # lazy import to avoid cycle
+    except Exception:  # pragma: no cover - fallback if import fails
+        FitResult = object  # type: ignore
+
+    if fit is None:
+        return None
+    if isinstance(fit, dict):
+        return bool(fit.get("fit_valid"))
+    if isinstance(fit, FitResult):
+        return bool(fit.params.get("fit_valid"))
+    return None
+
+
+def build_diagnostics(summary: Mapping[str, Any], spectrum_results: Any, time_fit_results: Mapping[str, Any], df_analysis, cfg: Mapping[str, Any]) -> dict:
+    """Construct diagnostics information for the current run."""
+
+    diag = default_diagnostics()
+
+    diag["spectral_fit_fit_valid"] = _fit_valid(spectrum_results)
+    diag["time_fit_po214_fit_valid"] = _fit_valid(time_fit_results.get("Po214"))
+    diag["time_fit_po218_fit_valid"] = _fit_valid(time_fit_results.get("Po218"))
+
+    n_removed_noise = summary.get("noise_cut", {}).get("removed_events", 0)
+    n_removed_burst = summary.get("burst_filter", {}).get("removed_events", 0)
+    discarded = int(n_removed_noise) + int(n_removed_burst)
+    diag["n_events_discarded"] = discarded
+    diag["n_events_loaded"] = discarded + len(df_analysis)
+
+    spec_cfg = cfg.get("spectral_fit", {})
+    bin_cfg = spec_cfg.get("binning", {}) if isinstance(spec_cfg.get("binning"), Mapping) else {}
+    bin_mode = (bin_cfg.get("method") or spec_cfg.get("spectral_binning_mode") or "adc")
+    if bin_mode == "fd":
+        bin_width = bin_cfg.get("default_bins") or spec_cfg.get("fd_hist_bins")
+    else:
+        bin_width = bin_cfg.get("adc_bin_width") or spec_cfg.get("adc_bin_width")
+    diag["selected_analysis_modes"] = {
+        "background_model": spec_cfg.get("background_model"),
+        "spectral_fit_unbinned_likelihood": spec_cfg.get("unbinned_likelihood"),
+        "spectrum_binning_mode": bin_mode,
+        "spectrum_binning_width": bin_width,
+    }
+
+    diag["warnings"] = get_captured_warnings()
+    return diag
+
+
+__all__ = [
+    "Diagnostics",
+    "start_warning_capture",
+    "get_captured_warnings",
+    "default_diagnostics",
+    "build_diagnostics",
+]

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -2,18 +2,19 @@ import json
 from pathlib import Path
 
 from io_utils import Summary, write_summary
-from reporting import Diagnostics
 
 
 def test_diagnostics_written(tmp_path):
     summary = Summary()
-    summary.diagnostics = Diagnostics(
-        spectral_fit_fit_valid=True,
-        time_fit_po214_fit_valid=False,
-        n_events_loaded=10,
-        n_events_discarded=2,
-        warnings=["example"]
-    )
+    summary.diagnostics = {
+        "spectral_fit_fit_valid": True,
+        "time_fit_po214_fit_valid": False,
+        "time_fit_po218_fit_valid": None,
+        "n_events_loaded": 10,
+        "n_events_discarded": 2,
+        "selected_analysis_modes": {},
+        "warnings": ["example"],
+    }
 
     results_dir = write_summary(tmp_path, summary)
     summary_path = Path(results_dir) / "summary.json"
@@ -24,8 +25,10 @@ def test_diagnostics_written(tmp_path):
     for key in {
         "spectral_fit_fit_valid",
         "time_fit_po214_fit_valid",
+        "time_fit_po218_fit_valid",
         "n_events_loaded",
         "n_events_discarded",
+        "selected_analysis_modes",
         "warnings",
     }:
         assert key in diag
@@ -40,7 +43,9 @@ def test_minimal_diagnostics_inserted(tmp_path):
     assert data["diagnostics"] == {
         "spectral_fit_fit_valid": None,
         "time_fit_po214_fit_valid": None,
+        "time_fit_po218_fit_valid": None,
         "n_events_loaded": 0,
         "n_events_discarded": 0,
+        "selected_analysis_modes": {},
         "warnings": [],
     }

--- a/tests/test_summary_diagnostics.py
+++ b/tests/test_summary_diagnostics.py
@@ -1,0 +1,79 @@
+import json
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import analyze
+
+
+def test_summary_has_diagnostics(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "calibration": {
+            "method": "two-point",
+            "peak_prominence": 0.0,
+            "peak_width": 1,
+            "nominal_adc": {"Po210": 1238, "Po218": 1300, "Po214": 1800},
+            "peak_search_radius": 30,
+            "fit_window_adc": 20,
+            "use_emg": False,
+            "init_sigma_adc": 5.0,
+            "init_tau_adc": 1.0,
+            "sanity_tolerance_mev": 1.0,
+        },
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": []},
+    }
+    cfg_path = tmp_path / "cfg.yaml"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    data_path = Path(__file__).resolve().parents[1] / "example_input.csv"
+
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "plot_time_series", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "cov_heatmap", lambda *a, **k: None)
+    monkeypatch.setattr(analyze, "efficiency_bar", lambda *a, **k: None)
+
+    from io_utils import write_summary as real_write_summary
+
+    captured = {}
+
+    def capture_write(out_dir, summary, timestamp=None):
+        p = real_write_summary(out_dir, summary, timestamp)
+        captured["dir"] = p
+        return str(p)
+
+    monkeypatch.setattr(analyze, "write_summary", capture_write)
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+
+    analyze.main()
+
+    summary_path = Path(captured["dir"]) / "summary.json"
+    data = json.loads(summary_path.read_text())
+    assert "diagnostics" in data
+    diag = data["diagnostics"]
+    for key in [
+        "spectral_fit_fit_valid",
+        "time_fit_po214_fit_valid",
+        "time_fit_po218_fit_valid",
+        "n_events_loaded",
+        "n_events_discarded",
+        "selected_analysis_modes",
+        "warnings",
+    ]:
+        assert key in diag


### PR DESCRIPTION
## Summary
- add `build_diagnostics` to collect fit validity, event counts, selected modes, and warnings
- include diagnostics in `Summary` dataclass and attach before writing summary
- ensure summary.json always contains a top-level diagnostics block and test it

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a799d800ac832ba89de4d5b47b6e43