### PR TITLE
Ensure rate-mode progeny estimates expose radon key

### DIFF
--- a/radon_joint_estimator.py
+++ b/radon_joint_estimator.py
@@ -85,6 +85,7 @@ def estimate_radon_activity(
                 )
             return {
                 "isotope_mode": "po214",
+                "Rn_activity_Bq": rate214,
                 "activity_Bq": rate214,
                 "stat_unc_Bq": err214,
                 "components": comp,
@@ -95,6 +96,7 @@ def estimate_radon_activity(
             )
         return {
             "isotope_mode": "po218",
+            "Rn_activity_Bq": rate218,
             "activity_Bq": rate218,
             "stat_unc_Bq": err218,
             "components": comp,

--- a/tests/test_radon_joint_estimator.py
+++ b/tests/test_radon_joint_estimator.py
@@ -127,6 +127,28 @@ def test_rate_shortcut_requires_requested_isotope_data():
         )
 
 
+def test_rate_shortcut_single_isotope_preserves_rn_key():
+    res_po218 = estimate_radon_activity(
+        rate218=0.42,
+        err218=0.07,
+        analysis_isotope="po218",
+    )
+
+    assert res_po218["isotope_mode"] == "po218"
+    assert res_po218["Rn_activity_Bq"] == pytest.approx(0.42)
+    assert res_po218["activity_Bq"] == pytest.approx(0.42)
+
+    res_po214 = estimate_radon_activity(
+        rate214=0.31,
+        err214=0.05,
+        analysis_isotope="po214",
+    )
+
+    assert res_po214["isotope_mode"] == "po214"
+    assert res_po214["Rn_activity_Bq"] == pytest.approx(0.31)
+    assert res_po214["activity_Bq"] == pytest.approx(0.31)
+
+
 def test_single_isotope_po218_zero_counts_returns_zero_with_inf_uncertainty():
     result = estimate_radon_activity(
         N218=0,


### PR DESCRIPTION
## Summary
- keep the radon activity key populated when returning Po-214/Po-218 rate shortcut results
- leave the original activity alias in place so downstream consumers continue to function
- add regression coverage confirming the shortcut API exposes the expected keys

## Testing
- pytest tests/test_radon_joint_estimator.py

------
https://chatgpt.com/codex/tasks/task_e_68d5ae9d9b68832bbc4237cd2473c2f4