### PR TITLE
Allow single-isotope counts without extra metadata

### DIFF
--- a/radon_joint_estimator.py
+++ b/radon_joint_estimator.py
@@ -100,11 +100,21 @@ def estimate_radon_activity(
             "components": comp,
         }
 
-    if epsilon218 is None or epsilon214 is None or f218 is None or f214 is None:
+    has218 = N218 is not None
+    has214 = N214 is not None
+
+    if has218 and (epsilon218 is None or f218 is None):
         raise ValueError("counts mode requires efficiencies and fractions")
-    if epsilon218 <= 0 or epsilon214 <= 0:
+    if has214 and (epsilon214 is None or f214 is None):
+        raise ValueError("counts mode requires efficiencies and fractions")
+
+    if has218 and epsilon218 <= 0:
         raise ValueError("efficiencies must be positive")
-    if f218 <= 0 or f214 <= 0:
+    if has214 and epsilon214 <= 0:
+        raise ValueError("efficiencies must be positive")
+    if has218 and f218 <= 0:
+        raise ValueError("fractions must be positive")
+    if has214 and f214 <= 0:
         raise ValueError("fractions must be positive")
 
     # Handle the special case when both counts are zero.  This avoids
@@ -141,13 +151,15 @@ def estimate_radon_activity(
 
     def _estimate(
         counts: int | None,
-        eff: float,
-        frac: float,
+        eff: float | None,
+        frac: float | None,
         live_time: float | None,
         label: str,
     ):
         if counts is None:
             return None
+        if eff is None or frac is None:
+            raise ValueError("counts mode requires efficiencies and fractions")
         if counts < 0:
             raise ValueError(f"counts for {label} must be non-negative")
         if counts == 0:

--- a/tests/test_radon_joint_estimator.py
+++ b/tests/test_radon_joint_estimator.py
@@ -55,6 +55,34 @@ def test_counts_without_live_time_raises():
         )
 
 
+def test_single_isotope_po218_only_requires_matching_metadata():
+    result = estimate_radon_activity(
+        N218=42,
+        epsilon218=0.5,
+        f218=0.9,
+        live_time218_s=1800.0,
+        analysis_isotope="po218",
+    )
+
+    assert result["isotope_mode"] == "po218"
+    assert "from_po218" in result["components"]
+    assert "from_po214" not in result["components"]
+
+
+def test_single_isotope_po214_only_requires_matching_metadata():
+    result = estimate_radon_activity(
+        N214=13,
+        epsilon214=0.6,
+        f214=0.8,
+        live_time214_s=2400.0,
+        analysis_isotope="po214",
+    )
+
+    assert result["isotope_mode"] == "po214"
+    assert "from_po214" in result["components"]
+    assert "from_po218" not in result["components"]
+
+
 def test_single_isotope_po218_missing_counts_raises():
     with pytest.raises(ValueError, match="Po-218 counts unavailable"):
         estimate_radon_activity(


### PR DESCRIPTION
## Summary
- update the counts-mode validation to only demand efficiency and plating fraction metadata for isotopes that supply counts
- guard the helper against missing metadata when counts are present
- add regression tests covering single-isotope Po-214 and Po-218 analyses

## Testing
- pytest tests/test_radon_joint_estimator.py

------
https://chatgpt.com/codex/tasks/task_e_68d486655848832bb3edd7ec34de78de