### PR TITLE
Fix ADC shift quadratic default and baseline fallback handling

### DIFF
--- a/systematics.py
+++ b/systematics.py
@@ -57,7 +57,7 @@ def apply_linear_adc_shift(
     elif mode == "quadratic":
         p = params or {}
         a = float(p.get("a", 0.0))
-        b = float(p.get("b", rate))
+        b = float(p.get("b", 0.0))
         shift = a * dt ** 2 + b * dt
     elif mode == "piecewise":
         if not params or "times" not in params or "shifts" not in params:

--- a/tests/test_baseline_utils.py
+++ b/tests/test_baseline_utils.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from baseline_utils import apply_baseline_subtraction, BaselineError
+
+
+def _df_from_seconds(seconds):
+    timestamps = pd.to_datetime(seconds, unit="s", utc=True)
+    return pd.DataFrame({"timestamp": timestamps, "adc": np.zeros(len(seconds))})
+
+
+def test_apply_baseline_subtraction_outside_range_without_fallback():
+    df = _df_from_seconds([0.0, 1.0, 2.0])
+    bins = np.array([0.0, 1.0])
+
+    with pytest.raises(BaselineError, match="outside data range"):
+        apply_baseline_subtraction(
+            df,
+            df,
+            bins,
+            pd.Timestamp(10, unit="s", tz="UTC"),
+            pd.Timestamp(12, unit="s", tz="UTC"),
+            allow_fallback=False,
+        )
+
+
+def test_apply_baseline_subtraction_empty_slice_without_fallback():
+    df = _df_from_seconds([0.0, 1.0, 2.0])
+    bins = np.array([0.0, 1.0])
+
+    with pytest.raises(BaselineError, match="matched no events"):
+        apply_baseline_subtraction(
+            df,
+            df,
+            bins,
+            pd.Timestamp(0.1, unit="s", tz="UTC"),
+            pd.Timestamp(0.2, unit="s", tz="UTC"),
+            allow_fallback=False,
+        )
+
+
+def test_apply_baseline_subtraction_allows_fallback_when_enabled():
+    df = _df_from_seconds([0.0, 1.0, 2.0])
+    bins = np.array([0.0, 1.0])
+
+    out_df, hist = apply_baseline_subtraction(
+        df,
+        df,
+        bins,
+        pd.Timestamp(10, unit="s", tz="UTC"),
+        pd.Timestamp(12, unit="s", tz="UTC"),
+        allow_fallback=True,
+    )
+
+    assert out_df.equals(df)
+    assert hist.shape == (1,)
+    assert hist[0] == pytest.approx(3.0)

--- a/tests/test_systematics.py
+++ b/tests/test_systematics.py
@@ -64,6 +64,20 @@ def test_apply_linear_adc_shift_quadratic():
     assert np.allclose(out, [0.0, 1.5, 4.0])
 
 
+def test_apply_linear_adc_shift_quadratic_ignores_rate_parameter():
+    adc = np.zeros(3)
+    t = np.array([0.0, 1.0, 2.0])
+    out = apply_linear_adc_shift(
+        adc,
+        t,
+        rate=5.0,
+        mode="quadratic",
+        params={"a": 0.5},
+    )
+    assert isinstance(out, np.ndarray)
+    assert np.allclose(out, [0.0, 0.5, 2.0])
+
+
 def test_apply_linear_adc_shift_piecewise():
     adc = np.zeros(4)
     t = np.array([0.0, 1.0, 2.0, 3.0])


### PR DESCRIPTION
## Summary
- ensure quadratic ADC drift corrections no longer default to the linear rate parameter
- make baseline subtraction honor the allow_fallback flag and raise BaselineError when disabled
- cover the new behaviour with targeted unit tests

## Testing
- pytest tests/test_systematics.py tests/test_baseline_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68cde2c13904832b90f703d46dba9f49