### PR TITLE
Allow zero radon uncertainty

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -176,7 +176,8 @@ def compute_total_radon(
 
     Both ``monitor_volume`` and ``sample_volume`` must be non-negative.  A
     ``ValueError`` is raised if ``monitor_volume`` is not positive, if
-    ``sample_volume`` is negative, or if ``err_bq`` is negative.  When
+    ``sample_volume`` is negative, or if ``err_bq`` is negative.  Zero
+    uncertainties are allowed and treated as exact measurements.  When
     ``activity_bq`` is negative a ``RuntimeError`` is raised unless
     ``allow_negative_activity`` is ``True`` in which case the negative value is
     used without modification.
@@ -214,8 +215,6 @@ def compute_total_radon(
         activity_bq, err_bq = clamp_non_negative(activity_bq, err_bq)
     if math.isnan(activity_bq):
         raise ValueError("activity_bq must not be NaN")
-    if err_bq == 0:
-        raise ValueError("err_bq must be non-zero")
     conc = activity_bq / monitor_volume
     sigma_conc = err_bq / monitor_volume
 

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -161,6 +161,14 @@ def test_compute_total_radon():
     assert dtot == pytest.approx(1.0)
 
 
+def test_compute_total_radon_zero_uncertainty():
+    conc, dconc, tot, dtot = compute_total_radon(5.0, 0.0, 10.0, 10.0)
+    assert conc == pytest.approx(0.5)
+    assert dconc == pytest.approx(0.0)
+    assert tot == pytest.approx(5.0)
+    assert dtot == pytest.approx(0.0)
+
+
 def test_compute_radon_activity_missing_uncertainty_returns_nan():
     """Single rate without uncertainty should propagate NaN error."""
     a, s = compute_radon_activity(5.0, None, 1.0, None, None, 1.0)


### PR DESCRIPTION
## Summary
- allow compute_total_radon to propagate zero-uncertainty activities instead of raising
- document that zero uncertainties are treated as exact measurements
- add regression test covering zero-uncertainty totals

## Testing
- pytest tests/test_radon_activity.py

------
https://chatgpt.com/codex/tasks/task_e_68cb4a746ab8832bbe56622d66cd197d