### PR TITLE
Correct total radon concentration scaling

### DIFF
--- a/radon_activity.py
+++ b/radon_activity.py
@@ -241,7 +241,7 @@ def compute_total_radon(
     Examples
     --------
     >>> compute_total_radon(5.0, 0.5, 10.0, 20.0)
-    (0.16666666666666666, 0.016666666666666666, 15.0, 1.5)
+    (0.5, 0.05, 15.0, 1.5)
     """
     if monitor_volume <= 0:
         raise ValueError("monitor_volume must be positive")
@@ -263,12 +263,11 @@ def compute_total_radon(
     if math.isnan(activity_bq):
         raise ValueError("activity_bq must not be NaN")
     total_volume = monitor_volume + sample_volume
-    conc = activity_bq / total_volume
-    sigma_conc = err_bq / total_volume
-
-    scale = (monitor_volume + sample_volume) / monitor_volume
+    scale = total_volume / monitor_volume
     total_bq = activity_bq * scale
     sigma_total = err_bq * scale
+    conc = total_bq / total_volume
+    sigma_conc = sigma_total / total_volume
     return conc, sigma_conc, total_bq, sigma_total
 
 

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -154,30 +154,39 @@ def test_compute_radon_activity_equilibrium_check():
 
 
 def test_compute_total_radon():
-    conc, dconc, tot, dtot = compute_total_radon(5.0, 0.5, 10.0, 20.0)
-    scale = (10.0 + 20.0) / 10.0
-    total_volume = 10.0 + 20.0
-    assert conc == pytest.approx(5.0 / total_volume)
-    assert dconc == pytest.approx(0.5 / total_volume)
+    monitor_volume = 10.0
+    sample_volume = 20.0
+    conc, dconc, tot, dtot = compute_total_radon(5.0, 0.5, monitor_volume, sample_volume)
+    scale = (monitor_volume + sample_volume) / monitor_volume
+    total_volume = monitor_volume + sample_volume
+    assert conc == pytest.approx(5.0 / monitor_volume)
+    assert conc == pytest.approx(tot / total_volume)
+    assert dconc == pytest.approx(0.5 / monitor_volume)
     assert tot == pytest.approx(5.0 * scale)
     assert dtot == pytest.approx(0.5 * scale)
 
 
 def test_compute_total_radon_zero_uncertainty():
-    conc, dconc, tot, dtot = compute_total_radon(5.0, 0.0, 10.0, 10.0)
-    scale = (10.0 + 10.0) / 10.0
-    total_volume = 10.0 + 10.0
-    assert conc == pytest.approx(5.0 / total_volume)
+    monitor_volume = 10.0
+    sample_volume = 10.0
+    conc, dconc, tot, dtot = compute_total_radon(5.0, 0.0, monitor_volume, sample_volume)
+    scale = (monitor_volume + sample_volume) / monitor_volume
+    total_volume = monitor_volume + sample_volume
+    assert conc == pytest.approx(5.0 / monitor_volume)
+    assert conc == pytest.approx(tot / total_volume)
     assert dconc == pytest.approx(0.0)
     assert tot == pytest.approx(5.0 * scale)
     assert dtot == pytest.approx(0.0)
 
 
 def test_compute_total_radon_background_run():
-    conc, dconc, tot, dtot = compute_total_radon(5.0, 0.5, 10.0, 0.0)
-    total_volume = 10.0 + 0.0
-    assert conc == pytest.approx(5.0 / total_volume)
-    assert dconc == pytest.approx(0.5 / total_volume)
+    monitor_volume = 10.0
+    sample_volume = 0.0
+    conc, dconc, tot, dtot = compute_total_radon(5.0, 0.5, monitor_volume, sample_volume)
+    total_volume = monitor_volume + sample_volume
+    assert conc == pytest.approx(5.0 / monitor_volume)
+    assert conc == pytest.approx(tot / total_volume)
+    assert dconc == pytest.approx(0.5 / monitor_volume)
     assert tot == pytest.approx(5.0)
     assert dtot == pytest.approx(0.5)
 
@@ -252,8 +261,9 @@ def test_compute_total_radon_negative_activity_allowed(caplog):
     )
     scale = (10.0 + 1.0) / 10.0
     total_volume = 10.0 + 1.0
-    assert conc == pytest.approx(-1.0 / total_volume)
-    assert dconc == pytest.approx(0.5 / total_volume)
+    assert conc == pytest.approx(-1.0 / 10.0)
+    assert conc == pytest.approx(tot / total_volume)
+    assert dconc == pytest.approx(0.5 / 10.0)
     assert tot == pytest.approx(-1.0 * scale)
     assert dtot == pytest.approx(0.5 * scale)
 


### PR DESCRIPTION
## Summary
- scale the fitted chamber activity to the combined counting volume before deriving concentration
- update the compute_total_radon example and unit tests to match the corrected physics

## Testing
- pytest tests/test_radon_activity.py -k compute_total_radon

------
https://chatgpt.com/codex/tasks/task_e_68d4920ba420832bae1468951f4d2554