### PR TITLE
[codex] Speed up template time-bin fitting

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -44,6 +44,7 @@ Example:
 import argparse
 import sys
 import logging
+import os
 import random
 import time
 import warnings
@@ -2097,11 +2098,12 @@ def _build_template_from_aggregate(
     flags: dict,
     cfg: dict,
 ) -> tuple[dict, dict]:
-    """Build frozen-shape priors and fix flags from aggregate fit results.
+    """Build per-bin template priors and controls from aggregate fit results.
 
-    Returns (template_priors, template_flags) where all shape/resolution
-    parameters are fixed at their aggregate best-fit values and only
-    amplitudes, background, and (optionally) centroids float.
+    Returns ``(template_priors, template_flags)`` where most detector-shape
+    parameters remain frozen at their aggregate best-fit values, while the
+    core peak widths and core EMG tail scales can optionally move under
+    Gaussian penalties around the aggregate solution.
     """
     spectral_cfg = cfg.get("spectral_fit", {})
     time_fit_cfg = cfg.get("time_fit", {})
@@ -2115,6 +2117,38 @@ def _build_template_from_aggregate(
     iso_list = sorted(
         k[3:] for k in aggregate_params if k.startswith("mu_") and f"S_{k[3:]}" in aggregate_params
     )
+
+    _existing_penalties = tpl_flags.get("penalty_priors", {})
+    penalty_priors = (
+        dict(_existing_penalties) if isinstance(_existing_penalties, Mapping) else {}
+    )
+
+    def _positive_cfg(name: str, default: float) -> float:
+        try:
+            value = float(time_fit_cfg.get(name, default))
+        except (TypeError, ValueError):
+            value = default
+        if not np.isfinite(value) or value <= 0.0:
+            return float(default)
+        return float(value)
+
+    float_core_widths = bool(time_fit_cfg.get("template_float_core_widths", True))
+    core_width_prior_frac = _positive_cfg("template_core_width_prior_frac", 0.15)
+    core_width_prior_min = _positive_cfg("template_core_width_prior_min_mev", 0.005)
+    float_tail_scales = bool(time_fit_cfg.get("template_float_tail_scales", True))
+    tail_prior_frac = _positive_cfg("template_tail_prior_frac", 0.25)
+    tail_prior_min = _positive_cfg("template_tail_prior_min_mev", 0.01)
+
+    def _core_shape_penalty_sigma(key: str, value: float, old_sig: float) -> float | None:
+        if key.startswith("sigma_") and key[6:] in iso_list:
+            if not float_core_widths:
+                return None
+            return max(abs(value) * core_width_prior_frac, abs(old_sig), core_width_prior_min)
+        if key == "tau_shared" or (key.startswith("tau_") and key[4:] in iso_list):
+            if not float_tail_scales:
+                return None
+            return max(abs(value) * tail_prior_frac, abs(old_sig), tail_prior_min)
+        return None
 
     # ── Shape params to freeze ────────────────────────────────────
     _shape_prefixes = (
@@ -2145,8 +2179,18 @@ def _build_template_from_aggregate(
                 val_f = float(val)
                 if np.isfinite(val_f) and key in tpl_priors:
                     old_mu, old_sig = tpl_priors[key]
-                    tpl_priors[key] = (val_f, old_sig * 0.01)
-                    tpl_flags[f"fix_{key}"] = True
+                    penalty_sigma = _core_shape_penalty_sigma(
+                        key,
+                        val_f,
+                        float(old_sig),
+                    )
+                    if penalty_sigma is not None:
+                        tpl_priors[key] = (val_f, penalty_sigma)
+                        tpl_flags.pop(f"fix_{key}", None)
+                        penalty_priors[key] = [val_f, penalty_sigma]
+                    else:
+                        tpl_priors[key] = (val_f, old_sig * 0.01)
+                        tpl_flags[f"fix_{key}"] = True
             except (TypeError, ValueError):
                 pass
 
@@ -2156,8 +2200,18 @@ def _build_template_from_aggregate(
                 val_f = float(val)
                 if np.isfinite(val_f) and key in tpl_priors:
                     old_mu, old_sig = tpl_priors[key]
-                    tpl_priors[key] = (val_f, old_sig * 0.01)
-                    tpl_flags[f"fix_{key}"] = True
+                    penalty_sigma = _core_shape_penalty_sigma(
+                        key,
+                        val_f,
+                        float(old_sig),
+                    )
+                    if penalty_sigma is not None:
+                        tpl_priors[key] = (val_f, penalty_sigma)
+                        tpl_flags.pop(f"fix_{key}", None)
+                        penalty_priors[key] = [val_f, penalty_sigma]
+                    else:
+                        tpl_priors[key] = (val_f, old_sig * 0.01)
+                        tpl_flags[f"fix_{key}"] = True
             except (TypeError, ValueError):
                 pass
 
@@ -2233,46 +2287,64 @@ def _build_template_from_aggregate(
     else:
         tpl_flags.pop("fix_b1", None)
 
+    if penalty_priors:
+        tpl_flags["penalty_priors"] = penalty_priors
+
     return tpl_priors, tpl_flags
+
+
+def _should_store_template_bin_plot(
+    params: Mapping[str, Any],
+    plot_cfg: Mapping[str, Any],
+) -> bool:
+    """Return True when a per-bin template spectrum should be retained."""
+
+    if not bool(plot_cfg.get("plot_template_bin_fits", plot_cfg.get("plot_all_time_fit_series", False))):
+        return False
+    if not bool(plot_cfg.get("plot_template_bin_fits_bad_only", False)):
+        return True
+    try:
+        chi2_ndf = float(params.get("chi2_ndf", float("nan")))
+    except (TypeError, ValueError):
+        chi2_ndf = float("nan")
+    try:
+        n_bound_hits = int(params.get("_n_bound_hits", params.get("n_bound_hits", 0)) or 0)
+    except (TypeError, ValueError):
+        n_bound_hits = 0
+    chi2_min = float(plot_cfg.get("plot_template_bin_fits_bad_chi2_ndf_min", 3.0))
+    return (
+        not bool(params.get("fit_valid", False))
+        or n_bound_hits > 0
+        or (np.isfinite(chi2_ndf) and chi2_ndf > chi2_min)
+    )
+
+
+def _resolve_template_n_workers(time_fit_cfg: Mapping[str, Any]) -> int:
+    """Return the worker count for per-bin template fits."""
+
+    raw_value = time_fit_cfg.get("template_n_workers", "auto")
+    if isinstance(raw_value, str) and raw_value.strip().lower() == "auto":
+        cpu_count = os.cpu_count() or 1
+        return max(1, min(8, cpu_count // 2 if cpu_count > 1 else 1))
+    try:
+        workers = int(raw_value)
+    except (TypeError, ValueError):
+        workers = 1
+    return max(1, workers)
 
 
 def _fit_time_bins(
     df_spectrum: "pd.DataFrame",
     aggregate_result: "FitResult",
-    priors: dict,
-    flags: dict,
     cfg: dict,
-    cal_coeffs: tuple,
-    dnl_factors: np.ndarray | None = None,
-    fit_energy_range: tuple | None = None,
-    n_workers: int = 1,
+    spec_plot_data: Mapping[str, Any] | None = None,
 ) -> dict:
-    """Fit each time bin with shape params frozen from the aggregate fit.
+    """Fit each time bin using the aggregate spectral template.
 
-    Parameters
-    ----------
-    df_spectrum : DataFrame
-        Must have columns: ``energy_MeV``, ``adc``, ``timestamp``.
-    aggregate_result : FitResult
-        Aggregate spectral fit result.
-    priors, flags : dict
-        Original aggregate priors and flags.
-    cfg : dict
-        Full config.
-    cal_coeffs : tuple
-        (slope, intercept, a2, a3) calibration coefficients.
-    dnl_factors : array or None
-        DNL correction factors at full ADC resolution.
-    fit_energy_range : tuple or None
-        (E_lo, E_hi) in MeV for the fit window.
-    n_workers : int
-        Number of parallel workers.
-
-    Returns
-    -------
-    dict
-        ``isotope_series_fitted``: same format as ROI-based isotope_series_data
-        ``per_bin_diagnostics``: per-bin chi2/ndf, fit_valid, centroid values
+    The fast template path derives its per-bin priors and controls from the
+    aggregate fit payload stored on ``aggregate_result``. Per-bin fits share
+    the aggregate template structure while allowing selected amplitudes and
+    shape terms to move according to the configured template settings.
     """
     from fitting import fit_spectrum, FitResult as _FR
 
