### PR TITLE
Apply combined volume scaling to total radon outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ The analysis writes results to `<output_dir>/<timestamp>/` by default. When `--j
 - `efficiency.png` – bar chart of individual efficiencies and the BLUE result.
 - `eff_cov.png` – heatmap of the efficiency covariance matrix.
 - `radon_activity.png` – extrapolated radon concentration (Bq/L) over time.
-- `total_radon.png` – total radon present in the sampled air (Bq).
+- `total_radon.png` – total radon present in the sampled air after scaling the
+  fitted activity by the combined counting volume `(monitor + sample)` (Bq).
  - `equivalent_air.png` – equivalent air volume plot when `--ambient-file` or
    `--ambient-concentration` is provided.
 

--- a/analyze.py
+++ b/analyze.py
@@ -308,8 +308,9 @@ def _total_radon_series(activity, errors, monitor_volume, sample_volume):
         total = np.zeros_like(activity_arr)
         total_err = None if err_arr is None else np.zeros_like(err_arr)
     else:
-        total = activity_arr
-        total_err = err_arr
+        scale = (monitor_volume + sample_volume) / monitor_volume
+        total = activity_arr * scale
+        total_err = None if err_arr is None else err_arr * scale
 
     return total, total_err
 

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -155,17 +155,19 @@ def test_compute_radon_activity_equilibrium_check():
 
 def test_compute_total_radon():
     conc, dconc, tot, dtot = compute_total_radon(5.0, 0.5, 10.0, 20.0)
-    assert conc == pytest.approx(0.5)
-    assert dconc == pytest.approx(0.05)
-    assert tot == pytest.approx(5.0)
-    assert dtot == pytest.approx(0.5)
+    scale = (10.0 + 20.0) / 10.0
+    assert conc == pytest.approx((5.0 * scale) / 10.0)
+    assert dconc == pytest.approx((0.5 * scale) / 10.0)
+    assert tot == pytest.approx(5.0 * scale)
+    assert dtot == pytest.approx(0.5 * scale)
 
 
 def test_compute_total_radon_zero_uncertainty():
     conc, dconc, tot, dtot = compute_total_radon(5.0, 0.0, 10.0, 10.0)
-    assert conc == pytest.approx(0.5)
+    scale = (10.0 + 10.0) / 10.0
+    assert conc == pytest.approx((5.0 * scale) / 10.0)
     assert dconc == pytest.approx(0.0)
-    assert tot == pytest.approx(5.0)
+    assert tot == pytest.approx(5.0 * scale)
     assert dtot == pytest.approx(0.0)
 
 
@@ -229,10 +231,11 @@ def test_compute_total_radon_negative_activity_allowed(caplog):
     conc, dconc, tot, dtot = compute_total_radon(
         -1.0, 0.5, 10.0, 1.0, allow_negative_activity=True
     )
-    assert conc == pytest.approx(-0.1)
-    assert dconc == pytest.approx(0.05)
-    assert tot == pytest.approx(-1.0)
-    assert dtot == pytest.approx(0.5)
+    scale = (10.0 + 1.0) / 10.0
+    assert conc == pytest.approx((-1.0 * scale) / 10.0)
+    assert dconc == pytest.approx((0.5 * scale) / 10.0)
+    assert tot == pytest.approx(-1.0 * scale)
+    assert dtot == pytest.approx(0.5 * scale)
 
 
 def test_radon_activity_curve():

--- a/tests/test_sample_radon.py
+++ b/tests/test_sample_radon.py
@@ -78,5 +78,6 @@ def test_total_radon_uses_sample_volume(tmp_path, monkeypatch):
 
     summary = captured.get("summary", {})
     total_entry = summary["radon_results"]["total_radon_in_sample_Bq"]
-    assert total_entry["value"] == pytest.approx(5.0)
-    assert total_entry["uncertainty"] == pytest.approx(0.5)
+    scale = (10.0 + 5.0) / 10.0
+    assert total_entry["value"] == pytest.approx(5.0 * scale)
+    assert total_entry["uncertainty"] == pytest.approx(0.5 * scale)


### PR DESCRIPTION
## Summary
- scale total radon calculations by the combined monitor and sample volume
- propagate the same scaling to time-series totals and adjust unit tests and docs

## Testing
- pytest tests/test_radon_activity.py tests/test_sample_radon.py

------
https://chatgpt.com/codex/tasks/task_e_68d012c8ef9c832b8a37e69c219287ba