### PR TITLE
Add support for component-based timestamps and unit conversion in external radon data

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -197,10 +197,24 @@ radon_inference:
   external_rn:
     mode: constant  # allowed: constant, file
     constant_bq_per_m3: 120.0
-    file_path: mine_rn_timeseries.csv
-    time_column: timestamp
-    value_column: rn_bq_per_m3
-    tz: America/Toronto
+    # --- file-mode options (used when mode: file) ---
+    file_path: /path/to/rad_4996_pico40l.xls
+    # Option A: single timestamp column
+    # time_column: timestamp
+    # tz: America/Toronto            # applied when timestamps are naive
+    # Option B: component timestamp columns (e.g. pico40l .xls format)
+    time_columns:
+      year: Year
+      month: Month
+      day: Day
+      hour: Hour
+      minute: Minute
+      year_format: two_digit          # interpret years < 100 as 20xx
+    value_column: "rn_bq_per_m3"
+    units: bq_per_m3                  # allowed: bq_per_m3, pci_per_l
+    interpolation: nearest            # allowed: nearest, ffill
+    max_gap_seconds: 7200             # max gap tolerance in seconds
+    fallback_bq_per_m3: 80.0         # value when gap exceeds max_gap_seconds
   output:
     write_per_interval: true
     write_cumulative: true

--- a/config/validation.py
+++ b/config/validation.py
@@ -136,3 +136,26 @@ def validate_radon_inference(cfg: dict) -> None:
                 raise ValueError(
                     "radon_inference.external_rn.file_path must be provided when mode is 'file'"
                 )
+
+        units = external.get("units")
+        if units is not None:
+            supported_units = ("bq_per_m3", "pci_per_l")
+            if units not in supported_units:
+                raise ValueError(
+                    f"radon_inference.external_rn.units must be one of "
+                    f"{supported_units}, got {units!r}"
+                )
+
+        time_columns = external.get("time_columns")
+        if time_columns is not None:
+            if not isinstance(time_columns, Mapping):
+                raise ValueError(
+                    "radon_inference.external_rn.time_columns must be a mapping"
+                )
+            required_keys = ("year", "month", "day", "hour", "minute")
+            missing = [k for k in required_keys if not time_columns.get(k)]
+            if missing:
+                raise ValueError(
+                    "radon_inference.external_rn.time_columns is missing required keys: "
+                    + ", ".join(missing)
+                )

--- a/examples/config_radon.yaml
+++ b/examples/config_radon.yaml
@@ -97,6 +97,20 @@ radon_inference:
     Po218: 0.3
   transport_efficiency: 1.0
   retention_efficiency: 1.0
+  external_rn:
+    mode: file
+    file_path: /path/to/rad_4996_pico40l.xls
+    time_columns:
+      year: Year
+      month: Month
+      day: Day
+      hour: Hour
+      minute: Minute
+      year_format: two_digit
+    value_column: "My Radon Rate\nPci/l"
+    units: pci_per_l
+    interpolation: nearest
+    max_gap_seconds: 7200
 
 plotting:
   plot_save_formats:

--- a/io_utils.py
+++ b/io_utils.py
@@ -407,10 +407,30 @@ CONFIG_SCHEMA = {
                         },
                         "constant_bq_per_m3": {"type": "number"},
                         "fallback_bq_per_m3": {"type": "number"},
+                        "default_bq_per_m3": {"type": "number"},
                         "file_path": {"type": "string"},
                         "time_column": {"type": "string"},
+                        "time_columns": {
+                            "type": "object",
+                            "properties": {
+                                "year": {"type": "string"},
+                                "month": {"type": "string"},
+                                "day": {"type": "string"},
+                                "hour": {"type": "string"},
+                                "minute": {"type": "string"},
+                                "year_format": {
+                                    "type": "string",
+                                    "enum": ["full", "two_digit"],
+                                },
+                            },
+                        },
                         "value_column": {"type": "string"},
+                        "units": {
+                            "type": "string",
+                            "enum": ["bq_per_m3", "pci_per_l"],
+                        },
                         "tz": {"type": "string"},
+                        "timezone": {"type": "string"},
                         "interpolation": {
                             "type": "string",
                             "enum": ["nearest", "ffill"],

--- a/radon/external_rn_loader.py
+++ b/radon/external_rn_loader.py
@@ -173,7 +173,7 @@ def _load_file_series(cfg_external: dict, target_index: pd.DatetimeIndex) -> pd.
     df = _read_file(file_path_obj)
 
     value_column = cfg_external.get("value_column", "rn_bq_per_m3")
-    tz_name = cfg_external.get("timezone")
+    tz_name = cfg_external.get("timezone") or cfg_external.get("tz")
 
     if value_column not in df.columns:
         raise ValueError(


### PR DESCRIPTION
## Summary
This PR enhances the external radon data loader to support more flexible timestamp formats and radon concentration unit handling. It adds validation for new configuration options and updates example configurations to demonstrate the new capabilities.

## Key Changes

- **Component-based timestamps**: Added support for `time_columns` configuration that allows specifying radon data with separate year, month, day, hour, and minute columns (e.g., from Excel files). Includes `year_format` option to handle two-digit year interpretation.

- **Unit conversion support**: Added `units` configuration option to specify whether external radon data is in `bq_per_m3` (Becquerels per cubic meter) or `pci_per_l` (Picocuries per liter), enabling automatic conversion if needed.

- **Enhanced validation**: Extended `validate_radon_inference()` in `config/validation.py` to validate:
  - `units` must be one of the supported values
  - `time_columns` must be a mapping with all required keys (year, month, day, hour, minute)

- **Schema updates**: Updated JSON schema in `io_utils.py` to include:
  - `time_columns` object with component fields and `year_format` enum
  - `units` enum field
  - `default_bq_per_m3` and `timezone` fields for completeness

- **Configuration improvements**:
  - Updated main `config.yaml` with detailed comments explaining file-mode options and new parameters
  - Added comprehensive example in `examples/config_radon.yaml` demonstrating component-based timestamps with pci_per_l units

- **Backward compatibility**: Maintained support for legacy `time_column` and `tz` parameters; added fallback logic in `external_rn_loader.py` to check both `timezone` and `tz` keys.

## Implementation Details

The validation ensures that when `time_columns` is provided, all required temporal components are specified with non-empty values. The schema allows optional `year_format` specification to handle different year representations in source data.

https://claude.ai/code/session_01H2P2VdoD1fBT1FXj1LeRCn