### PR TITLE
Ensure baseline range overlaps analysis window

### DIFF
--- a/config/validation.py
+++ b/config/validation.py
@@ -44,15 +44,13 @@ def validate_baseline_window(cfg: dict) -> None:
 
     if a_end_dt is not None and start >= a_end_dt:
         raise ValueError(
-            "baseline.start >= analysis_end_time: "
-            f"{start.isoformat()} vs {a_end_dt.isoformat()}. "
-            "Check baseline.range and analysis.analysis_end_time"
+            "baseline range does not intersect analysis window: "
+            f"[{start.isoformat()}, {end.isoformat()}] vs end {a_end_dt.isoformat()}"
         )
 
     if a_start_dt is not None and end <= a_start_dt:
         raise ValueError(
-            "Baseline interval entirely before analysis window: "
-            f"[{start.isoformat()}, {end.isoformat()}] vs "
-            f"start {a_start_dt.isoformat()}"
+            "baseline range does not intersect analysis window: "
+            f"[{start.isoformat()}, {end.isoformat()}] vs start {a_start_dt.isoformat()}"
         )
 

--- a/tests/test_baseline_failfast.py
+++ b/tests/test_baseline_failfast.py
@@ -1,0 +1,93 @@
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from calibration import CalibrationResult
+
+import analyze
+import baseline_noise
+
+
+def test_baseline_range_outside_analysis_window(tmp_path, monkeypatch):
+    cfg = {
+        "pipeline": {"log_level": "INFO"},
+        "analysis": {"analysis_end_time": "1970-01-01T00:00:10Z"},
+        "baseline": {
+            "range": ["1970-01-01T00:00:20Z", "1970-01-01T00:00:30Z"],
+            "monitor_volume_l": 605.0,
+            "sample_volume_l": 0.0,
+        },
+        "calibration": {},
+        "spectral_fit": {"do_spectral_fit": False, "expected_peaks": {"Po210": 0}},
+        "time_fit": {"do_time_fit": False},
+        "systematics": {"enable": False},
+        "plotting": {"plot_save_formats": []},
+    }
+
+    cfg_path = tmp_path / "cfg.yaml"
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+    df = pd.DataFrame(
+        {
+            "fUniqueID": [1],
+            "fBits": [0],
+            "timestamp": [pd.Timestamp(0.5, unit="s", tz="UTC")],
+            "adc": [8.0],
+            "fchannel": [1],
+        }
+    )
+    data_path = tmp_path / "data.csv"
+    df.to_csv(data_path, index=False)
+
+    cal_mock = CalibrationResult(
+        coeffs=[0.0, 1.0],
+        cov=np.zeros((2, 2)),
+        peaks={"Po210": {"centroid_adc": 10}},
+        sigma_E=1.0,
+        sigma_E_error=0.0,
+    )
+
+    monkeypatch.setattr(
+        analyze, "derive_calibration_constants", lambda *a, **k: cal_mock
+    )
+    monkeypatch.setattr(
+        analyze, "derive_calibration_constants_auto", lambda *a, **k: cal_mock
+    )
+    monkeypatch.setattr(
+        analyze, "apply_burst_filter", lambda df, cfg, mode="rate": (df, 0)
+    )
+    monkeypatch.setattr(analyze, "plot_spectrum", lambda *a, **k: None)
+    monkeypatch.setattr(
+        analyze, "plot_time_series", lambda *a, **k: Path(k["out_png"]).touch()
+    )
+    monkeypatch.setattr(
+        analyze, "cov_heatmap", lambda *a, **k: Path(a[1]).touch()
+    )
+    monkeypatch.setattr(
+        analyze, "efficiency_bar", lambda *a, **k: Path(a[1]).touch()
+    )
+    monkeypatch.setattr(
+        baseline_noise, "estimate_baseline_noise", lambda *a, **k: (None, {})
+    )
+
+    args = [
+        "analyze.py",
+        "--config",
+        str(cfg_path),
+        "--input",
+        str(data_path),
+        "--output_dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+
+    with pytest.raises(
+        ValueError, match="baseline range does not intersect analysis window"
+    ):
+        analyze.main()
+


### PR DESCRIPTION
## Summary
- clarify baseline validation error when range lies outside analysis window
- add regression test for baseline range positioned entirely after analysis period

## Testing
- `pytest tests/test_baseline_failfast.py -q`
- `pytest -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68a7ae8a3cb0832b95eca3958a2d9cc3