### PR TITLE
Fix concentration scaling in compute_total_radon

### DIFF
--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -156,8 +156,8 @@ def test_compute_radon_activity_equilibrium_check():
 def test_compute_total_radon():
     conc, dconc, tot, dtot = compute_total_radon(5.0, 0.5, 10.0, 20.0)
     scale = (10.0 + 20.0) / 10.0
-    assert conc == pytest.approx((5.0 * scale) / 10.0)
-    assert dconc == pytest.approx((0.5 * scale) / 10.0)
+    assert conc == pytest.approx(5.0 / 10.0)
+    assert dconc == pytest.approx(0.5 / 10.0)
     assert tot == pytest.approx(5.0 * scale)
     assert dtot == pytest.approx(0.5 * scale)
 
@@ -165,7 +165,7 @@ def test_compute_total_radon():
 def test_compute_total_radon_zero_uncertainty():
     conc, dconc, tot, dtot = compute_total_radon(5.0, 0.0, 10.0, 10.0)
     scale = (10.0 + 10.0) / 10.0
-    assert conc == pytest.approx((5.0 * scale) / 10.0)
+    assert conc == pytest.approx(5.0 / 10.0)
     assert dconc == pytest.approx(0.0)
     assert tot == pytest.approx(5.0 * scale)
     assert dtot == pytest.approx(0.0)
@@ -232,8 +232,8 @@ def test_compute_total_radon_negative_activity_allowed(caplog):
         -1.0, 0.5, 10.0, 1.0, allow_negative_activity=True
     )
     scale = (10.0 + 1.0) / 10.0
-    assert conc == pytest.approx((-1.0 * scale) / 10.0)
-    assert dconc == pytest.approx((0.5 * scale) / 10.0)
+    assert conc == pytest.approx(-1.0 / 10.0)
+    assert dconc == pytest.approx(0.5 / 10.0)
     assert tot == pytest.approx(-1.0 * scale)
     assert dtot == pytest.approx(0.5 * scale)
 


### PR DESCRIPTION
## Summary
- stop scaling the reported radon concentration when a sample volume is present
- continue scaling the total radon amount so it reflects the combined monitor and sample volume
- update documentation and regression tests for the corrected concentration behaviour

## Testing
- pytest tests/test_radon_activity.py

------
https://chatgpt.com/codex/tasks/task_e_68d01a9a29ac832bb02c28d479e4345d