### PR TITLE
Fix radon concentration calculation

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -221,16 +221,16 @@ def compute_total_radon(
     Returns
     -------
     concentration : float
-        Radon concentration expressed per unit of ``monitor_volume`` (Bq/L when
-        the volumes are given in liters).
+        Radon concentration expressed per unit of the combined gas volume
+        ``(monitor_volume + sample_volume)`` (Bq/L when the volumes are given in
+        liters).
     sigma_conc : float
         Uncertainty on the concentration.
     total_bq : float
         Total radon present in the sample. When ``sample_volume`` is positive the
         fitted activity is scaled by the combined counting volume
         ``(monitor_volume + sample_volume)`` to account for radon present in both
-        the counting chamber and the sampled air. The concentration is not scaled
-        by this factor so that it reflects the physical Bq per liter of the gas.
+        the counting chamber and the sampled air.
     sigma_total : float
         Uncertainty on ``total_bq``.
 
@@ -241,7 +241,7 @@ def compute_total_radon(
     Examples
     --------
     >>> compute_total_radon(5.0, 0.5, 10.0, 20.0)
-    (0.5, 0.05, 15.0, 1.5)
+    (0.16666666666666666, 0.016666666666666666, 15.0, 1.5)
     """
     if monitor_volume <= 0:
         raise ValueError("monitor_volume must be positive")
@@ -262,8 +262,9 @@ def compute_total_radon(
         activity_bq, err_bq = clamp_non_negative(activity_bq, err_bq)
     if math.isnan(activity_bq):
         raise ValueError("activity_bq must not be NaN")
-    conc = activity_bq / monitor_volume
-    sigma_conc = err_bq / monitor_volume
+    total_volume = monitor_volume + sample_volume
+    conc = activity_bq / total_volume
+    sigma_conc = err_bq / total_volume
 
     scale = (monitor_volume + sample_volume) / monitor_volume
     total_bq = activity_bq * scale

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -156,8 +156,9 @@ def test_compute_radon_activity_equilibrium_check():
 def test_compute_total_radon():
     conc, dconc, tot, dtot = compute_total_radon(5.0, 0.5, 10.0, 20.0)
     scale = (10.0 + 20.0) / 10.0
-    assert conc == pytest.approx(5.0 / 10.0)
-    assert dconc == pytest.approx(0.5 / 10.0)
+    total_volume = 10.0 + 20.0
+    assert conc == pytest.approx(5.0 / total_volume)
+    assert dconc == pytest.approx(0.5 / total_volume)
     assert tot == pytest.approx(5.0 * scale)
     assert dtot == pytest.approx(0.5 * scale)
 
@@ -165,7 +166,8 @@ def test_compute_total_radon():
 def test_compute_total_radon_zero_uncertainty():
     conc, dconc, tot, dtot = compute_total_radon(5.0, 0.0, 10.0, 10.0)
     scale = (10.0 + 10.0) / 10.0
-    assert conc == pytest.approx(5.0 / 10.0)
+    total_volume = 10.0 + 10.0
+    assert conc == pytest.approx(5.0 / total_volume)
     assert dconc == pytest.approx(0.0)
     assert tot == pytest.approx(5.0 * scale)
     assert dtot == pytest.approx(0.0)
@@ -173,8 +175,9 @@ def test_compute_total_radon_zero_uncertainty():
 
 def test_compute_total_radon_background_run():
     conc, dconc, tot, dtot = compute_total_radon(5.0, 0.5, 10.0, 0.0)
-    assert conc == pytest.approx(5.0 / 10.0)
-    assert dconc == pytest.approx(0.5 / 10.0)
+    total_volume = 10.0 + 0.0
+    assert conc == pytest.approx(5.0 / total_volume)
+    assert dconc == pytest.approx(0.5 / total_volume)
     assert tot == pytest.approx(5.0)
     assert dtot == pytest.approx(0.5)
 
@@ -248,8 +251,9 @@ def test_compute_total_radon_negative_activity_allowed(caplog):
         -1.0, 0.5, 10.0, 1.0, allow_negative_activity=True
     )
     scale = (10.0 + 1.0) / 10.0
-    assert conc == pytest.approx(-1.0 / 10.0)
-    assert dconc == pytest.approx(0.5 / 10.0)
+    total_volume = 10.0 + 1.0
+    assert conc == pytest.approx(-1.0 / total_volume)
+    assert dconc == pytest.approx(0.5 / total_volume)
     assert tot == pytest.approx(-1.0 * scale)
     assert dtot == pytest.approx(0.5 * scale)
 


### PR DESCRIPTION
## Summary
- compute radon concentration using the combined chamber and sample volume
- update the compute_total_radon documentation and example to match the corrected formula
- adjust unit tests to validate the new concentration calculation

## Testing
- pytest tests/test_radon_activity.py

------
https://chatgpt.com/codex/tasks/task_e_68d4866f794c832b83403bc066aa32c6