### PR TITLE
Fix radon rate-mode result key

### DIFF
--- a/radon_joint_estimator.py
+++ b/radon_joint_estimator.py
@@ -74,7 +74,7 @@ def estimate_radon_activity(
         if mode == "radon":
             return {
                 "isotope_mode": "radon",
-                "activity_Bq": A,
+                "Rn_activity_Bq": A,
                 "stat_unc_Bq": sigma,
                 "components": comp,
             }


### PR DESCRIPTION
## Summary
- make the rate-mode radon return schema use `Rn_activity_Bq` to match the counts path

## Testing
- pytest tests/test_radon_joint_estimator.py

------
https://chatgpt.com/codex/tasks/task_e_68d4865b2c78832b98450c037672ded0