### PR TITLE
Handle hierarchical uncertainties and align config checks

### DIFF
--- a/assertions_and_ci.py
+++ b/assertions_and_ci.py
@@ -18,7 +18,7 @@ def run_assertions(summary: Mapping[str, Any], constants: Mapping[str, Any], con
     """
     if "radon" in summary:
         assert summary["radon"]["Rn_activity_Bq"] >= 0
-        assert summary["radon"]["stat_unc_Bq"] > 0
+        assert summary["radon"]["stat_unc_Bq"] >= 0
     # Spectral fit should be valid when requested
     spec = summary.get("spectral_fit", {})
     if spec:

--- a/io_utils.py
+++ b/io_utils.py
@@ -174,7 +174,7 @@ CONFIG_SCHEMA = {
                     "maxItems": 2,
                 },
                 "monitor_volume_l": {"type": "number", "minimum": 0},
-                "sample_volume_l": {"type": "number", "minimum": 0},
+                "sample_volume_l": {"type": "number", "exclusiveMinimum": 0},
                 "isotopes_to_subtract": {"type": "array", "items": {"type": "string"}},
             },
         },


### PR DESCRIPTION
## Summary
- filter hierarchical summary inputs to discard runs lacking finite half-life uncertainties and ignore invalid calibration errors
- allow zero statistical uncertainty in runtime assertions while keeping sample volume strictly positive
- tighten configuration schema to require a positive sample volume, matching runtime checks

## Testing
- pytest tests/test_assertions_and_ci.py tests/test_hierarchical_summary.py tests/test_hierarchical.py
- pytest tests/test_hierarchical_intervals.py

------
https://chatgpt.com/codex/tasks/task_e_68cdeb79cc00832b8658d52227916761