### PR TITLE
Fix total radon calculation and single-isotope fallback

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -195,6 +195,9 @@ def compute_total_radon(
     sigma_total : float
         Uncertainty on ``total_bq``.
 
+    When ``sample_volume`` is zero the returned ``total_bq`` and
+    ``sigma_total`` are both ``0.0`` regardless of the activity value.
+
     Examples
     --------
     >>> compute_total_radon(5.0, 0.5, 10.0, 20.0)
@@ -220,9 +223,13 @@ def compute_total_radon(
     conc = activity_bq / monitor_volume
     sigma_conc = err_bq / monitor_volume
 
-    total_volume = monitor_volume + sample_volume
-    total_bq = conc * total_volume
-    sigma_total = sigma_conc * total_volume
+    if sample_volume == 0.0:
+        total_bq = 0.0
+        sigma_total = 0.0
+    else:
+        total_volume = monitor_volume + sample_volume
+        total_bq = conc * total_volume
+        sigma_total = sigma_conc * total_volume
     return conc, sigma_conc, total_bq, sigma_total
 
 

--- a/radon_activity.py
+++ b/radon_activity.py
@@ -198,7 +198,7 @@ def compute_total_radon(
     Examples
     --------
     >>> compute_total_radon(5.0, 0.5, 10.0, 20.0)
-    (0.5, 0.05, 10.0, 1.0)
+    (0.5, 0.05, 15.0, 1.5)
     """
     if monitor_volume <= 0:
         raise ValueError("monitor_volume must be positive")
@@ -220,8 +220,9 @@ def compute_total_radon(
     conc = activity_bq / monitor_volume
     sigma_conc = err_bq / monitor_volume
 
-    total_bq = conc * sample_volume
-    sigma_total = sigma_conc * sample_volume
+    total_volume = monitor_volume + sample_volume
+    total_bq = conc * total_volume
+    sigma_total = sigma_conc * total_volume
     return conc, sigma_conc, total_bq, sigma_total
 
 

--- a/radon_joint_estimator.py
+++ b/radon_joint_estimator.py
@@ -156,7 +156,9 @@ def estimate_radon_activity(
     if mode not in {"radon", "po218", "po214"}:
         raise ValueError("invalid isotope mode")
 
-    if mode == "po218" and res218:
+    if mode == "po218":
+        if not res218:
+            raise ValueError("Po-218 counts unavailable for requested analysis_isotope='po218'")
         rn, var = res218
         return {
             "isotope_mode": "po218",
@@ -164,7 +166,9 @@ def estimate_radon_activity(
             "stat_unc_Bq": math.sqrt(var),
             "components": components,
         }
-    if mode == "po214" and res214:
+    if mode == "po214":
+        if not res214:
+            raise ValueError("Po-214 counts unavailable for requested analysis_isotope='po214'")
         rn, var = res214
         return {
             "isotope_mode": "po214",

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -157,15 +157,15 @@ def test_compute_total_radon():
     conc, dconc, tot, dtot = compute_total_radon(5.0, 0.5, 10.0, 20.0)
     assert conc == pytest.approx(0.5)
     assert dconc == pytest.approx(0.05)
-    assert tot == pytest.approx(10.0)
-    assert dtot == pytest.approx(1.0)
+    assert tot == pytest.approx(15.0)
+    assert dtot == pytest.approx(1.5)
 
 
 def test_compute_total_radon_zero_uncertainty():
     conc, dconc, tot, dtot = compute_total_radon(5.0, 0.0, 10.0, 10.0)
     assert conc == pytest.approx(0.5)
     assert dconc == pytest.approx(0.0)
-    assert tot == pytest.approx(5.0)
+    assert tot == pytest.approx(10.0)
     assert dtot == pytest.approx(0.0)
 
 
@@ -217,8 +217,8 @@ def test_compute_total_radon_negative_activity_allowed(caplog):
     )
     assert conc == pytest.approx(-0.1)
     assert dconc == pytest.approx(0.05)
-    assert tot == pytest.approx(-0.1)
-    assert dtot == pytest.approx(0.05)
+    assert tot == pytest.approx(-1.1)
+    assert dtot == pytest.approx(0.55)
 
 
 def test_radon_activity_curve():

--- a/tests/test_radon_joint_estimator.py
+++ b/tests/test_radon_joint_estimator.py
@@ -53,3 +53,31 @@ def test_counts_without_live_time_raises():
             f214=1.0,
         )
 
+
+def test_single_isotope_po218_missing_counts_raises():
+    with pytest.raises(ValueError, match="Po-218 counts unavailable"):
+        estimate_radon_activity(
+            N218=None,
+            epsilon218=0.5,
+            f218=1.0,
+            N214=20,
+            epsilon214=0.6,
+            f214=1.0,
+            live_time214_s=3600.0,
+            analysis_isotope="po218",
+        )
+
+
+def test_single_isotope_po214_missing_counts_raises():
+    with pytest.raises(ValueError, match="Po-214 counts unavailable"):
+        estimate_radon_activity(
+            N218=15,
+            epsilon218=0.5,
+            f218=1.0,
+            N214=None,
+            epsilon214=0.6,
+            f214=1.0,
+            live_time218_s=3600.0,
+            analysis_isotope="po214",
+        )
+


### PR DESCRIPTION
## Summary
- correct the total radon calculation to include both the sample and chamber volumes and update its documentation and tests
- prevent single-isotope radon estimates from silently falling back to combined mode when the requested counts are unavailable, and cover the behaviour with targeted tests

## Testing
- pytest tests/test_radon_activity.py tests/test_radon_joint_estimator.py tests/test_sample_radon.py

------
https://chatgpt.com/codex/tasks/task_e_68cb68de5754832ba46391b97182618d