### PR TITLE
Fix fractional systematic shifts to use central value

### DIFF
--- a/systematics.py
+++ b/systematics.py
@@ -114,15 +114,16 @@ def scan_systematics(
     for full_key, val in sigma_dict.items():
         if full_key.endswith("_frac"):
             key = full_key[:-5]
-            if key not in priors:
-                raise RuntimeError(f"No prior entry for '{key}'")
-            delta = val * priors[key][0]
+            shift_mode = "fractional"
         elif full_key.endswith("_keV"):
             key = full_key[:-4]
-            delta = val * 1e-3  # convert keV to MeV
+            shift_mode = "kev"
         else:
             key = full_key
-            delta = val
+            shift_mode = "absolute"
+
+        if key not in priors:
+            raise RuntimeError(f"No prior entry for '{key}'")
 
         if is_dict:
             if key not in central:
@@ -131,8 +132,12 @@ def scan_systematics(
         else:
             v0 = central
 
-        if key not in priors:
-            raise RuntimeError(f"No prior entry for '{key}'")
+        if shift_mode == "fractional":
+            delta = val * abs(v0)
+        elif shift_mode == "kev":
+            delta = val * 1e-3  # convert keV to MeV
+        else:
+            delta = val
 
         priors_mod = copy.deepcopy(base_priors)
         mu, sig = priors_mod[key]

--- a/tests/test_systematics.py
+++ b/tests/test_systematics.py
@@ -123,6 +123,19 @@ def test_scan_systematics_fractional_and_absolute():
     assert tot == pytest.approx(expected)
 
 
+def test_scan_systematics_fractional_uses_central_value():
+    priors = {"background": (0.0, 1.0)}
+
+    def fit_func(p):
+        mu = p["background"][0]
+        return {"background": 10.0 + mu}
+
+    shifts = {"background_frac": 0.1}
+    deltas, tot = scan_systematics(fit_func, priors, shifts)
+    assert deltas["background"] == pytest.approx(1.0)
+    assert tot == pytest.approx(1.0)
+
+
 def test_analyze_systematics_skip_unknown(tmp_path, monkeypatch):
     cfg = {
         "pipeline": {"log_level": "INFO"},


### PR DESCRIPTION
## Summary
- scale fractional systematic shifts using the magnitude of the fitted central value
- add a regression test to ensure fractional shifts affect parameters with zero-mean priors

## Testing
- pytest tests/test_systematics.py

------
https://chatgpt.com/codex/tasks/task_e_68d486474a7c832b950ccf8df4dc0d7b