### PR TITLE
Fix radon counts estimator to use live time

### DIFF
--- a/tests/test_radon_joint_estimator.py
+++ b/tests/test_radon_joint_estimator.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
-import math
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -10,9 +11,7 @@ from constants import load_nuclide_overrides
 
 def test_radon_joint_estimator_combination():
     consts = load_nuclide_overrides(None)
-    lam_rn = math.log(2.0) / consts["Rn222"].half_life_s
-    lam_218 = math.log(2.0) / consts["Po218"].half_life_s
-    lam_214 = math.log(2.0) / consts["Po214"].half_life_s
+    assert consts["Rn222"].half_life_s > 0
 
     A_true = 0.0063
     eff218 = 0.8
@@ -20,8 +19,11 @@ def test_radon_joint_estimator_combination():
     f218 = 1.0
     f214 = 1e-7
 
-    N218 = round(A_true * eff218 * f218 * lam_218 / lam_rn)
-    N214 = round(A_true * eff214 * f214 * lam_214 / lam_rn)
+    live_time218 = 7200.0
+    live_time214 = 7200.0
+
+    N218 = round(A_true * eff218 * f218 * live_time218)
+    N214 = round(A_true * eff214 * f214 * live_time214)
 
     result = estimate_radon_activity(
         N218,
@@ -30,10 +32,24 @@ def test_radon_joint_estimator_combination():
         N214,
         eff214,
         f214,
+        live_time218_s=live_time218,
+        live_time214_s=live_time214,
     )
 
     assert result["isotope_mode"] == "radon"
     est = result["Rn_activity_Bq"]
     sigma = result["stat_unc_Bq"]
     assert abs(est - A_true) <= sigma
+
+
+def test_counts_without_live_time_raises():
+    with pytest.raises(ValueError):
+        estimate_radon_activity(
+            N218=10,
+            epsilon218=0.5,
+            f218=1.0,
+            N214=None,
+            epsilon214=1.0,
+            f214=1.0,
+        )
 


### PR DESCRIPTION
## Summary
- convert the counts-based radon estimator to derive activities from the observed live time rather than decay-constant ratios
- thread the per-isotope live times through analysis helpers so counts-mode calls provide the required exposure
- add tests covering the live-time conversion and error handling when it is missing

## Testing
- pytest tests/test_radon_joint_estimator.py
- pytest tests/test_radon_hook_counts.py

------
https://chatgpt.com/codex/tasks/task_e_68cb327482f4832bbcbddc87b5094eb9