### PR TITLE
Fix Po proxy half-life usage in radon analysis

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -664,11 +664,7 @@ def _model_uncertainty(centers, widths, fit_obj, iso, cfg, normalise):
     if fit_obj is None:
         return None
     params = _fit_params(fit_obj)
-    # Po-214 and Po-218 activities follow the radon (Rn-222) decay constant
-    if iso in ("Po214", "Po218"):
-        hl = _hl_value(cfg, "Rn222")
-    else:
-        hl = _hl_value(cfg, iso)
+    hl = _hl_value(cfg, iso)
     eff_cfg = cfg.get("time_fit", {}).get(f"eff_{iso.lower()}")
     if isinstance(eff_cfg, list):
         eff = eff_cfg[0]
@@ -2930,7 +2926,7 @@ def main(argv=None):
             dE = fit.get("dE_corrected", fit.get("dE_Po214", 0.0))
             N0 = fit.get("N0_Po214", 0.0)
             dN0 = fit.get("dN0_Po214", 0.0)
-            hl = _hl_value(cfg, "Rn222")
+            hl = _hl_value(cfg, "Po214")
             cov = _cov_lookup(fit_result, "E_Po214", "N0_Po214")
             delta214, err_delta214 = radon_delta(
                 t_start_rel,
@@ -2951,7 +2947,7 @@ def main(argv=None):
             dE = fit.get("dE_corrected", fit.get("dE_Po218", 0.0))
             N0 = fit.get("N0_Po218", 0.0)
             dN0 = fit.get("dN0_Po218", 0.0)
-            hl = _hl_value(cfg, "Rn222")
+            hl = _hl_value(cfg, "Po218")
             cov = _cov_lookup(fit_result, "E_Po218", "N0_Po218")
             delta218, err_delta218 = radon_delta(
                 t_start_rel,
@@ -3277,7 +3273,7 @@ def main(argv=None):
                 dE = fit.get("dE_corrected", fit.get("dE_Po214", 0.0))
                 N0 = fit.get("N0_Po214", 0.0)
                 dN0 = fit.get("dN0_Po214", 0.0)
-                hl = _hl_value(cfg, "Rn222")
+                hl = _hl_value(cfg, "Po214")
                 cov = _cov_lookup(fit_result, "E_Po214", "N0_Po214")
                 A214, dA214 = radon_activity_curve(
                     t_rel, E, dE, N0, dN0, hl, cov
@@ -3299,7 +3295,7 @@ def main(argv=None):
                 dE = fit.get("dE_corrected", fit.get("dE_Po218", 0.0))
                 N0 = fit.get("N0_Po218", 0.0)
                 dN0 = fit.get("dN0_Po218", 0.0)
-                hl = _hl_value(cfg, "Rn222")
+                hl = _hl_value(cfg, "Po218")
                 cov = _cov_lookup(fit_result, "E_Po218", "N0_Po218")
                 A218, dA218 = radon_activity_curve(
                     t_rel, E, dE, N0, dN0, hl, cov
@@ -3365,7 +3361,7 @@ def main(argv=None):
                     dE214 = fit.get("dE_corrected", fit.get("dE_Po214", 0.0))
                     N0214 = fit.get("N0_Po214", 0.0)
                     dN0214 = fit.get("dN0_Po214", 0.0)
-                    hl214 = _hl_value(cfg, "Rn222")
+                    hl214 = _hl_value(cfg, "Po214")
                     cov214 = _cov_lookup(fit_result, "E_Po214", "N0_Po214")
                     A214_tr, _ = radon_activity_curve(
                         rel_trend, E214, dE214, N0214, dN0214, hl214, cov214
@@ -3379,7 +3375,7 @@ def main(argv=None):
                     dE218 = fit.get("dE_corrected", fit.get("dE_Po218", 0.0))
                     N0218 = fit.get("N0_Po218", 0.0)
                     dN0218 = fit.get("dN0_Po218", 0.0)
-                    hl218 = _hl_value(cfg, "Rn222")
+                    hl218 = _hl_value(cfg, "Po218")
                     cov218 = _cov_lookup(fit_result, "E_Po218", "N0_Po218")
                     A218_tr, _ = radon_activity_curve(
                         rel_trend, E218, dE218, N0218, dN0218, hl218, cov218


### PR DESCRIPTION
## Summary
- ensure Po-214/Po-218 model uncertainty propagation pulls each isotope's half-life from configuration
- pass the Po-214 and Po-218 half-lives to radon delta/activity reconstructions so Po-derived proxies decay correctly

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cb3789b264832baa636fd4c39e0fe9