### PR TITLE
Restrict baseline range to 24 hours

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -29,7 +29,7 @@ columns:
 baseline:
   range:
   - '2024-09-28T00:00:00Z'
-  - '2024-10-28T23:59:59Z'
+  - '2024-09-29T00:00:00Z'
   monitor_volume_l: 605.0
   sample_volume_l: 10.0
   isotopes_to_subtract:


### PR DESCRIPTION
## Summary
- Set default baseline window to a single day (2024-09-28 to 2024-09-29)

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7c731e3c4832b8cf67973fda45354