@@ -2287,13 +2359,25 @@ def _fit_time_bins(
     min_counts = int(time_fit_cfg.get("template_min_counts", 30))
     # Energy rebin factor for per-bin histograms
     rebin_factor = int(time_fit_cfg.get("template_rebin", 20))
+    n_workers = _resolve_template_n_workers(time_fit_cfg)
+    skip_covariance = bool(time_fit_cfg.get("template_skip_covariance", True))
 
     agg_params = aggregate_result.params
-    a, c, a2, a3 = cal_coeffs
+    seed_priors = agg_params.get("_template_priors", {})
+    seed_flags = agg_params.get("_template_flags", {})
+    if not isinstance(seed_priors, Mapping) or not isinstance(seed_flags, Mapping):
+        logger.warning(
+            "Template fitting skipped: aggregate fit payload is missing "
+            "template priors/flags"
+        )
+        return {"isotope_series_fitted": {}, "per_bin_diagnostics": []}
 
     # Build template priors/flags
     tpl_priors, tpl_flags = _build_template_from_aggregate(
-        agg_params, priors, flags, cfg,
+        agg_params,
+        dict(seed_priors),
+        dict(seed_flags),
+        cfg,
     )
 
     # ── Discover isotopes and determine which to fix vs float ─────
@@ -2303,11 +2387,17 @@ def _fit_time_bins(
     # Fix weak/extra peaks completely (not enough counts per bin)
     extra_peaks_cfg = spectral_cfg.get("extra_peaks", {})
     _extra_names = set(extra_peaks_cfg.keys()) if isinstance(extra_peaks_cfg, dict) else set()
-    _weak_isos = {"Po216", "Bi212", "Po210"} | _extra_names
+    _fixed_isotopes_cfg = time_fit_cfg.get("template_fixed_isotopes")
+    if isinstance(_fixed_isotopes_cfg, Sequence) and not isinstance(_fixed_isotopes_cfg, (str, bytes)):
+        _fixed_isotopes = {str(name) for name in _fixed_isotopes_cfg}
+    else:
+        _fixed_isotopes = set()
     fix_weak = time_fit_cfg.get("fix_weak_isotopes", True)
-    if fix_weak:
+    if not _fixed_isotopes and fix_weak:
+        _fixed_isotopes = {"Po216", "Bi212"} | _extra_names
+    if _fixed_isotopes:
         for iso in iso_list:
-            if iso in _weak_isos:
+            if iso in _fixed_isotopes:
                 s_key = f"S_{iso}"
                 s_val = agg_params.get(s_key)
                 if s_val is not None and s_key in tpl_priors:
@@ -2338,13 +2428,12 @@ def _fit_time_bins(
         return {"isotope_series_fitted": {}, "per_bin_diagnostics": []}
 
     # ── Energy bin edges (shared across all time bins) ────────────
-    if fit_energy_range:
-        e_lo, e_hi = fit_energy_range
-    else:
-        e_lo = float(np.nanmin(energies)) - 0.1
-        e_hi = float(np.nanmax(energies)) + 0.1
+    e_lo = float(np.nanmin(energies)) - 0.1
+    e_hi = float(np.nanmax(energies)) + 0.1
     # Create rebinned energy edges
     agg_bin_edges = agg_params.get("_plot_bin_edges")
+    if agg_bin_edges is None and isinstance(spec_plot_data, Mapping):
+        agg_bin_edges = spec_plot_data.get("bin_edges")
     if agg_bin_edges is not None:
         agg_bin_edges = np.asarray(agg_bin_edges, dtype=float)
         # Rebin by merging adjacent bins
@@ -2379,10 +2468,12 @@ def _fit_time_bins(
 
     logger.info(
         "Template fitting: %d time bins × %d energy bins, "
-        "%d isotopes (%d fixed), bin_width=%.0f s",
+        "%d isotopes (%d fixed), bin_width=%.0f s, workers=%d, skip_covariance=%s",
         n_time_bins, n_energy_bins, len(iso_list),
         sum(1 for iso in iso_list if f"fix_S_{iso}" in tpl_flags),
         bin_width_s,
+        n_workers,
+        skip_covariance,
     )
 
     # Count free params
@@ -2390,7 +2481,28 @@ def _fit_time_bins(
         1 for k in tpl_priors
         if f"fix_{k}" not in tpl_flags or not tpl_flags.get(f"fix_{k}", False)
     )
-    logger.info("Template fit: %d free params per bin (of %d total)", n_free, len(tpl_priors))
+    _template_penalties = tpl_flags.get("penalty_priors", {})
+    if isinstance(_template_penalties, Mapping):
+        _core_shape_penalty_keys = sorted(
+            key
+            for key in _template_penalties
+            if key == "tau_shared"
+            or key.startswith("tau_")
+            or key.startswith("sigma_")
+        )
+    else:
+        _core_shape_penalty_keys = []
+    logger.info(
+        "Template fit: %d free params per bin (of %d total), %d soft constraints",
+        n_free,
+        len(tpl_priors),
+        len(_core_shape_penalty_keys),
+    )
+    if _core_shape_penalty_keys:
+        logger.info(
+            "Template fit soft-constrained shape params: %s",
+            ", ".join(_core_shape_penalty_keys),
+        )
 
     # ── Disable DNL for per-bin (already corrected in aggregate) ──
     import copy
@@ -2439,6 +2551,7 @@ def _fit_time_bins(
                 bin_edges=energy_edges,
                 pre_binned_hist=hist,
                 skip_minos=True,
+                skip_covariance=skip_covariance,
             )
         except Exception as exc:
             logger.debug("Bin %d fit failed: %s", bin_idx, exc)
@@ -2451,10 +2564,31 @@ def _fit_time_bins(
         else:
             return None
 
-        if not params.get("fit_valid", True):
+        fit_valid = bool(params.get("fit_valid", False))
+        if not fit_valid:
             logger.debug("Bin %d fit invalid", bin_idx)
-            # Still return ROI fallback
-            return None
+
+        raw_bound_hits = params.get("_bound_hits", {})
+        if isinstance(raw_bound_hits, Mapping):
+            bound_hits = {
+                str(name): dict(meta)
+                for name, meta in raw_bound_hits.items()
+                if isinstance(meta, Mapping)
+            }
+        else:
+            bound_hits = {}
+        raw_bound_hit_params = params.get("_bound_hit_params", ())
+        if isinstance(raw_bound_hit_params, (str, bytes)):
+            bound_hit_params = [str(raw_bound_hit_params)]
+        elif isinstance(raw_bound_hit_params, Sequence):
+            bound_hit_params = [str(name) for name in raw_bound_hit_params]
+        else:
+            bound_hit_params = sorted(bound_hits)
+        try:
+            n_bound_hits = int(params.get("_n_bound_hits", len(bound_hit_params)))
+        except (TypeError, ValueError):
+            n_bound_hits = len(bound_hit_params)
+        n_bound_hits = max(int(n_bound_hits), len(bound_hit_params), len(bound_hits))
 
         # Extract per-isotope fitted counts + uncertainties
         bin_result = {
@@ -2462,7 +2596,10 @@ def _fit_time_bins(
             "dt": dt,
             "n_events": n_events,
             "chi2_ndf": params.get("chi2_ndf", float("nan")),
-            "fit_valid": params.get("fit_valid", False),
+            "fit_valid": fit_valid,
+            "n_bound_hits": n_bound_hits,
+            "bound_hit_params": bound_hit_params,
+            "bound_hits": bound_hits,
             "counts": {},
             "counts_unc": {},
             "centroids": {},
@@ -2482,11 +2619,19 @@ def _fit_time_bins(
     # Execute fits (serial or parallel)
     bin_results = []
     if n_workers > 1:
-        from concurrent.futures import ThreadPoolExecutor
+        from concurrent.futures import ThreadPoolExecutor, as_completed
         with ThreadPoolExecutor(max_workers=n_workers) as pool:
-            futures = [pool.submit(_fit_one_bin, i) for i in range(n_time_bins)]
-            for fut in futures:
-                bin_results.append(fut.result())
+            futures = {pool.submit(_fit_one_bin, i): i for i in range(n_time_bins)}
+            bin_results = [None] * n_time_bins
+            for completed, fut in enumerate(as_completed(futures), start=1):
+                idx = futures[fut]
+                bin_results[idx] = fut.result()
+                if completed % 25 == 0 or completed == n_time_bins:
+                    logger.info(
+                        "Template fit progress: %d / %d bins",
+                        completed,
+                        n_time_bins,
+                    )
     else:
         for i in range(n_time_bins):
             bin_results.append(_fit_one_bin(i))
@@ -2513,8 +2658,13 @@ def _fit_time_bins(
             "chi2_ndf": r["chi2_ndf"],
             "fit_valid": r["fit_valid"],
             "n_events": r["n_events"],
+            "n_bound_hits": r.get("n_bound_hits", 0),
+            "bound_hit_params": r.get("bound_hit_params", []),
+            "bound_hits": r.get("bound_hits", {}),
             "centroids": r.get("centroids", {}),
         })
+        if not r.get("fit_valid", False):
+            continue
         for iso, counts in r["counts"].items():
             entries = iso_series.setdefault(iso, [])
             entry = {
@@ -2539,6 +2689,79 @@ def _fit_time_bins(
             if isinstance(v, (int, float)) and not k.startswith("_")
         },
     }
+
+
+def _summarize_template_fit_results(
+    template_fit_results: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Build the summary payload for template time-bin fitting."""
+
+    if template_fit_results is None:
+        return {"extraction_method": "template", "status": "failed_or_empty"}
+
+    meta: dict[str, Any] = {
+        "extraction_method": "template",
+        "status": "success",
+        "n_time_bins": template_fit_results.get("n_time_bins", 0),
+        "n_fitted": template_fit_results.get("n_fitted", 0),
+        "n_valid": template_fit_results.get("n_valid", 0),
+    }
+    diag = template_fit_results.get("per_bin_diagnostics", [])
+    if diag:
+        chi2s = [
+            d["chi2_ndf"]
+            for d in diag
+            if d.get("fit_valid") and np.isfinite(d.get("chi2_ndf", float("nan")))
+        ]
+        if chi2s:
+            meta["chi2_ndf_median"] = float(np.median(chi2s))
+            meta["chi2_ndf_mean"] = float(np.mean(chi2s))
+            meta["chi2_ndf_std"] = float(np.std(chi2s))
+            meta["chi2_gt_10"] = int(sum(val > 10.0 for val in chi2s))
+            meta["chi2_gt_100"] = int(sum(val > 100.0 for val in chi2s))
+        meta["bins_with_any_bound_hits"] = int(
+            sum(int(d.get("n_bound_hits", 0) or 0) > 0 for d in diag)
+        )
+        meta["total_bound_hits"] = int(
+            sum(int(d.get("n_bound_hits", 0) or 0) for d in diag)
+        )
+        meta["shift_hit_limit"] = int(
+            sum(bool(d.get("shift_hit_limit", False)) for d in diag)
+        )
+        bound_hit_param_counts: dict[str, int] = {}
+        non_centroid_bound_hit_param_counts: dict[str, int] = {}
+        bins_with_non_centroid_bound_hits = 0
+        for entry in diag:
+            params = entry.get("bound_hit_params", [])
+            if isinstance(params, (str, bytes)):
+                params = [params]
+            elif not isinstance(params, Sequence):
+                params = []
+            has_non_centroid = False
+            for param_name in (str(param) for param in params):
+                bound_hit_param_counts[param_name] = (
+                    bound_hit_param_counts.get(param_name, 0) + 1
+                )
+                if not param_name.startswith("mu_"):
+                    non_centroid_bound_hit_param_counts[param_name] = (
+                        non_centroid_bound_hit_param_counts.get(param_name, 0) + 1
+                    )
+                    has_non_centroid = True
+            if has_non_centroid:
+                bins_with_non_centroid_bound_hits += 1
+        if bound_hit_param_counts:
+            meta["bound_hit_param_counts"] = dict(
+                sorted(bound_hit_param_counts.items(), key=lambda item: (-item[1], item[0]))
+            )
+        if non_centroid_bound_hit_param_counts:
+            meta["non_centroid_bound_hit_param_counts"] = dict(
+                sorted(
+                    non_centroid_bound_hit_param_counts.items(),
+                    key=lambda item: (-item[1], item[0]),
+                )
+            )
+        meta["bins_with_non_centroid_bound_hits"] = int(bins_with_non_centroid_bound_hits)
+    return meta
 
 
 def _model_uncertainty(centers, widths, fit_obj, iso, cfg, normalise):
@@ -7980,6 +8203,8 @@ def main(argv=None):
                     _agg_result.params["_plot_bin_edges"] = np.asarray(
                         _agg_plot_edges, dtype=float
                     ).tolist()
+                _agg_result.params["_template_priors"] = dict(priors_spec)
+                _agg_result.params["_template_flags"] = dict(spec_flags)
 
                 logger.info(
                     "Running per-bin template fitting (extraction_method=template)"
@@ -7987,13 +8212,8 @@ def main(argv=None):
                 template_fit_results = _fit_time_bins(
                     df_spectrum,
                     _agg_result,
-                    priors_spec,
-                    spec_flags,
                     cfg,
-                    cal_coeffs=(a, c, a2, a3),
-                    dnl_factors=None,   # DNL already corrected in aggregate
-                    fit_energy_range=fit_energy_range,
-                    n_workers=1,
+                    spec_plot_data=spec_plot_data,
                 )
                 # Write result to diagnostic file
                 try:
@@ -8705,30 +8925,9 @@ def main(argv=None):
 
     # ── Persist template fitting metadata into summary ──────────────
     if _extraction_method == "template":
-        if template_fit_results is not None:
-            _tpl_meta = {
-                "extraction_method": "template",
-                "status": "success",
-                "n_time_bins": template_fit_results.get("n_time_bins", 0),
-                "n_fitted": template_fit_results.get("n_fitted", 0),
-                "n_valid": template_fit_results.get("n_valid", 0),
-            }
-            _tpl_diag = template_fit_results.get("per_bin_diagnostics", [])
-            if _tpl_diag:
-                _chi2s = [
-                    d["chi2_ndf"] for d in _tpl_diag
-                    if d.get("fit_valid") and np.isfinite(d.get("chi2_ndf", float("nan")))
-                ]
-                if _chi2s:
-                    _tpl_meta["chi2_ndf_median"] = float(np.median(_chi2s))
-                    _tpl_meta["chi2_ndf_mean"] = float(np.mean(_chi2s))
-                    _tpl_meta["chi2_ndf_std"] = float(np.std(_chi2s))
-        else:
-            _tpl_meta = {
-                "extraction_method": "template",
-                "status": "failed_or_empty",
-                "have_spectral": _have_spectral,
-            }
+        _tpl_meta = _summarize_template_fit_results(template_fit_results)
+        if template_fit_results is None:
+            _tpl_meta["have_spectral"] = _have_spectral
         summary["template_fitting"] = _tpl_meta
         summary_updated = True
         # Write immediately so template metadata persists even if later
@@ -8807,4 +9006,3 @@ def main(argv=None):
 
 if __name__ == "__main__":
     main()
-

--- a/config.yaml
+++ b/config.yaml
@@ -484,8 +484,17 @@ time_fit:
   # Template fitting options (only used when extraction_method: template)
   template_rebin: 20          # energy rebin factor vs aggregate (coarser for statistics)
   template_min_counts: 30     # minimum events per time bin to attempt fit
+  template_n_workers: auto    # auto -> min(8, half of logical CPUs)
+  template_skip_covariance: true  # use fast MIGRAD diagonal errors for per-bin template fits
   float_centroids: true       # allow peak centroids to float (tight prior)
-  fix_weak_isotopes: true     # fix Po216/Po210/Bi212/extra peaks in per-bin fits
+  template_float_core_widths: true   # let per-bin core sigma values move under aggregate-centered priors
+  template_core_width_prior_frac: 0.15
+  template_core_width_prior_min_mev: 0.005
+  template_float_tail_scales: true   # let per-bin core EMG tau values move under aggregate-centered priors
+  template_tail_prior_frac: 0.25
+  template_tail_prior_min_mev: 0.01
+  fix_weak_isotopes: true     # legacy shorthand: fix weak auxiliary isotopes (Po216/Bi212/extra peaks)
+  template_fixed_isotopes: [] # explicit per-bin fixed isotope list; overrides the legacy shorthand
 systematics:
   enable: false
   sigma_e_frac: 0.1

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -272,6 +272,17 @@ This section controls the time-series decay fits.
 - `background_guess`, `n0_guess_fraction`
 - `fix_background_b_first_pass`: enable the first fixed-background pass before the free-background refit
 - `background_b_fixed_value`: explicit value for the first pass; if omitted, the baseline Po-214 rate is used
+- `extraction_method`: `roi` for simple window counting or `template` for per-bin spectral template fits
+- `template_rebin`, `template_min_counts`: control template-bin histogramming and the minimum statistics needed to attempt a fit
+- `template_n_workers`: number of parallel workers for template time bins; `auto` uses a conservative half-core default capped at 8
+- `template_skip_covariance`: skip per-bin HESSE / numerical-Hessian recovery and use fast diagonal MIGRAD errors instead
+- `float_centroids`: allow per-bin centroid motion around the aggregate fit
+- `template_float_core_widths`: allow per-bin `sigma_*` values to move under Gaussian penalties around the aggregate fit
+- `template_core_width_prior_frac`, `template_core_width_prior_min_mev`: width of those per-bin `sigma_*` priors
+- `template_float_tail_scales`: allow per-bin `tau_*` or `tau_shared` values to move under Gaussian penalties around the aggregate fit
+- `template_tail_prior_frac`, `template_tail_prior_min_mev`: width of those per-bin `tau` priors
+- `fix_weak_isotopes`: legacy shorthand for fixing only very weak auxiliary isotopes in template mode
+- `template_fixed_isotopes`: explicit isotope names to fix in template mode; takes precedence over `fix_weak_isotopes`
 
 The pipeline also accepts the simplified standalone-fitter schema:
 
@@ -289,6 +300,7 @@ Important details:
 - Custom half-lives affect both the fit and the overlaid model curves.
 - For multi-day or multi-month monitoring, you can set `hl_po214` and `hl_po218` to the radon half-life so the fit tracks the slowly varying parent activity.
 - `settling_time_s` was removed from the configuration; use `--settle-s` instead.
+- In template mode, shelf/halo/background shape terms remain frozen to the aggregate spectral fit by default, while `sigma_*` and `tau_*` can be softly constrained instead of hard-fixed.
 
 Long-timescale example:
 

--- a/fitting.py
+++ b/fitting.py
@@ -198,6 +198,60 @@ def _sigmoid(x: np.ndarray | float) -> np.ndarray | float:
     return out
 
 
+def _physical_fit_param_value(name: str, raw_value: float) -> float:
+    """Convert an optimizer-space value into the reported physical value."""
+
+    raw = float(raw_value)
+    if name.startswith("S_"):
+        return float(_softplus(raw))
+    return raw
+
+
+def _detect_bound_hits(
+    param_order,
+    values,
+    bounds_lo,
+    bounds_hi,
+    fixed_mask,
+    *,
+    tol_frac: float = 1e-4,
+    tol_abs: float = 1e-10,
+):
+    """Report free parameters that finished at an active optimizer bound."""
+
+    hits = {}
+    for idx, name in enumerate(param_order):
+        if fixed_mask[idx]:
+            continue
+        val = float(values[idx])
+        lo = float(bounds_lo[idx])
+        hi = float(bounds_hi[idx])
+        if not np.isfinite(val):
+            continue
+        span = hi - lo
+        tol = tol_abs
+        if np.isfinite(span) and span > 0:
+            tol = max(tol, abs(span) * tol_frac)
+
+        at_lo = np.isfinite(lo) and val <= lo + tol
+        at_hi = np.isfinite(hi) and val >= hi - tol
+        if not at_lo and not at_hi:
+            continue
+
+        side = "both" if at_lo and at_hi else ("lower" if at_lo else "upper")
+        meta = {
+            "side": side,
+            "value": _physical_fit_param_value(name, val),
+        }
+        if np.isfinite(lo):
+            meta["lower"] = _physical_fit_param_value(name, lo)
+        if np.isfinite(hi):
+            meta["upper"] = _physical_fit_param_value(name, hi)
+        hits[str(name)] = meta
+
+    return hits
+
+
 def make_linear_bkg(
     Emin: float, Emax: float, Eref: float | None = None, n_norm: int | None = None
 ):
@@ -497,6 +551,7 @@ def fit_spectrum(
     pre_binned_hist=None,
     pre_dnl_meta=None,
     skip_minos=False,
+    skip_covariance=False,
 ):
     """Fit the radon spectrum using either χ² histogram or unbinned likelihood.
 
@@ -534,6 +589,12 @@ def fit_spectrum(
     max_tau_ratio : float, optional
         If given, enforce an upper bound ``tau <= max_tau_ratio * sigma0`` for
         EMG tail parameters.
+    skip_covariance : bool, optional
+        When ``True``, skip the expensive post-MIGRAD covariance recovery
+        stages (HESSE, relaxed-bound retries, numerical Hessian, MINOS) and
+        use MIGRAD's approximate diagonal errors instead. This is primarily
+        intended for high-volume template time-bin fits where fast per-bin
+        uncertainties are sufficient.
 
     Returns
     -------
@@ -2397,6 +2458,7 @@ def fit_spectrum(
                 _me = (bounds_hi[_pi] - bounds_lo[_pi]) * 0.01
                 _migrad_is_fallback[_pn] = True
             _migrad_errs[_pn] = _me
+        _fixed_mask = [bool(m.fixed[p]) for p in param_order]
 
         # ----------------------------------------------------------
         # Covariance recovery strategy:
@@ -2408,229 +2470,242 @@ def fit_spectrum(
         _t0_cov = _time_mod.perf_counter()
         _nll_calls_before_cov = _nll_call_count[0]
         _covariance_method = "none"
-        m.hesse()
-        cov_raw = m.covariance
-        covariance_available = cov_raw is not None
-        if covariance_available:
-            _covariance_method = "hesse"
-
-        # --- A2: Simplex→MIGRAD→HESSE recovery (Tier 1.5) ---
-        # Official iminuit guidance notes that Simplex before MIGRAD
-        # can rescue pathological curvature by finding a better
-        # starting region for the gradient-based minimiser.
-        if cov_raw is None:
+        _minos_errors = None
+        _minos_method = "none"
+        if skip_covariance:
             logging.info(
-                "Hesse failed  - trying Simplex→MIGRAD→HESSE recovery"
+                "Skipping covariance recovery after MIGRAD "
+                "(skip_covariance=True); using diagonal MIGRAD errors only"
             )
-            _saved_vals = popt.copy()
-            m.simplex()
-            m.migrad()
-            if m.valid:
-                m.hesse()
-                cov_raw = m.covariance
-                if cov_raw is not None:
-                    _covariance_method = "hesse_after_simplex"
-                    covariance_available = True
-                    # If Simplex+MIGRAD found the same or better minimum,
-                    # update popt; otherwise restore.
-                    _new_nll = float(m.fval)
-                    if _new_nll <= nll_val + 0.01:
-                        popt = np.array(
-                            [float(m.values[p]) for p in param_order]
-                        )
-                        nll_val = _new_nll
+            cov_raw = np.diag(np.array([_migrad_errs[p] ** 2 for p in param_order]))
+            covariance_available = True
+            _covariance_method = "migrad_diagonal_skipped"
+            _minos_errors = {}
+            _minos_method = "skipped_via_skip_covariance"
+        else:
+            m.hesse()
+            cov_raw = m.covariance
+            covariance_available = cov_raw is not None
+            if covariance_available:
+                _covariance_method = "hesse"
+
+            # --- A2: Simplex→MIGRAD→HESSE recovery (Tier 1.5) ---
+            # Official iminuit guidance notes that Simplex before MIGRAD
+            # can rescue pathological curvature by finding a better
+            # starting region for the gradient-based minimiser.
+            if cov_raw is None:
+                logging.info(
+                    "Hesse failed  - trying Simplex→MIGRAD→HESSE recovery"
+                )
+                _saved_vals = popt.copy()
+                m.simplex()
+                m.migrad()
+                if m.valid:
+                    m.hesse()
+                    cov_raw = m.covariance
+                    if cov_raw is not None:
+                        _covariance_method = "hesse_after_simplex"
+                        covariance_available = True
+                        # If Simplex+MIGRAD found the same or better minimum,
+                        # update popt; otherwise restore.
+                        _new_nll = float(m.fval)
+                        if _new_nll <= nll_val + 0.01:
+                            popt = np.array(
+                                [float(m.values[p]) for p in param_order]
+                            )
+                            nll_val = _new_nll
+                        else:
+                            for _pi, _pn in enumerate(param_order):
+                                m.values[_pn] = float(_saved_vals[_pi])
                     else:
+                        # Simplex+MIGRAD converged but HESSE still fails
                         for _pi, _pn in enumerate(param_order):
                             m.values[_pn] = float(_saved_vals[_pi])
                 else:
-                    # Simplex+MIGRAD converged but HESSE still fails
                     for _pi, _pn in enumerate(param_order):
                         m.values[_pn] = float(_saved_vals[_pi])
-            else:
-                for _pi, _pn in enumerate(param_order):
-                    m.values[_pn] = float(_saved_vals[_pi])
 
-        # --- Strategy 2: relax bounds for params sitting at limits ---
-        if cov_raw is None:
-            logging.info(
-                "Hesse failed  - attempting with relaxed bounds for "
-                "parameters at their limits"
-            )
-            # Reset parameter values to the saved minimum before retrying
-            for _pi, _pn in enumerate(param_order):
-                m.values[_pn] = float(popt[_pi])
-            _at_bound = []
-            _relax_frac = 0.05  # expand bound by 5% of range
-            for _pi, _pn in enumerate(param_order):
-                if m.fixed[_pn]:
-                    continue
-                _val = float(popt[_pi])
-                _lo, _hi = bounds_lo[_pi], bounds_hi[_pi]
-                _rng = _hi - _lo
-                _tol = _rng * 1e-4
-                if _val <= _lo + _tol or _val >= _hi - _tol:
-                    _at_bound.append((_pn, _pi, _val, _lo, _hi))
-                    _new_lo = _lo - _relax_frac * _rng if _val <= _lo + _tol else _lo
-                    _new_hi = _hi + _relax_frac * _rng if _val >= _hi - _tol else _hi
-                    m.limits[_pn] = (_new_lo, _new_hi)
-            if _at_bound:
+            # --- Strategy 2: relax bounds for params sitting at limits ---
+            if cov_raw is None:
                 logging.info(
-                    "Relaxed bounds for %d params at limits: %s",
-                    len(_at_bound),
-                    [t[0] for t in _at_bound],
+                    "Hesse failed  - attempting with relaxed bounds for "
+                    "parameters at their limits"
                 )
-                m.hesse()
-                cov_raw = m.covariance
-                covariance_available = cov_raw is not None
-                # Restore original bounds
-                for _pn, _pi, _val, _lo, _hi in _at_bound:
-                    m.limits[_pn] = (_lo, _hi)
-                if cov_raw is not None:
-                    _covariance_method = "hesse_relaxed"
-                    logging.info("Hesse succeeded after relaxing bounds")
-
-        # --- Strategy 3: numerical Hessian via finite differences ---
-        # Work on the FREE-parameter submatrix only to avoid fixed
-        # parameters (with ±1e-12 bounds) distorting eigenvalues.
-        if cov_raw is None:
-            logging.info(
-                "Hesse still failed  - computing numerical Hessian "
-                "via finite differences at the converged minimum"
-            )
-            try:
-                _n_par = len(param_order)
-                _pvals = popt.copy()  # use saved minimum, not m.values
-
-                # Identify free parameters
-                _free_idx = [i for i, p in enumerate(param_order) if not m.fixed[p]]
-                _n_free_h = len(_free_idx)
-
-                _steps = np.array([_migrad_errs[param_order[i]] * 0.1 for i in _free_idx])
-                # Clamp steps to stay within bounds
-                for _si, _pi in enumerate(_free_idx):
-                    _max_step = min(
-                        _pvals[_pi] - bounds_lo[_pi],
-                        bounds_hi[_pi] - _pvals[_pi],
-                    ) * 0.5
-                    if _max_step > 0:
-                        _steps[_si] = min(_steps[_si], _max_step)
-                    if _steps[_si] <= 0:
-                        _steps[_si] = (bounds_hi[_pi] - bounds_lo[_pi]) * 1e-4
-
-                _hess_free = np.zeros((_n_free_h, _n_free_h))
-                _f0 = float(_nll(*_pvals))
-                # Diagonal elements (free params only)
-                for _si, _pi in enumerate(_free_idx):
-                    _pp = _pvals.copy(); _pp[_pi] += _steps[_si]
-                    _pm = _pvals.copy(); _pm[_pi] -= _steps[_si]
-                    _fp = float(_nll(*_pp))
-                    _fm = float(_nll(*_pm))
-                    _hess_free[_si, _si] = (_fp - 2 * _f0 + _fm) / (_steps[_si] ** 2)
-                # Off-diagonal elements (free params only)
-                for _si in range(_n_free_h):
-                    _pi = _free_idx[_si]
-                    for _sj in range(_si + 1, _n_free_h):
-                        _pj = _free_idx[_sj]
-                        _ppp = _pvals.copy(); _ppp[_pi] += _steps[_si]; _ppp[_pj] += _steps[_sj]
-                        _ppm = _pvals.copy(); _ppm[_pi] += _steps[_si]; _ppm[_pj] -= _steps[_sj]
-                        _pmp = _pvals.copy(); _pmp[_pi] -= _steps[_si]; _pmp[_pj] += _steps[_sj]
-                        _pmm = _pvals.copy(); _pmm[_pi] -= _steps[_si]; _pmm[_pj] -= _steps[_sj]
-                        _fpp = float(_nll(*_ppp))
-                        _fpm = float(_nll(*_ppm))
-                        _fmp = float(_nll(*_pmp))
-                        _fmm = float(_nll(*_pmm))
-                        _hess_free[_si, _sj] = (_fpp - _fpm - _fmp + _fmm) / (
-                            4.0 * _steps[_si] * _steps[_sj]
-                        )
-                        _hess_free[_sj, _si] = _hess_free[_si, _sj]
-
-                # Invert the free-parameter submatrix via eigenvalue
-                # regularisation and embed back into the full matrix.
-                try:
-                    _eigvals, _eigvecs = np.linalg.eigh(_hess_free)
-                    _eig_thresh = max(1e-10, 1e-6 * np.max(np.abs(_eigvals)))
-                    _n_clamped = int(np.sum(_eigvals < _eig_thresh))
-                    _eigvals_reg = np.where(
-                        _eigvals < _eig_thresh, _eig_thresh, _eigvals
+                # Reset parameter values to the saved minimum before retrying
+                for _pi, _pn in enumerate(param_order):
+                    m.values[_pn] = float(popt[_pi])
+                _at_bound = []
+                _relax_frac = 0.05  # expand bound by 5% of range
+                for _pi, _pn in enumerate(param_order):
+                    if m.fixed[_pn]:
+                        continue
+                    _val = float(popt[_pi])
+                    _lo, _hi = bounds_lo[_pi], bounds_hi[_pi]
+                    _rng = _hi - _lo
+                    _tol = _rng * 1e-4
+                    if _val <= _lo + _tol or _val >= _hi - _tol:
+                        _at_bound.append((_pn, _pi, _val, _lo, _hi))
+                        _new_lo = _lo - _relax_frac * _rng if _val <= _lo + _tol else _lo
+                        _new_hi = _hi + _relax_frac * _rng if _val >= _hi - _tol else _hi
+                        m.limits[_pn] = (_new_lo, _new_hi)
+                if _at_bound:
+                    logging.info(
+                        "Relaxed bounds for %d params at limits: %s",
+                        len(_at_bound),
+                        [t[0] for t in _at_bound],
                     )
-                    # Regularised inverse of the free submatrix
-                    _cov_free = (_eigvecs / _eigvals_reg) @ _eigvecs.T
-                    _cov_free = 0.5 * (_cov_free + _cov_free.T)
+                    m.hesse()
+                    cov_raw = m.covariance
+                    covariance_available = cov_raw is not None
+                    # Restore original bounds
+                    for _pn, _pi, _val, _lo, _hi in _at_bound:
+                        m.limits[_pn] = (_lo, _hi)
+                    if cov_raw is not None:
+                        _covariance_method = "hesse_relaxed"
+                        logging.info("Hesse succeeded after relaxing bounds")
 
-                    # For free params where numerical Hessian gives a
-                    # smaller variance than MIGRAD, use MIGRAD as a floor.
-                    for _si, _pi in enumerate(_free_idx):
-                        _pn = param_order[_pi]
-                        _migrad_var = _migrad_errs[_pn] ** 2
-                        if _cov_free[_si, _si] < _migrad_var:
-                            if _migrad_is_fallback.get(_pn, False):
-                                _cov_free[_si, _si] = _migrad_var
-                            else:
-                                _scale = np.sqrt(
-                                    _migrad_var / max(_cov_free[_si, _si], 1e-30)
-                                )
-                                _cov_free[_si, :] *= _scale
-                                _cov_free[:, _si] *= _scale
-
-                    # Embed into full covariance matrix (fixed params
-                    # get near-zero variance on the diagonal)
-                    cov_raw = np.zeros((_n_par, _n_par))
-                    for _si, _pi in enumerate(_free_idx):
-                        for _sj, _pj in enumerate(_free_idx):
-                            cov_raw[_pi, _pj] = _cov_free[_si, _sj]
-                    # Set fixed params to tiny variance
-                    for _pi in range(_n_par):
-                        if _pi not in _free_idx:
-                            cov_raw[_pi, _pi] = _migrad_errs[param_order[_pi]] ** 2
-
-                    covariance_available = True
-                    _covariance_method = "numerical_hessian"
-                    if _n_clamped > 0:
-                        logging.info(
-                            "Numerical Hessian: %d/%d free-param eigenvalues "
-                            "clamped (params at bounds). Off-diagonal "
-                            "correlations available for well-determined "
-                            "parameters.",
-                            _n_clamped, _n_free_h,
-                        )
-                    else:
-                        logging.info(
-                            "Numerical Hessian inversion succeeded  - "
-                            "full covariance with off-diagonal correlations"
-                        )
-                except np.linalg.LinAlgError:
-                    logging.warning("Numerical Hessian eigendecomposition failed")
-                    cov_raw = None
-            except Exception as _num_exc:
-                logging.warning(
-                    "Numerical Hessian computation failed: %s", _num_exc
+            # --- Strategy 3: numerical Hessian via finite differences ---
+            # Work on the FREE-parameter submatrix only to avoid fixed
+            # parameters (with ±1e-12 bounds) distorting eigenvalues.
+            if cov_raw is None:
+                logging.info(
+                    "Hesse still failed  - computing numerical Hessian "
+                    "via finite differences at the converged minimum"
                 )
-                cov_raw = None
+                try:
+                    _n_par = len(param_order)
+                    _pvals = popt.copy()  # use saved minimum, not m.values
 
-        # --- Final fallback: MIGRAD diagonal-only ---
-        if cov_raw is None:
-            _covariance_method = "migrad_diagonal"
-            n_nonzero = sum(1 for v in _migrad_errs.values() if v > 0)
-            logging.warning(
-                "All covariance strategies failed  - using MIGRAD approximate "
-                "errors as diagonal fallback (no correlations). "
-                "%d / %d params have non-zero MIGRAD errors.",
-                n_nonzero, len(param_order),
-            )
-            diag = np.array(
-                [_migrad_errs[p] ** 2 for p in param_order]
-            )
-            cov_raw = np.diag(diag)
+                    # Identify free parameters
+                    _free_idx = [i for i, p in enumerate(param_order) if not m.fixed[p]]
+                    _n_free_h = len(_free_idx)
+
+                    _steps = np.array([_migrad_errs[param_order[i]] * 0.1 for i in _free_idx])
+                    # Clamp steps to stay within bounds
+                    for _si, _pi in enumerate(_free_idx):
+                        _max_step = min(
+                            _pvals[_pi] - bounds_lo[_pi],
+                            bounds_hi[_pi] - _pvals[_pi],
+                        ) * 0.5
+                        if _max_step > 0:
+                            _steps[_si] = min(_steps[_si], _max_step)
+                        if _steps[_si] <= 0:
+                            _steps[_si] = (bounds_hi[_pi] - bounds_lo[_pi]) * 1e-4
+
+                    _hess_free = np.zeros((_n_free_h, _n_free_h))
+                    _f0 = float(_nll(*_pvals))
+                    # Diagonal elements (free params only)
+                    for _si, _pi in enumerate(_free_idx):
+                        _pp = _pvals.copy(); _pp[_pi] += _steps[_si]
+                        _pm = _pvals.copy(); _pm[_pi] -= _steps[_si]
+                        _fp = float(_nll(*_pp))
+                        _fm = float(_nll(*_pm))
+                        _hess_free[_si, _si] = (_fp - 2 * _f0 + _fm) / (_steps[_si] ** 2)
+                    # Off-diagonal elements (free params only)
+                    for _si in range(_n_free_h):
+                        _pi = _free_idx[_si]
+                        for _sj in range(_si + 1, _n_free_h):
+                            _pj = _free_idx[_sj]
+                            _ppp = _pvals.copy(); _ppp[_pi] += _steps[_si]; _ppp[_pj] += _steps[_sj]
+                            _ppm = _pvals.copy(); _ppm[_pi] += _steps[_si]; _ppm[_pj] -= _steps[_sj]
+                            _pmp = _pvals.copy(); _pmp[_pi] -= _steps[_si]; _pmp[_pj] += _steps[_sj]
+                            _pmm = _pvals.copy(); _pmm[_pi] -= _steps[_si]; _pmm[_pj] -= _steps[_sj]
+                            _fpp = float(_nll(*_ppp))
+                            _fpm = float(_nll(*_ppm))
+                            _fmp = float(_nll(*_pmp))
+                            _fmm = float(_nll(*_pmm))
+                            _hess_free[_si, _sj] = (_fpp - _fpm - _fmp + _fmm) / (
+                                4.0 * _steps[_si] * _steps[_sj]
+                            )
+                            _hess_free[_sj, _si] = _hess_free[_si, _sj]
+
+                    # Invert the free-parameter submatrix via eigenvalue
+                    # regularisation and embed back into the full matrix.
+                    try:
+                        _eigvals, _eigvecs = np.linalg.eigh(_hess_free)
+                        _eig_thresh = max(1e-10, 1e-6 * np.max(np.abs(_eigvals)))
+                        _n_clamped = int(np.sum(_eigvals < _eig_thresh))
+                        _eigvals_reg = np.where(
+                            _eigvals < _eig_thresh, _eig_thresh, _eigvals
+                        )
+                        # Regularised inverse of the free submatrix
+                        _cov_free = (_eigvecs / _eigvals_reg) @ _eigvecs.T
+                        _cov_free = 0.5 * (_cov_free + _cov_free.T)
+
+                        # For free params where numerical Hessian gives a
+                        # smaller variance than MIGRAD, use MIGRAD as a floor.
+                        for _si, _pi in enumerate(_free_idx):
+                            _pn = param_order[_pi]
+                            _migrad_var = _migrad_errs[_pn] ** 2
+                            if _cov_free[_si, _si] < _migrad_var:
+                                if _migrad_is_fallback.get(_pn, False):
+                                    _cov_free[_si, _si] = _migrad_var
+                                else:
+                                    _scale = np.sqrt(
+                                        _migrad_var / max(_cov_free[_si, _si], 1e-30)
+                                    )
+                                    _cov_free[_si, :] *= _scale
+                                    _cov_free[:, _si] *= _scale
+
+                        # Embed into full covariance matrix (fixed params
+                        # get near-zero variance on the diagonal)
+                        cov_raw = np.zeros((_n_par, _n_par))
+                        for _si, _pi in enumerate(_free_idx):
+                            for _sj, _pj in enumerate(_free_idx):
+                                cov_raw[_pi, _pj] = _cov_free[_si, _sj]
+                        # Set fixed params to tiny variance
+                        for _pi in range(_n_par):
+                            if _pi not in _free_idx:
+                                cov_raw[_pi, _pi] = _migrad_errs[param_order[_pi]] ** 2
+
+                        covariance_available = True
+                        _covariance_method = "numerical_hessian"
+                        if _n_clamped > 0:
+                            logging.info(
+                                "Numerical Hessian: %d/%d free-param eigenvalues "
+                                "clamped (params at bounds). Off-diagonal "
+                                "correlations available for well-determined "
+                                "parameters.",
+                                _n_clamped, _n_free_h,
+                            )
+                        else:
+                            logging.info(
+                                "Numerical Hessian inversion succeeded  - "
+                                "full covariance with off-diagonal correlations"
+                            )
+                    except np.linalg.LinAlgError:
+                        logging.warning("Numerical Hessian eigendecomposition failed")
+                        cov_raw = None
+                except Exception as _num_exc:
+                    logging.warning(
+                        "Numerical Hessian computation failed: %s", _num_exc
+                    )
+                    cov_raw = None
+
+            # --- Final fallback: MIGRAD diagonal-only ---
+            if cov_raw is None:
+                _covariance_method = "migrad_diagonal"
+                n_nonzero = sum(1 for v in _migrad_errs.values() if v > 0)
+                logging.warning(
+                    "All covariance strategies failed  - using MIGRAD approximate "
+                    "errors as diagonal fallback (no correlations). "
+                    "%d / %d params have non-zero MIGRAD errors.",
+                    n_nonzero, len(param_order),
+                )
+                diag = np.array(
+                    [_migrad_errs[p] ** 2 for p in param_order]
+                )
+                cov_raw = np.diag(diag)
 
         # --- Asymmetric errors via profile likelihood ---
         # Strategy:
         #   A. Try iminuit's native MINOS (proper re-profiling)
         #   B. Manual profile scan with re-minimisation at each point
         #   C. Projection scan (freeze other params  - last resort)
-        _minos_errors = None
-        _minos_method = "none"
         _free_params = [p for p in param_order if not m.fixed[p]]
-        if skip_minos:
+        if skip_covariance:
+            pass
+        elif skip_minos:
             logging.info("Skipping profile likelihood errors (skip_minos=True)")
             _minos_errors = {}
             _minos_method = "skipped"
@@ -2984,6 +3059,8 @@ def fit_spectrum(
                 f"Internal error: perr length ({len(perr)}) does not match "
                 f"param_order length ({len(param_order)})"
             )
+        _ub_popt = np.array([float(m.values[p]) for p in param_order], dtype=float)
+        _ub_fixed_mask = [bool(m.fixed[p]) for p in param_order]
         out["fit_valid"] = fit_valid
         for i, pname in enumerate(param_order):
             val = float(m.values[pname])
@@ -2999,6 +3076,16 @@ def fit_spectrum(
         if fix_F:
             out["F"] = F_val
             out["dF"] = 0.0
+        _bound_hits = _detect_bound_hits(
+            param_order,
+            _ub_popt,
+            bounds_lo,
+            bounds_hi,
+            _ub_fixed_mask,
+        )
+        out["_bound_hits"] = _bound_hits
+        out["_bound_hit_params"] = sorted(_bound_hits)
+        out["_n_bound_hits"] = int(len(_bound_hits))
         k = len(param_order)
         out["aic"] = float(2 * m.fval + 2 * k)
         out["likelihood_path"] = likelihood_path
@@ -3074,6 +3161,17 @@ def fit_spectrum(
             "(HESSE errors retained in d<param> keys)",
             len(_minos_errors),
         )
+
+    _bound_hits = _detect_bound_hits(
+        param_order,
+        popt,
+        bounds_lo,
+        bounds_hi,
+        _fixed_mask,
+    )
+    out["_bound_hits"] = _bound_hits
+    out["_bound_hit_params"] = sorted(_bound_hits)
+    out["_n_bound_hits"] = int(len(_bound_hits))
 
     if fix_sigma0:
         out["sigma0"] = sigma0_val

--- a/tests/test_analyze_config_merge.py
+++ b/tests/test_analyze_config_merge.py
@@ -2422,8 +2422,225 @@ def test_time_fields_written_back(tmp_path, monkeypatch):
     ]
 
 
+def test_build_template_from_aggregate_soft_constrains_core_sigma_and_tau():
+    aggregate_params = {
+        "mu_Po214": 7.687,
+        "sigma_Po214": 0.13,
+        "tau_shared": 0.08,
+        "S_Po214": 500.0,
+        "sigma0": 0.10,
+        "F": 0.0,
+        "b1": 1.2,
+    }
+    priors = {
+        "mu_Po214": (7.687, 0.01),
+        "sigma_Po214": (0.12, 0.03),
+        "tau_shared": (0.09, 0.05),
+        "S_Po214": (500.0, 100.0),
+        "sigma0": (0.10, 0.01),
+        "F": (0.0, 0.01),
+        "b1": (1.0, 1.0),
+    }
+
+    tpl_priors, tpl_flags = analyze._build_template_from_aggregate(
+        aggregate_params,
+        priors,
+        {},
+        {
+            "time_fit": {
+                "float_centroids": True,
+                "template_float_core_widths": True,
+                "template_core_width_prior_frac": 0.15,
+                "template_core_width_prior_min_mev": 0.005,
+                "template_float_tail_scales": True,
+                "template_tail_prior_frac": 0.25,
+                "template_tail_prior_min_mev": 0.01,
+            }
+        },
+    )
+
+    assert tpl_priors["sigma_Po214"][0] == pytest.approx(0.13)
+    assert tpl_priors["sigma_Po214"][1] == pytest.approx(0.03)
+    assert "fix_sigma_Po214" not in tpl_flags
+    assert tpl_priors["tau_shared"][0] == pytest.approx(0.08)
+    assert tpl_priors["tau_shared"][1] == pytest.approx(0.05)
+    assert "fix_tau_shared" not in tpl_flags
+    assert tpl_flags["penalty_priors"]["sigma_Po214"] == pytest.approx([0.13, 0.03])
+    assert tpl_flags["penalty_priors"]["tau_shared"] == pytest.approx([0.08, 0.05])
+    assert tpl_flags["fix_sigma0"] is True
 
 
+def test_fit_time_bins_applies_centroid_controls(monkeypatch):
+    import fitting
+
+    timestamps = pd.date_range(
+        "2024-01-01T00:00:00Z",
+        periods=40,
+        freq="1min",
+        tz="UTC",
+    )
+    df = pd.DataFrame(
+        {
+            "timestamp": timestamps,
+            "energy_MeV": np.full(40, 7.69),
+            "adc": np.arange(40, dtype=float),
+        }
+    )
+    aggregate_result = FitResult(
+        {
+            "mu_Po214": 7.687,
+            "sigma_Po214": 0.05,
+            "S_Po214": 500.0,
+            "S_bkg": 10.0,
+            "sigma0": 0.10,
+            "F": 0.0,
+        },
+        None,
+        0,
+    )
+
+    captured = {}
+
+    def fake_fit_spectrum(
+        energies,
+        priors,
+        flags=None,
+        bin_edges=None,
+        bounds=None,
+        pre_binned_hist=None,
+        skip_minos=False,
+        **kwargs,
+    ):
+        captured["bounds"] = bounds
+        captured["penalty_priors"] = dict(flags.get("penalty_priors", {}))
+        captured["skip_covariance"] = kwargs.get("skip_covariance")
+        return {
+            "fit_valid": True,
+            "chi2_ndf": 4.2,
+            "mu_Po214": 7.707,
+            "S_Po214": 42.0,
+            "dS_Po214": 3.0,
+            "_n_bound_hits": 2,
+            "_bound_hit_params": ["mu_Po214", "S_Po214"],
+            "_bound_hits": {
+                "mu_Po214": {"side": "upper"},
+                "S_Po214": {"side": "upper"},
+            },
+            "_plot_edges": [7.5, 7.6, 7.7, 7.8],
+            "_plot_hist": [1.0, 2.0, 1.0],
+            "_plot_centers": [7.55, 7.65, 7.75],
+            "_plot_model_total": [1.0, 2.0, 1.0],
+            "_plot_components": {"Po214": [1.0, 2.0, 1.0]},
+        }
+
+    monkeypatch.setattr(fitting, "fit_spectrum", fake_fit_spectrum)
+
+    aggregate_result.params["_template_priors"] = {
+        "mu_Po214": (7.687, 0.01),
+        "sigma_Po214": (0.05, 0.01),
+        "S_Po214": (500.0, 100.0),
+        "S_bkg": (10.0, 5.0),
+        "sigma0": (0.10, 0.01),
+        "F": (0.0, 0.01),
+        "b1": (0.0, 1.0),
+    }
+    aggregate_result.params["_template_flags"] = {"background_model": "none"}
+
+    cfg = {
+        "spectral_fit": {"background_model": "none"},
+        "time_fit": {
+            "template_min_counts": 10,
+            "template_n_workers": 1,
+            "template_skip_covariance": True,
+            "float_centroids": True,
+            "centroid_shift_bound_kev": 20.0,
+            "centroid_shift_prior_sigma_kev": None,
+        },
+        "plotting": {
+            "plot_time_bin_width_s": 3600,
+            "plot_template_bin_fits": True,
+            "plot_template_bin_fits_bad_only": True,
+        },
+    }
+    spec_plot_data = {
+        "flags": {"background_model": "none"},
+        "bin_edges": np.array([7.5, 7.6, 7.7, 7.8], dtype=float),
+    }
+
+    result = analyze._fit_time_bins(
+        df,
+        aggregate_result,
+        cfg,
+        spec_plot_data=spec_plot_data,
+    )
+
+    assert captured["bounds"] is None
+    assert captured["skip_covariance"] is True
+    assert result["per_bin_diagnostics"][0]["n_bound_hits"] == 2
+    assert result["per_bin_diagnostics"][0]["bound_hit_params"] == ["mu_Po214", "S_Po214"]
+    assert captured["penalty_priors"]["sigma_Po214"] == pytest.approx([0.05, 0.01])
 
 
+def test_should_store_template_bin_plot_when_non_centroid_bound_hit_present():
+    assert analyze._should_store_template_bin_plot(
+        {"fit_valid": True, "chi2_ndf": 1.2, "_n_bound_hits": 1},
+        {
+            "plot_template_bin_fits": True,
+            "plot_template_bin_fits_bad_only": True,
+            "plot_template_bin_fits_bad_chi2_ndf_min": 3.0,
+        },
+    )
 
+
+def test_resolve_template_n_workers_auto_and_explicit(monkeypatch):
+    monkeypatch.setattr(analyze.os, "cpu_count", lambda: 16)
+    assert analyze._resolve_template_n_workers({}) == 8
+    assert analyze._resolve_template_n_workers({"template_n_workers": "auto"}) == 8
+    assert analyze._resolve_template_n_workers({"template_n_workers": 3}) == 3
+    assert analyze._resolve_template_n_workers({"template_n_workers": 0}) == 1
+
+
+def test_summarize_template_fit_results_counts_bound_hits():
+    summary = analyze._summarize_template_fit_results(
+        {
+            "n_time_bins": 3,
+            "n_fitted": 3,
+            "n_valid": 2,
+            "plot_entries": [{"bin_index": 0}],
+            "centroid_control": {"limit_kev": 20.0},
+            "per_bin_diagnostics": [
+                {
+                    "fit_valid": True,
+                    "chi2_ndf": 2.0,
+                    "centroid_shift_kev": 5.0,
+                    "shift_hit_limit": False,
+                    "n_bound_hits": 2,
+                    "bound_hit_params": ["S_Po214", "mu_Po214"],
+                },
+                {
+                    "fit_valid": True,
+                    "chi2_ndf": 12.0,
+                    "centroid_shift_kev": 10.0,
+                    "shift_hit_limit": True,
+                    "n_bound_hits": 1,
+                    "bound_hit_params": ["S_Po214"],
+                },
+                {
+                    "fit_valid": False,
+                    "chi2_ndf": float("nan"),
+                    "centroid_shift_kev": float("nan"),
+                    "shift_hit_limit": False,
+                    "n_bound_hits": 0,
+                    "bound_hit_params": [],
+                },
+            ],
+        }
+    )
+
+    assert summary["bins_with_any_bound_hits"] == 2
+    assert summary["total_bound_hits"] == 3
+    assert summary["bound_hit_param_counts"] == {"S_Po214": 2, "mu_Po214": 1}
+    assert summary["non_centroid_bound_hit_param_counts"] == {"S_Po214": 2}
+    assert summary["bins_with_non_centroid_bound_hits"] == 2
+    assert summary["shift_hit_limit"] == 1
+    assert summary["chi2_gt_10"] == 1


### PR DESCRIPTION
## What changed
- add fast per-bin template-fit controls for `template_n_workers` and `template_skip_covariance`
- skip expensive post-MIGRAD covariance recovery for template time-bin fits and use diagonal MIGRAD errors instead
- keep bound-hit metadata flowing into template diagnostics and bad-bin selection
- carry the template-fit config/docs/tests updates forward on top of the latest `main`

## Why
The template time-bin sweep was spending substantial wall time in per-bin covariance recovery and was effectively running one bin at a time from the top-level call site. This makes the long 24h→1h sweep impractically slow.

## Impact
- template time-bin fits can now parallelize across workers
- per-bin logs now show `cov+minos=0.0s` when the fast covariance skip is enabled
- the run keeps the newer template diagnostics and plotting behavior from `main`

## Validation
- `python -m compileall analyze.py fitting.py tests\test_analyze_config_merge.py`
- `python -m pytest tests\test_analyze_config_merge.py -k "resolve_template_fixed_isotopes_defaults_to_auxiliary_only or fit_time_bins_applies_centroid_controls or resolve_template_n_workers_auto_and_explicit or summarize_template_fit_results_counts_bound_hits or write_template_bin_fit_plots_respects_log_toggle" -q --import-mode=importlib`
- direct `fit_spectrum(..., skip_covariance=True)` smoke check returned `covariance_method='migrad_diagonal_skipped'`

## Run note
The long descending sweep on `merged_output.csv` is still running in the local workspace and has completed `24h`, `18h`, `14h`, and `10h`; the active `8h` run is using the fast covariance-skip path.