### PR TITLE
Handle non-finite radon rates

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -104,24 +104,34 @@ def compute_radon_activity(
     weights: list[Optional[float]] = []
 
     if rate218 is not None and eff218 > 0:
-        values.append(rate218)
-        if err218 is not None and err218 >= 0:
-            if err218 == 0:
-                weights.append(float("inf"))
-            else:
-                weights.append(1.0 / err218**2)
+        if not math.isfinite(rate218):
+            logging.warning(
+                "Skipping non-finite Po-218 rate when computing radon activity"
+            )
         else:
-            weights.append(None)
+            values.append(rate218)
+            if err218 is not None and err218 >= 0:
+                if err218 == 0:
+                    weights.append(float("inf"))
+                else:
+                    weights.append(1.0 / err218**2)
+            else:
+                weights.append(None)
 
     if rate214 is not None and eff214 > 0:
-        values.append(rate214)
-        if err214 is not None and err214 >= 0:
-            if err214 == 0:
-                weights.append(float("inf"))
-            else:
-                weights.append(1.0 / err214**2)
+        if not math.isfinite(rate214):
+            logging.warning(
+                "Skipping non-finite Po-214 rate when computing radon activity"
+            )
         else:
-            weights.append(None)
+            values.append(rate214)
+            if err214 is not None and err214 >= 0:
+                if err214 == 0:
+                    weights.append(float("inf"))
+                else:
+                    weights.append(1.0 / err214**2)
+            else:
+                weights.append(None)
 
     if not values:
         return 0.0, math.nan

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -197,6 +197,13 @@ def test_compute_radon_activity_both_missing_errors():
     assert math.isnan(s)
 
 
+def test_compute_radon_activity_skips_nan_rate():
+    """Treat non-finite rates as absent measurements."""
+    a, s = compute_radon_activity(float("nan"), 0.4, 1.0, 7.0, 0.6, 1.0)
+    assert a == pytest.approx(7.0)
+    assert s == pytest.approx(0.6)
+
+
 def test_compute_total_radon_negative_sample_volume():
     with pytest.raises(ValueError):
         compute_total_radon(5.0, 0.5, 10.0, -1.0)


### PR DESCRIPTION
## Summary
- skip non-finite Po-218 and Po-214 rates when computing radon activity
- log a warning when a non-finite rate is ignored
- add regression coverage to ensure NaN inputs do not contaminate the combined result

## Testing
- pytest tests/test_radon_activity.py

------
https://chatgpt.com/codex/tasks/task_e_68ce0a292b70832b8bb9095dd916885f