### PR TITLE
Validate dilution volumes

### DIFF
--- a/baseline_utils.py
+++ b/baseline_utils.py
@@ -38,10 +38,11 @@ def compute_dilution_factor(monitor_volume: float, sample_volume: float) -> floa
     Parameters
     ----------
     monitor_volume:
-        Detector chamber volume in litres. Must be strictly positive.
+        Detector chamber volume in litres. Must be finite and strictly
+        positive.
     sample_volume:
         Volume of the sample air introduced to the chamber in litres. Must be
-        non-negative.
+        finite and non-negative.
 
     Raises
     ------
@@ -51,6 +52,10 @@ def compute_dilution_factor(monitor_volume: float, sample_volume: float) -> floa
 
     monitor = float(monitor_volume)
     sample = float(sample_volume)
+    if not np.isfinite(monitor):
+        raise ValueError("monitor_volume must be finite")
+    if not np.isfinite(sample):
+        raise ValueError("sample_volume must be finite")
     if monitor <= 0:
         raise ValueError("monitor_volume must be positive")
     if sample < 0:

--- a/tests/test_scaling_factor.py
+++ b/tests/test_scaling_factor.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import math
 import sys
 
 import pytest
@@ -37,6 +38,10 @@ def test_compute_dilution_factor():
         (0.0, 5.0, "monitor_volume must be positive"),
         (-1.0, 5.0, "monitor_volume must be positive"),
         (10.0, -0.5, "sample_volume must be non-negative"),
+        (math.nan, 1.0, "monitor_volume must be finite"),
+        (math.inf, 1.0, "monitor_volume must be finite"),
+        (10.0, math.nan, "sample_volume must be finite"),
+        (10.0, math.inf, "sample_volume must be finite"),
     ],
 )
 def test_compute_dilution_factor_invalid_inputs(monitor_volume, sample_volume, message):


### PR DESCRIPTION
## Summary
- reject non-finite monitor and sample volumes in `compute_dilution_factor`
- document the finite volume requirement
- extend the scaling factor tests to cover NaN/Inf inputs

## Testing
- pytest tests/test_scaling_factor.py

------
https://chatgpt.com/codex/tasks/task_e_68cdeb79cc00832b8658d52227916761