### PR TITLE
Fix total radon scaling to undo dilution

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -227,7 +227,7 @@ def compute_total_radon(
     Examples
     --------
     >>> compute_total_radon(5.0, 0.5, 10.0, 20.0)
-    (0.5, 0.05, 10.0, 1.0)
+    (0.5, 0.05, 15.0, 1.5)
     """
     if monitor_volume <= 0:
         raise ValueError("monitor_volume must be positive")
@@ -253,8 +253,9 @@ def compute_total_radon(
         total_bq = 0.0
         sigma_total = 0.0
     else:
-        total_bq = conc * sample_volume
-        sigma_total = sigma_conc * sample_volume
+        dilution_factor = (monitor_volume + sample_volume) / monitor_volume
+        total_bq = activity_bq * dilution_factor
+        sigma_total = err_bq * dilution_factor
     return conc, sigma_conc, total_bq, sigma_total
 
 

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -157,15 +157,15 @@ def test_compute_total_radon():
     conc, dconc, tot, dtot = compute_total_radon(5.0, 0.5, 10.0, 20.0)
     assert conc == pytest.approx(0.5)
     assert dconc == pytest.approx(0.05)
-    assert tot == pytest.approx(10.0)
-    assert dtot == pytest.approx(1.0)
+    assert tot == pytest.approx(15.0)
+    assert dtot == pytest.approx(1.5)
 
 
 def test_compute_total_radon_zero_uncertainty():
     conc, dconc, tot, dtot = compute_total_radon(5.0, 0.0, 10.0, 10.0)
     assert conc == pytest.approx(0.5)
     assert dconc == pytest.approx(0.0)
-    assert tot == pytest.approx(5.0)
+    assert tot == pytest.approx(10.0)
     assert dtot == pytest.approx(0.0)
 
 
@@ -231,8 +231,8 @@ def test_compute_total_radon_negative_activity_allowed(caplog):
     )
     assert conc == pytest.approx(-0.1)
     assert dconc == pytest.approx(0.05)
-    assert tot == pytest.approx(-0.1)
-    assert dtot == pytest.approx(0.05)
+    assert tot == pytest.approx(-1.1)
+    assert dtot == pytest.approx(0.55)
 
 
 def test_radon_activity_curve():


### PR DESCRIPTION
## Summary
- update `compute_total_radon` to undo the measurement dilution using `(monitor_volume + sample_volume) / monitor_volume`
- refresh the docstring example and tests to expect the rescaled totals, including negative-activity handling

## Testing
- pytest tests/test_radon_activity.py tests/test_sample_radon.py

------
https://chatgpt.com/codex/tasks/task_e_68ce046dd224832ba196ce086a5003fa