### PR TITLE
Fix log_expm1_stable domain handling and infinite radon weights

### DIFF
--- a/math_utils.py
+++ b/math_utils.py
@@ -19,10 +19,8 @@ def log_expm1_stable(y: np.ndarray) -> np.ndarray:
     mask = y > 0
     # For positive values use stable formulation that avoids overflow
     out[mask] = y[mask] + np.log1p(-np.exp(-y[mask]))
-    # For non-positive values fallback to direct computation while
-    # clamping the argument to avoid log(0)
-    tiny = np.finfo(float).tiny
-    tmp = np.expm1(y[~mask])
-    tmp = np.clip(tmp, tiny, None)
-    out[~mask] = np.log(tmp)
+    # For non-positive inputs defer to NumPy's behaviour so that values
+    # outside the domain ``expm1(y) > 0`` propagate ``nan``/``-inf``
+    # instead of being silently clamped to tiny positives.
+    out[~mask] = np.log(np.expm1(y[~mask]))
     return out

--- a/radon_activity.py
+++ b/radon_activity.py
@@ -113,8 +113,10 @@ def compute_radon_activity(
             if err218 is not None and err218 >= 0:
                 if err218 == 0:
                     weights.append(float("inf"))
-                else:
+                elif math.isfinite(err218):
                     weights.append(1.0 / err218**2)
+                else:
+                    weights.append(None)
             else:
                 weights.append(None)
 
@@ -128,8 +130,10 @@ def compute_radon_activity(
             if err214 is not None and err214 >= 0:
                 if err214 == 0:
                     weights.append(float("inf"))
-                else:
+                elif math.isfinite(err214):
                     weights.append(1.0 / err214**2)
+                else:
+                    weights.append(None)
             else:
                 weights.append(None)
 
@@ -149,8 +153,13 @@ def compute_radon_activity(
             A = values[1]
             sigma = 0.0
         else:
-            A = (values[0] * w1 + values[1] * w2) / (w1 + w2)
-            sigma = math.sqrt(1.0 / (w1 + w2))
+            weight_sum = w1 + w2
+            if weight_sum <= 0:
+                A = (values[0] + values[1]) / 2.0
+                sigma = math.nan
+            else:
+                A = (values[0] * w1 + values[1] * w2) / weight_sum
+                sigma = math.sqrt(1.0 / weight_sum)
         return A, sigma
 
     if len(values) == 2:

--- a/tests/test_math_utils.py
+++ b/tests/test_math_utils.py
@@ -4,13 +4,20 @@ from math_utils import log_expm1_stable
 
 def test_log_expm1_stable_matches_numpy():
     y = np.array([-50.0, -1e-6, 0.0, 1e-6, 1.0, 10.0])
-    tiny = np.finfo(float).tiny
-    expected = np.where(
-        y > 0,
-        y + np.log1p(-np.exp(-y)),
-        np.log(np.clip(np.expm1(y), tiny, None)),
-    )
-    np.testing.assert_allclose(log_expm1_stable(y), expected, rtol=1e-12, atol=0)
+    result = log_expm1_stable(y)
+
+    expected = np.log(np.expm1(y))
+    pos = y > 0
+    expected[pos] = y[pos] + np.log1p(-np.exp(-y[pos]))
+
+    np.testing.assert_allclose(result[pos], expected[pos], rtol=1e-12, atol=0)
+    np.testing.assert_array_equal(result[~pos], expected[~pos])
+
+
+def test_log_expm1_stable_negative_inputs_propagate_nan():
+    res = log_expm1_stable(np.array([-1.0, -2.5]))
+    assert np.isnan(res[0])
+    assert np.isnan(res[1])
 
 
 def test_log_expm1_stable_large_monotonic():

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -214,6 +214,12 @@ def test_compute_radon_activity_skips_nan_rate():
     assert s == pytest.approx(0.6)
 
 
+def test_compute_radon_activity_infinite_uncertainties_degrade_gracefully():
+    a, s = compute_radon_activity(5.0, math.inf, 1.0, 7.0, math.inf, 1.0)
+    assert a == pytest.approx(6.0)
+    assert math.isnan(s)
+
+
 def test_compute_total_radon_negative_sample_volume():
     with pytest.raises(ValueError):
         compute_total_radon(5.0, 0.5, 10.0, -1.0)


### PR DESCRIPTION
## Summary
- allow log_expm1_stable to propagate NaN/-inf for non-positive inputs instead of clamping to tiny positives
- treat non-finite radon uncertainties as invalid weights and guard against zero weight sums when averaging
- extend unit tests to cover the corrected log_expm1_stable behaviour and infinite radon uncertainties

## Testing
- pytest tests/test_math_utils.py tests/test_radon_activity.py

------
https://chatgpt.com/codex/tasks/task_e_68d37c6d0354832b9913b77c286f5f98