### PR TITLE
Clamp negative total radon outputs

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -2895,8 +2895,15 @@ def main(argv=None):
         "value": conc,
         "uncertainty": dconc,
     }
+    # Allow the analysis to proceed with negative activities when explicitly
+    # requested, but clamp the reported total to zero to avoid presenting a
+    # physically impossible negative quantity in the summary outputs.
+    total_bq_display = total_bq
+    if total_bq_display < 0:
+        total_bq_display = 0.0
+
     radon_results["total_radon_in_sample_Bq"] = {
-        "value": total_bq,
+        "value": total_bq_display,
         "uncertainty": dtotal_bq,
     }
 


### PR DESCRIPTION
## Summary
- clamp the reported total radon in the sample to zero when negative activities are allowed so downstream summaries remain physical

## Testing
- pytest tests/test_negative_activity_policy.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cc5d120e60832b984936568ae8d5fd