### PR TITLE
Validate rate shortcut isotope selection

### DIFF
--- a/radon_joint_estimator.py
+++ b/radon_joint_estimator.py
@@ -69,6 +69,8 @@ def estimate_radon_activity(
             require_equilibrium=False,
         )
         mode = analysis_isotope.lower()
+        if mode not in {"radon", "po214", "po218"}:
+            raise ValueError("invalid isotope mode")
         if mode == "radon":
             return {
                 "isotope_mode": "radon",
@@ -77,20 +79,26 @@ def estimate_radon_activity(
                 "components": comp,
             }
         if mode == "po214":
+            if rate214 is None:
+                raise ValueError(
+                    "Po-214 rate unavailable for requested analysis_isotope='po214'"
+                )
             return {
                 "isotope_mode": "po214",
                 "activity_Bq": rate214,
                 "stat_unc_Bq": err214,
                 "components": comp,
             }
-        if mode == "po218":
-            return {
-                "isotope_mode": "po218",
-                "activity_Bq": rate218,
-                "stat_unc_Bq": err218,
-                "components": comp,
-            }
-        raise ValueError("invalid isotope mode")
+        if rate218 is None:
+            raise ValueError(
+                "Po-218 rate unavailable for requested analysis_isotope='po218'"
+            )
+        return {
+            "isotope_mode": "po218",
+            "activity_Bq": rate218,
+            "stat_unc_Bq": err218,
+            "components": comp,
+        }
 
     if epsilon218 is None or epsilon214 is None or f218 is None or f214 is None:
         raise ValueError("counts mode requires efficiencies and fractions")

--- a/tests/test_radon_joint_estimator.py
+++ b/tests/test_radon_joint_estimator.py
@@ -81,3 +81,19 @@ def test_single_isotope_po214_missing_counts_raises():
             analysis_isotope="po214",
         )
 
+
+def test_rate_shortcut_requires_requested_isotope_data():
+    with pytest.raises(ValueError, match="Po-214 rate unavailable"):
+        estimate_radon_activity(
+            rate218=1.0,
+            err218=0.1,
+            analysis_isotope="po214",
+        )
+
+    with pytest.raises(ValueError, match="Po-218 rate unavailable"):
+        estimate_radon_activity(
+            rate214=0.9,
+            err214=0.05,
+            analysis_isotope="po218",
+        )
+


### PR DESCRIPTION
## Summary
- validate isotope selection in the rate-based shortcut of `estimate_radon_activity`
- raise clear errors when a requested Po-214 or Po-218 rate is missing and preserve existing radon behavior
- extend unit tests to cover the rate shortcut validation

## Testing
- `pytest tests/test_radon_joint_estimator.py`


------
https://chatgpt.com/codex/tasks/task_e_68cc5d120e60832b984936568ae8d5fd