### PR TITLE
Handle missing baseline config and stabilize hierarchical priors

### DIFF
--- a/assertions_and_ci.py
+++ b/assertions_and_ci.py
@@ -41,4 +41,7 @@ def run_assertions(summary: Mapping[str, Any], constants: Mapping[str, Any], con
 
     po214 = _const_field(constants["Po214"], "half_life_s")
     assert po214 < 1e3
-    assert config["baseline"]["sample_volume_l"] >= 0
+
+    baseline_cfg = config.get("baseline") if isinstance(config, Mapping) else None
+    if baseline_cfg:
+        assert float(baseline_cfg.get("sample_volume_l", 0.0)) >= 0

--- a/hierarchical.py
+++ b/hierarchical.py
@@ -1,6 +1,33 @@
 import numpy as np
 import pymc as pm
 
+
+def _mean_prior_sigma(obs, obs_err, *, min_scale=1e-3):
+    obs = np.asarray(obs, dtype=float)
+    obs_err = np.asarray(obs_err, dtype=float)
+    spread = float(np.std(obs)) if obs.size else 0.0
+    if not np.isfinite(spread):
+        spread = 0.0
+    err_mean = float(np.mean(obs_err)) if obs_err.size else 0.0
+    err_max = float(np.max(obs_err)) if obs_err.size else 0.0
+    err_scale = max(err_mean, err_max)
+    loc_scale = float(np.abs(np.mean(obs)) * 0.1) if obs.size else 0.0
+    sigma = max(10.0 * spread, 3.0 * err_scale, loc_scale, min_scale)
+    return sigma
+
+
+def _scatter_prior_scale(obs, obs_err, *, min_scale=1e-3):
+    obs = np.asarray(obs, dtype=float)
+    obs_err = np.asarray(obs_err, dtype=float)
+    spread = float(np.std(obs)) if obs.size else 0.0
+    if not np.isfinite(spread):
+        spread = 0.0
+    err_mean = float(np.mean(obs_err)) if obs_err.size else 0.0
+    err_max = float(np.max(obs_err)) if obs_err.size else 0.0
+    err_scale = max(err_mean, err_max)
+    loc_scale = float(np.abs(np.mean(obs)) * 0.1) if obs.size else 0.0
+    return max(spread, err_scale, loc_scale, min_scale)
+
 __all__ = ["fit_hierarchical_runs"]
 
 
@@ -50,8 +77,10 @@ def fit_hierarchical_runs(run_results, draws=2000, tune=1000, chains=2, random_s
             and np.isfinite(slope)
             and np.isfinite(dslope)
         ):
-            clean["slope_MeV_per_ch"] = float(slope)
-            clean["dslope"] = float(dslope)
+            dslope = float(dslope)
+            if dslope > 0:
+                clean["slope_MeV_per_ch"] = float(slope)
+                clean["dslope"] = dslope
 
         intercept = entry.get("intercept")
         dintercept = entry.get("dintercept")
@@ -61,8 +90,10 @@ def fit_hierarchical_runs(run_results, draws=2000, tune=1000, chains=2, random_s
             and np.isfinite(intercept)
             and np.isfinite(dintercept)
         ):
-            clean["intercept"] = float(intercept)
-            clean["dintercept"] = float(dintercept)
+            dintercept = float(dintercept)
+            if dintercept > 0:
+                clean["intercept"] = float(intercept)
+                clean["dintercept"] = dintercept
 
         sanitized.append(clean)
 
@@ -76,31 +107,47 @@ def fit_hierarchical_runs(run_results, draws=2000, tune=1000, chains=2, random_s
     use_slope = all("slope_MeV_per_ch" in r and "dslope" in r for r in sanitized)
     if use_slope:
         slope_obs = np.array([r["slope_MeV_per_ch"] for r in sanitized], dtype=float)
-        slope_err = np.array([max(r["dslope"], 1e-6) for r in sanitized], dtype=float)
+        slope_err = np.clip(
+            np.array([r["dslope"] for r in sanitized], dtype=float), 1e-6, None
+        )
 
     use_intercept = all("intercept" in r and "dintercept" in r for r in sanitized)
     if use_intercept:
         int_obs = np.array([r["intercept"] for r in sanitized], dtype=float)
-        int_err = np.array([max(r["dintercept"], 1e-6) for r in sanitized], dtype=float)
+        int_err = np.clip(
+            np.array([r["dintercept"] for r in sanitized], dtype=float), 1e-6, None
+        )
 
     with pm.Model():
         # Global mean and between-run scatter for half-life
-        mu_hl = pm.Normal("mu_hl", mu=hl_obs.mean(), sigma=10 * hl_obs.std() + 1e-6)
-        hl_scale = max(hl_obs.std(), hl_obs.mean() * 0.1, 1e-3)
+        mu_hl = pm.Normal(
+            "mu_hl",
+            mu=hl_obs.mean(),
+            sigma=_mean_prior_sigma(hl_obs, hl_err, min_scale=1e-3),
+        )
+        hl_scale = _scatter_prior_scale(hl_obs, hl_err, min_scale=1e-3)
         sigma_hl = pm.HalfNormal("sigma_hl", sigma=hl_scale)
         hl = pm.Normal("hl", mu=mu_hl, sigma=sigma_hl, shape=n)
         pm.Normal("hl_obs", mu=hl, sigma=hl_err, observed=hl_obs)
 
         if use_slope:
-            mu_a = pm.Normal("mu_a", mu=slope_obs.mean(), sigma=10 * slope_obs.std() + 1e-6)
-            slope_scale = max(slope_obs.std(), slope_obs.mean() * 0.1, 1e-3)
+            mu_a = pm.Normal(
+                "mu_a",
+                mu=slope_obs.mean(),
+                sigma=_mean_prior_sigma(slope_obs, slope_err, min_scale=1e-3),
+            )
+            slope_scale = _scatter_prior_scale(slope_obs, slope_err, min_scale=1e-3)
             sigma_a = pm.HalfNormal("sigma_a", sigma=slope_scale)
             a = pm.Normal("a", mu=mu_a, sigma=sigma_a, shape=n)
             pm.Normal("a_obs", mu=a, sigma=slope_err, observed=slope_obs)
 
         if use_intercept:
-            mu_c = pm.Normal("mu_c", mu=int_obs.mean(), sigma=10 * int_obs.std() + 1e-6)
-            int_scale = max(int_obs.std(), int_obs.mean() * 0.1, 1e-3)
+            mu_c = pm.Normal(
+                "mu_c",
+                mu=int_obs.mean(),
+                sigma=_mean_prior_sigma(int_obs, int_err, min_scale=1e-3),
+            )
+            int_scale = _scatter_prior_scale(int_obs, int_err, min_scale=1e-3)
             sigma_c = pm.HalfNormal("sigma_c", sigma=int_scale)
             c = pm.Normal("c", mu=mu_c, sigma=sigma_c, shape=n)
             pm.Normal("c_obs", mu=c, sigma=int_err, observed=int_obs)

--- a/tests/test_assertions_and_ci.py
+++ b/tests/test_assertions_and_ci.py
@@ -41,6 +41,13 @@ def test_run_assertions_zero_uncertainty_allowed():
     run_assertions(summary, constants, config)
 
 
+def test_run_assertions_without_baseline_block():
+    summary = {"radon": {"Rn_activity_Bq": 1.0, "stat_unc_Bq": 0.1}}
+    constants = {"Po214": {"half_life_s": 0.000164}}
+    config = {}
+    run_assertions(summary, constants, config)
+
+
 def test_run_assertions_accepts_dataclass_constants():
     summary = {"radon": {"Rn_activity_Bq": 1.0, "stat_unc_Bq": 0.1}}
     constants = load_nuclide_overrides({})

--- a/tests/test_hierarchical.py
+++ b/tests/test_hierarchical.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+import hierarchical
 from hierarchical import fit_hierarchical_runs
 
 
@@ -18,3 +19,30 @@ def test_fit_hierarchical_runs_basic():
     assert "mean" in res["half_life"]
     assert "slope_MeV_per_ch" in res
     assert "mean" in res["slope_MeV_per_ch"]
+
+
+def test_prior_width_uses_measurement_uncertainty_when_no_spread():
+    obs = [1.0, 1.0]
+    errs = [0.2, 0.2]
+    sigma = hierarchical._mean_prior_sigma(obs, errs, min_scale=1e-6)
+    assert sigma >= 0.6  # 3 * measurement uncertainty
+
+
+def test_invalid_calibration_uncertainties_are_ignored():
+    runs = [
+        {
+            "half_life": 1.0,
+            "dhalf_life": 0.1,
+            "slope_MeV_per_ch": 0.5,
+            "dslope": -0.1,
+            "intercept": 0.0,
+            "dintercept": -0.2,
+        },
+        {"half_life": 1.1, "dhalf_life": 0.1},
+    ]
+
+    res = fit_hierarchical_runs(runs, draws=50, tune=50, chains=1)
+
+    assert "half_life" in res
+    assert "slope_MeV_per_ch" not in res
+    assert "intercept" not in res


### PR DESCRIPTION
## Summary
- skip baseline-specific checks in `run_assertions` when the baseline block is absent
- derive hierarchical mean and scatter priors from measurement uncertainties and drop invalid calibration errors
- add regression tests covering optional baseline configs and hierarchical prior behaviour

## Testing
- pytest tests/test_assertions_and_ci.py tests/test_hierarchical.py

------
https://chatgpt.com/codex/tasks/task_e_68e49b01989c832b8ea31199d630d3d4