### PR TITLE
Return undiluted radon totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--j
 - `efficiency.png` – bar chart of individual efficiencies and the BLUE result.
 - `eff_cov.png` – heatmap of the efficiency covariance matrix.
 - `radon_activity.png` – extrapolated radon concentration (Bq/L) over time.
-- `total_radon.png` – total radon present in the assay volume (Bq).
+- `total_radon.png` – total radon present in the sampled air (Bq).
  - `equivalent_air.png` – equivalent air volume plot when `--ambient-file` or
    `--ambient-concentration` is provided.
 

--- a/analyze.py
+++ b/analyze.py
@@ -308,9 +308,8 @@ def _total_radon_series(activity, errors, monitor_volume, sample_volume):
         total = np.zeros_like(activity_arr)
         total_err = None if err_arr is None else np.zeros_like(err_arr)
     else:
-        scale = sample_volume / monitor_volume
-        total = activity_arr * scale
-        total_err = None if err_arr is None else err_arr * scale
+        total = activity_arr
+        total_err = err_arr
 
     return total, total_err
 
@@ -2952,7 +2951,7 @@ def main(argv=None):
         }
 
     # Convert activity to a concentration per liter of monitor volume and the
-    # total amount of radon present in just the assay sample.
+    # total amount of radon present in the sampled air (undiluted by the chamber volume).
     try:
         conc, dconc, total_bq, dtotal_bq = compute_total_radon(
             A_radon,

--- a/radon_activity.py
+++ b/radon_activity.py
@@ -217,7 +217,8 @@ def compute_total_radon(
     sigma_conc : float
         Uncertainty on the concentration.
     total_bq : float
-        Total radon in the sample volume in Bq.
+        Total radon present in the sample, equal to the fitted activity when the
+        sample volume is positive.
     sigma_total : float
         Uncertainty on ``total_bq``.
 
@@ -227,7 +228,7 @@ def compute_total_radon(
     Examples
     --------
     >>> compute_total_radon(5.0, 0.5, 10.0, 20.0)
-    (0.5, 0.05, 10.0, 1.0)
+    (0.5, 0.05, 5.0, 0.5)
     """
     if monitor_volume <= 0:
         raise ValueError("monitor_volume must be positive")
@@ -253,9 +254,8 @@ def compute_total_radon(
         total_bq = 0.0
         sigma_total = 0.0
     else:
-        scaling = sample_volume / monitor_volume
-        total_bq = activity_bq * scaling
-        sigma_total = err_bq * scaling
+        total_bq = activity_bq
+        sigma_total = err_bq
     return conc, sigma_conc, total_bq, sigma_total
 
 

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -157,8 +157,8 @@ def test_compute_total_radon():
     conc, dconc, tot, dtot = compute_total_radon(5.0, 0.5, 10.0, 20.0)
     assert conc == pytest.approx(0.5)
     assert dconc == pytest.approx(0.05)
-    assert tot == pytest.approx(10.0)
-    assert dtot == pytest.approx(1.0)
+    assert tot == pytest.approx(5.0)
+    assert dtot == pytest.approx(0.5)
 
 
 def test_compute_total_radon_zero_uncertainty():
@@ -231,8 +231,8 @@ def test_compute_total_radon_negative_activity_allowed(caplog):
     )
     assert conc == pytest.approx(-0.1)
     assert dconc == pytest.approx(0.05)
-    assert tot == pytest.approx(-0.1)
-    assert dtot == pytest.approx(0.05)
+    assert tot == pytest.approx(-1.0)
+    assert dtot == pytest.approx(0.5)
 
 
 def test_radon_activity_curve():

--- a/tests/test_sample_radon.py
+++ b/tests/test_sample_radon.py
@@ -77,5 +77,6 @@ def test_total_radon_uses_sample_volume(tmp_path, monkeypatch):
     analyze.main()
 
     summary = captured.get("summary", {})
-    expected = radon_activity.compute_total_radon(5.0, 0.5, 10.0, 5.0)[2]
-    assert summary["radon_results"]["total_radon_in_sample_Bq"]["value"] == pytest.approx(expected)
+    total_entry = summary["radon_results"]["total_radon_in_sample_Bq"]
+    assert total_entry["value"] == pytest.approx(5.0)
+    assert total_entry["uncertainty"] == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- return the fitted radon activity for total-radon outputs when the sample volume is positive
- align analyze.py helpers, CLI comments, and documentation with the undiluted definition
- update unit tests to check for the new totals and uncertainties

## Testing
- pytest tests/test_radon_activity.py tests/test_sample_radon.py


------
https://chatgpt.com/codex/tasks/task_e_68cf88dc8ee4832bb7d850c20735944e