### PR TITLE
Handle zero uncertainty measurements in BLUE combination

### DIFF
--- a/efficiency.py
+++ b/efficiency.py
@@ -129,6 +129,16 @@ def blue_combine(
     if vals.size == 0:
         raise ValueError("no values provided")
 
+    zero_mask = errs == 0
+    if np.any(zero_mask):
+        exact_values = vals[zero_mask]
+        reference_value = exact_values[0]
+        if not np.allclose(exact_values, reference_value):
+            raise ValueError("exact measurements with zero uncertainty disagree")
+        weights = np.zeros(vals.size, dtype=float)
+        weights[zero_mask] = 1.0 / zero_mask.sum()
+        return float(reference_value), 0.0, weights
+
     if corr is None:
         cov = np.diag(errs**2)
     else:

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -106,3 +106,19 @@ def test_blue_combine_negative_uncertainty_corr():
     corr = np.array([[1.0, 0.5], [0.5, 1.0]])
     with pytest.raises(ValueError, match="errors cannot be negative"):
         blue_combine(vals, errs, corr)
+
+
+def test_blue_combine_zero_uncertainty_exact_value_dominates():
+    vals = np.array([0.4, 0.5, 0.6])
+    errs = np.array([0.1, 0.0, 0.2])
+    combined, sigma, weights = blue_combine(vals, errs)
+    assert combined == pytest.approx(0.5)
+    assert sigma == 0.0
+    assert np.allclose(weights, [0.0, 1.0, 0.0])
+
+
+def test_blue_combine_zero_uncertainty_conflict():
+    vals = np.array([0.4, 0.5])
+    errs = np.array([0.0, 0.0])
+    with pytest.raises(ValueError, match="exact measurements with zero uncertainty disagree"):
+        blue_combine(vals, errs)


### PR DESCRIPTION
## Summary
- treat zero-uncertainty measurements as exact values when performing a BLUE combination
- raise a clear error when exact measurements disagree instead of triggering a linear algebra failure
- add regression coverage for zero-uncertainty inputs

## Testing
- pytest tests/test_efficiency.py::test_blue_combine_zero_uncertainty_exact_value_dominates tests/test_efficiency.py::test_blue_combine_zero_uncertainty_conflict

------
https://chatgpt.com/codex/tasks/task_e_68e49ad33a54832bad7c3b4c76fa4417