### PR TITLE
Fix radon concentration scaling with sample volume

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -3001,8 +3001,8 @@ def main(argv=None):
             "unc_Bq": dA_radon,
         }
 
-    # Convert activity to a concentration per liter of monitor volume and the
-    # total amount of radon present in the sampled air (undiluted by the chamber volume).
+    # Convert activity to a concentration per liter of the combined gas volume and
+    # the total amount of radon present in the sampled air (undiluted by the chamber volume).
     try:
         conc, dconc, total_bq, dtotal_bq = compute_total_radon(
             A_radon,

--- a/radon_activity.py
+++ b/radon_activity.py
@@ -241,7 +241,7 @@ def compute_total_radon(
     Examples
     --------
     >>> compute_total_radon(5.0, 0.5, 10.0, 20.0)
-    (0.5, 0.05, 15.0, 1.5)
+    (0.16666666666666666, 0.016666666666666666, 15.0, 1.5)
     """
     if monitor_volume <= 0:
         raise ValueError("monitor_volume must be positive")
@@ -266,8 +266,8 @@ def compute_total_radon(
     scale = total_volume / monitor_volume
     total_bq = activity_bq * scale
     sigma_total = err_bq * scale
-    conc = total_bq / total_volume
-    sigma_conc = sigma_total / total_volume
+    conc = activity_bq / total_volume
+    sigma_conc = err_bq / total_volume
     return conc, sigma_conc, total_bq, sigma_total
 
 

--- a/tests/test_radon_activity.py
+++ b/tests/test_radon_activity.py
@@ -159,9 +159,8 @@ def test_compute_total_radon():
     conc, dconc, tot, dtot = compute_total_radon(5.0, 0.5, monitor_volume, sample_volume)
     scale = (monitor_volume + sample_volume) / monitor_volume
     total_volume = monitor_volume + sample_volume
-    assert conc == pytest.approx(5.0 / monitor_volume)
-    assert conc == pytest.approx(tot / total_volume)
-    assert dconc == pytest.approx(0.5 / monitor_volume)
+    assert conc == pytest.approx(5.0 / total_volume)
+    assert dconc == pytest.approx(0.5 / total_volume)
     assert tot == pytest.approx(5.0 * scale)
     assert dtot == pytest.approx(0.5 * scale)
 
@@ -172,8 +171,7 @@ def test_compute_total_radon_zero_uncertainty():
     conc, dconc, tot, dtot = compute_total_radon(5.0, 0.0, monitor_volume, sample_volume)
     scale = (monitor_volume + sample_volume) / monitor_volume
     total_volume = monitor_volume + sample_volume
-    assert conc == pytest.approx(5.0 / monitor_volume)
-    assert conc == pytest.approx(tot / total_volume)
+    assert conc == pytest.approx(5.0 / total_volume)
     assert dconc == pytest.approx(0.0)
     assert tot == pytest.approx(5.0 * scale)
     assert dtot == pytest.approx(0.0)
@@ -184,9 +182,8 @@ def test_compute_total_radon_background_run():
     sample_volume = 0.0
     conc, dconc, tot, dtot = compute_total_radon(5.0, 0.5, monitor_volume, sample_volume)
     total_volume = monitor_volume + sample_volume
-    assert conc == pytest.approx(5.0 / monitor_volume)
-    assert conc == pytest.approx(tot / total_volume)
-    assert dconc == pytest.approx(0.5 / monitor_volume)
+    assert conc == pytest.approx(5.0 / total_volume)
+    assert dconc == pytest.approx(0.5 / total_volume)
     assert tot == pytest.approx(5.0)
     assert dtot == pytest.approx(0.5)
 
@@ -261,9 +258,8 @@ def test_compute_total_radon_negative_activity_allowed(caplog):
     )
     scale = (10.0 + 1.0) / 10.0
     total_volume = 10.0 + 1.0
-    assert conc == pytest.approx(-1.0 / 10.0)
-    assert conc == pytest.approx(tot / total_volume)
-    assert dconc == pytest.approx(0.5 / 10.0)
+    assert conc == pytest.approx(-1.0 / total_volume)
+    assert dconc == pytest.approx(0.5 / total_volume)
     assert tot == pytest.approx(-1.0 * scale)
     assert dtot == pytest.approx(0.5 * scale)
 


### PR DESCRIPTION
## Summary
- compute radon concentration using the combined monitor and sample volume so additional air lowers the reported value
- update the compute_total_radon example, analysis comment, and tests to reflect the revised concentration definition

## Testing
- pytest tests/test_radon_activity.py

------
https://chatgpt.com/codex/tasks/task_e_68e49ab6b584832bbe01bab03637f66f