### PR TITLE
Fix total radon calculation

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -201,7 +201,7 @@ def compute_total_radon(
     Examples
     --------
     >>> compute_total_radon(5.0, 0.5, 10.0, 20.0)
-    (0.5, 0.05, 15.0, 1.5)
+    (0.5, 0.05, 10.0, 1.0)
     """
     if monitor_volume <= 0:
         raise ValueError("monitor_volume must be positive")
@@ -227,9 +227,8 @@ def compute_total_radon(
         total_bq = 0.0
         sigma_total = 0.0
     else:
-        total_volume = monitor_volume + sample_volume
-        total_bq = conc * total_volume
-        sigma_total = sigma_conc * total_volume
+        total_bq = conc * sample_volume
+        sigma_total = sigma_conc * sample_volume
     return conc, sigma_conc, total_bq, sigma_total
 
 

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -157,15 +157,15 @@ def test_compute_total_radon():
     conc, dconc, tot, dtot = compute_total_radon(5.0, 0.5, 10.0, 20.0)
     assert conc == pytest.approx(0.5)
     assert dconc == pytest.approx(0.05)
-    assert tot == pytest.approx(15.0)
-    assert dtot == pytest.approx(1.5)
+    assert tot == pytest.approx(10.0)
+    assert dtot == pytest.approx(1.0)
 
 
 def test_compute_total_radon_zero_uncertainty():
     conc, dconc, tot, dtot = compute_total_radon(5.0, 0.0, 10.0, 10.0)
     assert conc == pytest.approx(0.5)
     assert dconc == pytest.approx(0.0)
-    assert tot == pytest.approx(10.0)
+    assert tot == pytest.approx(5.0)
     assert dtot == pytest.approx(0.0)
 
 
@@ -217,8 +217,8 @@ def test_compute_total_radon_negative_activity_allowed(caplog):
     )
     assert conc == pytest.approx(-0.1)
     assert dconc == pytest.approx(0.05)
-    assert tot == pytest.approx(-1.1)
-    assert dtot == pytest.approx(0.55)
+    assert tot == pytest.approx(-0.1)
+    assert dtot == pytest.approx(0.05)
 
 
 def test_radon_activity_curve():


### PR DESCRIPTION
## Summary
- correct `compute_total_radon` to scale totals by the sampled air volume instead of the chamber plus sample volume
- update the function documentation example to reflect the corrected totals
- adjust unit tests to match the physically consistent calculation

## Testing
- pytest tests/test_radon_activity.py tests/test_sample_radon.py

------
https://chatgpt.com/codex/tasks/task_e_68cc5528dd44832bb6ffcff7d760543f