### PR TITLE
Document radon concentration units

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--j
 - Optional `*_ts.json` files containing binned time series when enabled.
 - `efficiency.png` – bar chart of individual efficiencies and the BLUE result.
 - `eff_cov.png` – heatmap of the efficiency covariance matrix.
-- `radon_activity.png` – extrapolated radon activity over time.
+- `radon_activity.png` – extrapolated radon concentration (Bq/L) over time.
  - `equivalent_air.png` – equivalent air volume plot when `--ambient-file` or
    `--ambient-concentration` is provided.
 
@@ -764,11 +764,11 @@ sigmas = cal.uncertainty([1500, 1700])
 ## Radon Activity Output
 
 After the decay fits a weighted average of the Po‑218 and Po‑214 rates is
-converted to an instantaneous radon activity.  The result is written to
-`summary.json` under `radon_results` together with the corresponding
-concentration (per liter) and the total amount of radon contained in the
-sample volume.  The file `radon_activity.png` visualises this
-activity versus time.  When either `--ambient-file` or
+converted to an instantaneous radon activity for the counting cell.  Dividing
+by the monitor volume yields the radon concentration (Bq/L) reported in
+`summary.json` under `radon_results` alongside the total amount of radon in the
+sample volume.  The file `radon_activity.png` visualises this concentration over
+time using Bq/L on the vertical axis.  When either `--ambient-file` or
 `--ambient-concentration` is supplied an additional plot
 `equivalent_air.png` shows the volume of ambient air containing the same
 activity.

--- a/plot_utils/__init__.py
+++ b/plot_utils/__init__.py
@@ -543,11 +543,11 @@ def plot_radon_activity_full(
     palette_name = str(config.get("palette", "default")) if config else "default"
     palette = COLOR_SCHEMES.get(palette_name, COLOR_SCHEMES["default"])
     color = palette.get("radon_activity", "#9467bd")
-    label = None if po214_activity is None else "Rn-222 Activity"
+    label = None if po214_activity is None else "Rn-222 Concentration"
     ax.errorbar(times_mpl, activity, yerr=errors, fmt="o-", color=color, label=label)
     ax.set_xlabel("Time (UTC)")
-    ax.set_ylabel("Rn-222 Activity (Bq)")
-    ax.set_title("Extrapolated Radon Activity vs. Time")
+    ax.set_ylabel("Rn-222 Concentration (Bq/L)")
+    ax.set_title("Extrapolated Radon Concentration vs. Time")
     ax.ticklabel_format(axis="y", style="plain")
     setup_time_axis(ax, times_mpl)
 
@@ -555,8 +555,14 @@ def plot_radon_activity_full(
         po214_activity = np.asarray(po214_activity, dtype=float)
         color214 = palette.get("Po214", "#d62728")
         ax2 = ax.twinx()
-        ax2.plot(times_mpl, po214_activity, "--", color=color214, label="Po-214 Activity (QC)")
-        ax2.set_ylabel("Po-214 Activity (Bq)")
+        ax2.plot(
+            times_mpl,
+            po214_activity,
+            "--",
+            color=color214,
+            label="Po-214 Concentration (QC)",
+        )
+        ax2.set_ylabel("Po-214 Concentration (Bq/L)")
         ax2.ticklabel_format(axis="y", style="plain")
         ax2.yaxis.get_offset_text().set_visible(False)
         lines1, labels1 = ax.get_legend_handles_labels()
@@ -678,8 +684,8 @@ def plot_radon_trend_full(times, activity, out_png, config=None, *, fit_valid=Tr
     color = palette.get("radon_activity", "#9467bd")
     ax.plot(times_mpl, activity, "o-", color=color)
     ax.set_xlabel("Time (UTC)")
-    ax.set_ylabel("Radon Activity (Bq)")
-    ax.set_title("Radon Activity Trend")
+    ax.set_ylabel("Radon Concentration (Bq/L)")
+    ax.set_title("Radon Concentration Trend")
 
     ax.ticklabel_format(axis="y", style="plain")
     setup_time_axis(ax, times_mpl)
@@ -702,7 +708,7 @@ def plot_radon_activity(ts_dict, outdir):
 
     fig, ax = plt.subplots()
     ax.errorbar(times_mpl, y, yerr=e, fmt="o")
-    ax.set_ylabel("Radon activity [Bq]")
+    ax.set_ylabel("Radon concentration [Bq/L]")
     ax.set_xlabel("Time (UTC)")
     ax.ticklabel_format(axis="y", style="plain")
     setup_time_axis(ax, times_mpl)

--- a/plot_utils/radon.py
+++ b/plot_utils/radon.py
@@ -17,7 +17,7 @@ def plot_radon_activity(ts_dict, outdir: Path, out_png: str | Path | None = None
     errors = np.asarray(ts_dict["error"], dtype=float)
     fig, ax = plt.subplots()
     ax.errorbar(times_mpl, activity, yerr=errors, fmt="o")
-    ax.set_ylabel("Rn-222 activity [Bq]")
+    ax.set_ylabel("Rn-222 concentration [Bq/L]")
     ax.set_xlabel("Time (UTC)")
     ax.ticklabel_format(axis="y", style="plain")
     setup_time_axis(ax, times_mpl)
@@ -39,8 +39,12 @@ def plot_radon_trend(ts_dict, outdir: Path, out_png: str | Path | None = None) -
         coeff = np.polyfit(times_mpl, activity, 1)
     fig, ax = plt.subplots()
     ax.plot(times_mpl, activity, "o")
-    ax.plot(times_mpl, np.polyval(coeff, times_mpl), label=f"slope={coeff[0]:.2e} Bq/s")
-    ax.set_ylabel("Rn-222 activity [Bq]")
+    ax.plot(
+        times_mpl,
+        np.polyval(coeff, times_mpl),
+        label=f"slope={coeff[0]:.2e} Bq/L/s",
+    )
+    ax.set_ylabel("Rn-222 concentration [Bq/L]")
     ax.set_xlabel("Time (UTC)")
     ax.ticklabel_format(axis="y", style="plain")
     ax.legend()

--- a/radon_activity.py
+++ b/radon_activity.py
@@ -172,7 +172,8 @@ def compute_total_radon(
 
     The ``monitor_volume`` of the counting chamber and the ``sample_volume`` of
     the air sample must be supplied using the same units.  The configuration
-    files included with this repository use liters.
+    files included with this repository use liters, making the derived
+    concentration a Bq/L value.
 
     Both ``monitor_volume`` and ``sample_volume`` must be non-negative.  A
     ``ValueError`` is raised if ``monitor_volume`` is not positive, if
@@ -184,7 +185,8 @@ def compute_total_radon(
     Returns
     -------
     concentration : float
-        Radon concentration in Bq per same unit as ``monitor_volume``.
+        Radon concentration expressed per unit of ``monitor_volume`` (Bq/L when
+        the volumes are given in liters).
     sigma_conc : float
         Uncertainty on the concentration.
     total_bq : float


### PR DESCRIPTION
## Summary
- update the radon activity documentation to explain the concentration is reported in Bq/L
- relabel radon plots and legends to show concentration units instead of activity in Bq
- clarify the compute_total_radon docstring about returning Bq/L concentration

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cb4a746ab8832bbe56622d66cd197d