### PR TITLE
Fix total radon calculation

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -207,17 +207,16 @@ def compute_total_radon(
     sigma_conc : float
         Uncertainty on the concentration.
     total_bq : float
-        Total radon in the sample volume in Bq.
+        Total radon in the sample volume in Bq.  This equals the clamped
+        activity because the integration chamber collects the full sample prior
+        to counting.
     sigma_total : float
         Uncertainty on ``total_bq``.
-
-    When ``sample_volume`` is zero the returned ``total_bq`` and
-    ``sigma_total`` are both ``0.0`` regardless of the activity value.
 
     Examples
     --------
     >>> compute_total_radon(5.0, 0.5, 10.0, 20.0)
-    (0.5, 0.05, 10.0, 1.0)
+    (0.5, 0.05, 5.0, 0.5)
     """
     if monitor_volume <= 0:
         raise ValueError("monitor_volume must be positive")
@@ -239,12 +238,8 @@ def compute_total_radon(
     conc = activity_bq / monitor_volume
     sigma_conc = err_bq / monitor_volume
 
-    if sample_volume == 0.0:
-        total_bq = 0.0
-        sigma_total = 0.0
-    else:
-        total_bq = conc * sample_volume
-        sigma_total = sigma_conc * sample_volume
+    total_bq = activity_bq
+    sigma_total = err_bq
     return conc, sigma_conc, total_bq, sigma_total
 
 

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -157,8 +157,8 @@ def test_compute_total_radon():
     conc, dconc, tot, dtot = compute_total_radon(5.0, 0.5, 10.0, 20.0)
     assert conc == pytest.approx(0.5)
     assert dconc == pytest.approx(0.05)
-    assert tot == pytest.approx(10.0)
-    assert dtot == pytest.approx(1.0)
+    assert tot == pytest.approx(5.0)
+    assert dtot == pytest.approx(0.5)
 
 
 def test_compute_total_radon_zero_uncertainty():
@@ -224,8 +224,8 @@ def test_compute_total_radon_negative_activity_allowed(caplog):
     )
     assert conc == pytest.approx(-0.1)
     assert dconc == pytest.approx(0.05)
-    assert tot == pytest.approx(-0.1)
-    assert dtot == pytest.approx(0.05)
+    assert tot == pytest.approx(-1.0)
+    assert dtot == pytest.approx(0.5)
 
 
 def test_radon_activity_curve():


### PR DESCRIPTION
## Summary
- report the total radon in a sample using the clamped activity measurement instead of scaling by the volume ratio
- update the compute_total_radon documentation example to match the new behavior
- adjust unit tests to cover the corrected totals, including the negative-activity path

## Testing
- pytest tests/test_radon_activity.py tests/test_sample_radon.py


------
https://chatgpt.com/codex/tasks/task_e_68cc5d120e60832b984936568ae8d5fd